### PR TITLE
🗞 openshift: Use modern v1 API for deployments

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -23,8 +23,8 @@ objects:
 
 # Deploy the image-builder container, add an environment variable from the
 # configmap, and open a port.
-- apiVersion: apps/v1
-  kind: Deployment
+- apiVersion: v1
+  kind: DeploymentConfig
   metadata:
     labels:
       service: image-builder


### PR DESCRIPTION
apps/v1 + Deployment is the old style.
v1 + DeploymentConfig is the new style.

Signed-off-by: Major Hayden <major@redhat.com>