### PR TITLE
openshift: Wrap port number in quotes

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -72,7 +72,7 @@ parameters:
     value: "EXAMPLE_DATA"
   - description: image-builder backend listening port
     name: BACKEND_LISTENER_PORT
-    value: 8086
+    value: "8086"
   - description: image-builder image name
     name: IMAGE_NAME
     value: quay.io/cloudservices/image-builder


### PR DESCRIPTION
OpenShift really does not like having the port number as a raw integer.
Wrap the port number in quotes to please OpenShift.

Signed-off-by: Major Hayden <major@redhat.com>