### PR TITLE
👂 openshift: listen on all addresses

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -65,6 +65,8 @@ objects:
             containerPort: 8086
             protocol: TCP
           env:
+            - name: LISTEN_ADDRESS
+              value: "${LISTEN_ADDRESS}"
             - name: EXAMPLE
               valueFrom:
                 configMapKeyRef:
@@ -108,3 +110,6 @@ parameters:
   - name: HEALTHCHECK_URI
     description: URI to query for the health check
     value: "/api/image-builder/v1/version"
+  - name: LISTEN_ADDRESS
+    description: Listening address and port
+    value: "0.0.0.0:8086"


### PR DESCRIPTION
image-builder listens only on localhost by default, so we need to
specify the listen address inside the container so the port is
accessible within the cluster.

Signed-off-by: Major Hayden <major@redhat.com>