### PR TITLE
openshift: run 2 replicas

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -30,7 +30,7 @@ objects:
       service: image-builder
     name: image-builder
   spec:
-    replicas: 1
+    replicas: 2
     selector:
       matchLabels:
         name: image-builder


### PR DESCRIPTION
Let's work out bugs that arise from running more than one replica of image-builder in OpenShift by increasing the replica count to 2.