### PR TITLE
🔧 openshift: fix cloudwatch log group var

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -110,7 +110,7 @@ objects:
                 secretKeyRef:
                   key: aws_secret_access_key
                   name: image-builder-cloudwatch
-            - name: CW_LOG_GROUP_NAME
+            - name: CW_LOG_GROUP
               valueFrom:
                 secretKeyRef:
                   key: log_group_name


### PR DESCRIPTION
The image-builder code is looking for `CW_LOG_GROUP` and not `CW_LOG_GROUP_NAME`.

Signed-off-by: Major Hayden <major@redhat.com>