### PR TITLE
✂ openshift: shorten deployment port name

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -61,7 +61,7 @@ objects:
             successThreshold: 1
             timeoutSeconds: 1
           ports:
-          - name: image-builder-api
+          - name: api
             containerPort: 8086
             protocol: TCP
           env:


### PR DESCRIPTION
Apparently OpenShift does not like port names longer than 15 characters. 🤷🏻‍♂️

Fixes #34