### PR TITLE
openshift: add name for service port mapping

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -61,7 +61,8 @@ objects:
     name: image-builder
   spec:
     ports:
-      - protocol: TCP
+      - name: image-builder
+        protocol: TCP
         port: ${{BACKEND_LISTENER_PORT}}
         targetPort: 8086
     selector:


### PR DESCRIPTION
Make it easier to keep track of port mappings later.

Signed-off-by: Major Hayden <major@redhat.com>