### PR TITLE
Error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 # pip3 install openapi-spec-validator
 .PHONY: check-api-spec
 check-api-spec:
-	 openapi-spec-validator openapi/api.spec.yaml
+	 openapi-spec-validator internal/server/api.yaml
 
 COMMIT = $(shell (cd "$(SRCDIR)" && git rev-parse HEAD))
 RPM_SPECFILE=rpmbuild/SPECS/image-builder-$(COMMIT).spec

--- a/cmd/image-builder-tests/main_test.go
+++ b/cmd/image-builder-tests/main_test.go
@@ -62,5 +62,10 @@ func TestImageBuilder(t *testing.T) {
 	client, err = server.NewClientWithResponses("http://127.0.0.1:8086/api/image-builder/v1")
 	versionResp, err := client.GetVersionWithResponse(ctx)
 	require.NoError(t, err)
-	require.Equalf(t, http.StatusUnauthorized, versionResp.StatusCode(), "Error: got non-401 status. Full response: %s", versionResp.Body)
+	require.Equalf(t, http.StatusNotFound, versionResp.StatusCode(), "Error: got non-401 status. Full response: %s", versionResp.Body)
+
+	client, err = server.NewClientWithResponses("http://127.0.0.1:8086/api/image-builder/v1.0", ConfigureClient)
+	versionResp, err = client.GetVersionWithResponse(ctx)
+	require.NoError(t, err)
+	require.Equalf(t, http.StatusOK, versionResp.StatusCode(), "Error: got non-200 status. Full response: %s", versionResp.Body)
 }

--- a/internal/server/api.yaml
+++ b/internal/server/api.yaml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.1
 info:
-  version: "1"
+  version: "1.0"
   title: Image-builder service
   description: Service that relays image build requests
   license:
@@ -59,7 +59,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Architectures'
-  /compose/{composeId}:
+  /composes/{composeId}:
     get:
       summary: get status of an image compose
       parameters:
@@ -97,9 +97,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ComposeResponse'
-
+        '400':
+          description: the compose request is malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
 components:
   schemas:
+    HTTPError:
+      required:
+        - title
+        - detail
+      properties:
+        title:
+          type: string
+        detail:
+          type: string
+    HTTPErrorList:
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/HTTPError'
     Version:
       required:
         - version


### PR DESCRIPTION
- [x] blocked on #41 
- [x] needs adjustments in frontend (`composes/$id` rather than `compose/$id`)

---

This contains mostly little adjustments to be compliant with clouddot guidelines.

They also prefer using the content-Type `application/vnd.api+json` however echo doesn't really support this, and it would require overwriting headers, or encoding the response into json ourselves etc... so I'd just leave it unless it turns out to be a real problem.

