### PR TITLE
image-builder: Specify config default values when creating it

### DIFF
--- a/cmd/image-builder/config.go
+++ b/cmd/image-builder/config.go
@@ -2,8 +2,8 @@ package main
 
 // Do not write this config to logs or stdout, it contains secrets!
 type ImageBuilderConfig struct {
-	ListenAddress   string  `env:"LISTEN_ADDRESS" default:"localhost:8086"`
-	LogLevel        string  `env:"LOG_LEVEL" default:"INFO"`
+	ListenAddress   string  `env:"LISTEN_ADDRESS"`
+	LogLevel        string  `env:"LOG_LEVEL"`
 	LogGroup        *string `env:"CW_LOG_GROUP"`
 	Region          *string `env:"CW_AWS_REGION"`
 	AccessKeyID     *string `env:"CW_AWS_ACCESS_KEY_ID"`

--- a/cmd/image-builder/config_test.go
+++ b/cmd/image-builder/config_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefault(t *testing.T) {
+	os.Clearenv()
+
+	config := ImageBuilderConfig{
+		ListenAddress: "localhost",
+		LogLevel: "DEBUG",
+	}
+	err := LoadConfigFromEnv(&config)
+	require.NoError(t, err)
+	require.Equal(t, config.ListenAddress, "localhost")
+	require.Equal(t, config.LogLevel, "DEBUG")
+	require.Nil(t, config.LogGroup)
+	require.Nil(t, config.Region)
+	require.Nil(t, config.AccessKeyID)
+	require.Nil(t, config.SecretAccessKey)
+}
+
+func TestEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("LISTEN_ADDRESS", "localhost:8000")
+	os.Setenv("LOG_LEVEL", "INFO")
+
+	config := ImageBuilderConfig{
+		ListenAddress: "localhost",
+		LogLevel: "DEBUG",
+	}
+	err := LoadConfigFromEnv(&config)
+	require.NoError(t, err)
+	require.Equal(t, config.ListenAddress, "localhost:8000")
+	require.Equal(t, config.LogLevel, "INFO")
+	require.Nil(t, config.LogGroup)
+	require.Nil(t, config.Region)
+	require.Nil(t, config.AccessKeyID)
+	require.Nil(t, config.SecretAccessKey)
+}
+
+func TestEnvPointerValues(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("CW_LOG_GROUP", "somegroup")
+	os.Setenv("CW_AWS_REGION", "us-east-1")
+
+	var config ImageBuilderConfig
+	err := LoadConfigFromEnv(&config)
+	require.NoError(t, err)
+	require.Empty(t, config.ListenAddress)
+	require.Empty(t, config.LogLevel)
+	require.Equal(t, *config.LogGroup, "somegroup")
+	require.Equal(t, *config.Region, "us-east-1")
+	require.Nil(t, config.AccessKeyID)
+	require.Nil(t, config.SecretAccessKey)
+}
+
+func TestErrors(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("BAD_TYPE", "1000")
+
+	config := struct {
+		BadType int `env:"BAD_TYPE"`
+	}{}
+	err := LoadConfigFromEnv(&config)
+	require.Error(t, err, "Unsupported type")
+
+	config2 := struct {
+		BadType *int `env:"BAD_TYPE"`
+	}{}
+	err = LoadConfigFromEnv(&config2)
+	require.Error(t, err, "Unsupported type")
+}

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -23,31 +23,31 @@ func LoadConfigFromEnv(intf interface{}) error {
 			return fmt.Errorf("No env tag in config field")
 		}
 
-		// If no value is defined in the env try the default value
 		confV, ok := os.LookupEnv(key)
-		if !ok {
-			confV, ok = fieldT.Tag.Lookup("default")
-		}
-
 		kind := fieldV.Kind()
 		if ok {
 			switch kind {
 			case reflect.Ptr:
+				if fieldT.Type.Elem().Kind() != reflect.String {
+					return fmt.Errorf("Unsupported type")
+				}
 				fieldV.Set(reflect.ValueOf(&confV))
 			case reflect.String:
 				fieldV.SetString(confV)
 			default:
 				return fmt.Errorf("Unsupported type")
 			}
-		} else if kind == reflect.String {
-			return fmt.Errorf("Undefined non-pointer field without default value %v", fieldT)
 		}
 	}
 	return nil
 }
 
 func main() {
-	var config ImageBuilderConfig
+	config := ImageBuilderConfig{
+		ListenAddress: "localhost:8086",
+		LogLevel: "INFO",
+	}
+
 	err := LoadConfigFromEnv(&config)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Instead of defining them in tags, define them when creating the object.