### PR TITLE
Add cloudwatch configuration and startup script

### DIFF
--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -11,5 +11,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN mkdir /app
 COPY --from=builder /opt/app-root/src/go/bin/image-builder /app/
 COPY ./distributions /app/distributions
+COPY ./distribution/openshift-startup.sh /opt/openshift-startup.sh
 EXPOSE 8086
-CMD ["/app/image-builder", "-v"]
+CMD ["/opt/openshift-startup.sh"]

--- a/distribution/openshift-startup.sh
+++ b/distribution/openshift-startup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -z "${KUBERNETES_PORT:-}" ]]; then
+    echo "Starting image-builder inside container..."
+else
+    echo "Starting image-builder inside OpenShift..."
+    echo "Cloudwatch logs: ${CW_LOG_GROUP_NAME} in ${CW_AWS_REGION}"
+    echo "Database: ${PGDATABASE} on ${PGHOST}:${PGPORT}"
+fi
+
+/app/image-builder -v

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -77,6 +77,7 @@ objects:
               value: "${CW_LOG_GROUP}"
             - name: CW_AWS_REGION
               value: "${CW_AWS_REGION}"
+            # Credentials/configuration for AWS RDS.
             - name: PGHOST
               valueFrom:
                 secretKeyRef:
@@ -102,17 +103,27 @@ objects:
                 secretKeyRef:
                   name: image-builder-db
                   key: db.password
-# Wait until these secrets have been put in place before uncommenting them
-            # - name: CW_AWS_ACCESS_KEY_ID
-            #   valueFrom:
-            #     secretKeyRef:
-            #       key: CW_AWS_ACCESS_KEY_ID
-            #       name: cloudwatch
-            # - name: CW_AWS_SECRET_ACCESS_KEY
-            #   valueFrom:
-            #     secretKeyRef:
-            #       key: CW_AWS_SECRET_ACCESS_KEY
-            #       name: cloudwatch
+            # Credentials/configuration for AWS cloudwatch.
+            - name: CW_AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws_access_key_id
+                  name: image-builder-cloudwatch
+            - name: CW_AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws_secret_access_key
+                  name: image-builder-cloudwatch
+            - name: CW_LOG_GROUP_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: log_group_name
+                  name: image-builder-cloudwatch
+            - name: CW_AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: aws_region
+                  name: image-builder-cloudwatch
 
 # Set up a service within the namespace for the backend.
 - apiVersion: v1
@@ -154,9 +165,3 @@ parameters:
   - name: LISTEN_ADDRESS
     description: Listening address and port
     value: "0.0.0.0:8086"
-  - name: CW_LOG_GROUP
-    description: CloudWatch log group
-    value: "platform-dev"
-  - name: CW_AWS_REGION
-    description: CloudWatch region
-    value: "us-east-1"


### PR DESCRIPTION
Add the AWS Cloudwatch configuration and credentials to the deployment for logging. Also, use a startup script for image-builder that prints some diagnostic information about its database connection and where to find logs in AWS.