### PR TITLE
openshift: Add identity header for health check

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -48,6 +48,9 @@ objects:
               path: ${HEALTHCHECK_URI}
               port: 8086
               scheme: HTTP
+              httpHeaders:
+                - name: X-Rh-Identity
+                  value: health-check
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -57,6 +60,9 @@ objects:
               path: ${HEALTHCHECK_URI}
               port: 8086
               scheme: HTTP
+              httpHeaders:
+                - name: X-Rh-Identity
+                  value: health-check
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1


### PR DESCRIPTION
Now that we have a identity header requirement, pass this header when
doing health checks.

Signed-off-by: Major Hayden <major@redhat.com>