### PR TITLE
👂 Set a custom listen address if provided

### DIFF
--- a/cmd/osbuild-installer/main.go
+++ b/cmd/osbuild-installer/main.go
@@ -1,9 +1,20 @@
 package main
 
 import (
+	"os"
+
 	"github.com/osbuild/osbuild-installer/internal/server"
 )
 
 func main() {
-	server.Run("localhost:8086")
+	// Look for a custom listen address in environment variables.
+	listenAddress, ok := os.LookupEnv("LISTEN_ADDRESS")
+
+	// Listen on localhost otherwise.
+	if !ok {
+		listenAddress = "localhost:8086"
+	}
+
+	// Run the server and listen for requests.
+	server.Run(listenAddress)
 }


### PR DESCRIPTION
When running in OpenShift, installer needs to listen on a different
address (and possibly different port, too). Allow a user to specify a
custom listen address via environment variable.

Signed-off-by: Major Hayden <major@redhat.com>