### PR TITLE
server: Only require Region and ShareWithAccounts for aws upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,5 @@ ubi-container:
 
 .PHONY: update-cloudapi
 update-cloudapi:
-	curl https://raw.githubusercontent.com/osbuild/osbuild-composer/master/internal/cloudapi/openapi.yml -o internal/cloudapi/cloudapi_client.yml
+	curl https://raw.githubusercontent.com/osbuild/osbuild-composer/main/internal/cloudapi/openapi.yml -o internal/cloudapi/cloudapi_client.yml
 	tools/prepare-source.sh

--- a/cmd/image-builder-tests/main_test.go
+++ b/cmd/image-builder-tests/main_test.go
@@ -65,20 +65,11 @@ func RunTestWithClient(t *testing.T, ib string)  {
 			server.ImageRequest{
 				Architecture: (*archResp.JSON200)[0].Arch,
 				ImageType: (*archResp.JSON200)[0].ImageTypes[0],
-				UploadRequests: &[]server.UploadRequest{
+				UploadRequests: []server.UploadRequest{
 					{
 						Type: "aws",
 						Options: server.AWSUploadRequestOptions{
-							Ec2: server.AWSUploadRequestOptionsEc2{
-								AccessKeyId: "invalid",
-								SecretAccessKey: "invalid",
-							},
-							S3: server.AWSUploadRequestOptionsS3{
-								AccessKeyId: "invalid",
-								SecretAccessKey: "invalid",
-								Bucket: "invalid",
-							},
-							Region: "invalid",
+							ShareWithAccounts: []string{"012345678912"},
 						},
 					},
 				},
@@ -96,7 +87,7 @@ func RunTestWithClient(t *testing.T, ib string)  {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, composeResp.StatusCode(), "Error: got non-201 status. Full response: %s", composeResp.Body)
 	require.NotEmpty(t, statusResp.JSON200)
-	require.Contains(t, []string{"WAITING", "RUNNING"}, statusResp.JSON200.Status)
+	require.Contains(t, []string{"pending", "running"}, statusResp.JSON200.Status)
 
 	// Check if we get 404 without the identity header
 	client, err = server.NewClientWithResponses(ib)

--- a/cmd/image-builder/config.go
+++ b/cmd/image-builder/config.go
@@ -2,14 +2,18 @@ package main
 
 // Do not write this config to logs or stdout, it contains secrets!
 type ImageBuilderConfig struct {
-	ListenAddress   string  `env:"LISTEN_ADDRESS"`
-	LogLevel        string  `env:"LOG_LEVEL"`
-	LogGroup        *string `env:"CW_LOG_GROUP"`
-	Region          *string `env:"CW_AWS_REGION"`
-	AccessKeyID     *string `env:"CW_AWS_ACCESS_KEY_ID"`
-	SecretAccessKey *string `env:"CW_AWS_SECRET_ACCESS_KEY"`
-	OsbuildURL      string  `env:"OSBUILD_URL"`
-	OsbuildCert     *string `env:"OSBUILD_CERT_PATH"`
-	OsbuildKey      *string `env:"OSBUILD_KEY_PATH"`
-	OsbuildCA       *string `env:"OSBUILD_CA_PATH"`
+	ListenAddress          string  `env:"LISTEN_ADDRESS"`
+	LogLevel               string  `env:"LOG_LEVEL"`
+	LogGroup               *string `env:"CW_LOG_GROUP"`
+	CwRegion               *string `env:"CW_AWS_REGION"`
+	CwAccessKeyID          *string `env:"CW_AWS_ACCESS_KEY_ID"`
+	CwSecretAccessKey      *string `env:"CW_AWS_SECRET_ACCESS_KEY"`
+	OsbuildRegion          string  `env:"OSBUILD_AWS_REGION"`
+	OsbuildAccessKeyID     string  `env:"OSBUILD_AWS_ACCESS_KEY_ID"`
+	OsbuildSecretAccessKey string  `env:"OSBUILD_AWS_SECRET_ACCESS_KEY"`
+	OsbuildS3Bucket        string  `env:"OSBUILD_AWS_S3_BUCKET"`
+	OsbuildURL             string  `env:"OSBUILD_URL"`
+	OsbuildCert            *string `env:"OSBUILD_CERT_PATH"`
+	OsbuildKey             *string `env:"OSBUILD_KEY_PATH"`
+	OsbuildCA              *string `env:"OSBUILD_CA_PATH"`
 }

--- a/cmd/image-builder/config_test.go
+++ b/cmd/image-builder/config_test.go
@@ -19,9 +19,9 @@ func TestDefault(t *testing.T) {
 	require.Equal(t, config.ListenAddress, "localhost")
 	require.Equal(t, config.LogLevel, "DEBUG")
 	require.Nil(t, config.LogGroup)
-	require.Nil(t, config.Region)
-	require.Nil(t, config.AccessKeyID)
-	require.Nil(t, config.SecretAccessKey)
+	require.Nil(t, config.CwRegion)
+	require.Nil(t, config.CwAccessKeyID)
+	require.Nil(t, config.CwSecretAccessKey)
 }
 
 func TestEnv(t *testing.T) {
@@ -38,9 +38,9 @@ func TestEnv(t *testing.T) {
 	require.Equal(t, config.ListenAddress, "localhost:8000")
 	require.Equal(t, config.LogLevel, "INFO")
 	require.Nil(t, config.LogGroup)
-	require.Nil(t, config.Region)
-	require.Nil(t, config.AccessKeyID)
-	require.Nil(t, config.SecretAccessKey)
+	require.Nil(t, config.CwRegion)
+	require.Nil(t, config.CwAccessKeyID)
+	require.Nil(t, config.CwSecretAccessKey)
 }
 
 func TestEnvPointerValues(t *testing.T) {
@@ -54,9 +54,9 @@ func TestEnvPointerValues(t *testing.T) {
 	require.Empty(t, config.ListenAddress)
 	require.Empty(t, config.LogLevel)
 	require.Equal(t, *config.LogGroup, "somegroup")
-	require.Equal(t, *config.Region, "us-east-1")
-	require.Nil(t, config.AccessKeyID)
-	require.Nil(t, config.SecretAccessKey)
+	require.Equal(t, *config.CwRegion, "us-east-1")
+	require.Nil(t, config.CwAccessKeyID)
+	require.Nil(t, config.CwSecretAccessKey)
 }
 
 func TestErrors(t *testing.T) {

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -54,13 +54,13 @@ func main() {
 		panic(err)
 	}
 
-	log, err := logger.NewLogger(config.LogLevel, config.AccessKeyID, config.SecretAccessKey, config.Region, config.LogGroup)
+	log, err := logger.NewLogger(config.LogLevel, config.CwAccessKeyID, config.CwSecretAccessKey, config.CwRegion, config.LogGroup)
 	if err != nil {
 		panic(err)
 	}
 
 	client := cloudapi.NewOsbuildClient(config.OsbuildURL, config.OsbuildCert, config.OsbuildKey, config.OsbuildCA)
 
-	s := server.NewServer(log, client)
+	s := server.NewServer(log, client, config.OsbuildRegion, config.OsbuildAccessKeyID, config.OsbuildSecretAccessKey, config.OsbuildS3Bucket)
 	s.Run(config.ListenAddress)
 }

--- a/distributions/fedora-32.json
+++ b/distributions/fedora-32.json
@@ -4,7 +4,7 @@
     "description": "Fedora 32"
   },
   "x86_64": {
-    "image_types": [ "qcow2" ],
+    "image_types": [ "ami" ],
     "repositories": [{
       "baseurl": "http://mirrors.kernel.org/fedora/releases/32/Everything/x86_64/os/",
       "rhsm": false

--- a/distributions/rhel-8.json
+++ b/distributions/rhel-8.json
@@ -4,7 +4,7 @@
     "description": "Red Hat Enterprise Linux (RHEL) 8.2"
   },
   "x86_64": {
-    "image_types": [ "qcow2" ],
+    "image_types": [ "ami" ],
     "repositories": [{
       "baseurl": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os",
       "rhsm": true

--- a/internal/cloudapi/cloudapi_client.go
+++ b/internal/cloudapi/cloudapi_client.go
@@ -25,9 +25,10 @@ type AWSUploadRequestOptions struct {
 
 // AWSUploadRequestOptionsEc2 defines model for AWSUploadRequestOptionsEc2.
 type AWSUploadRequestOptionsEc2 struct {
-	AccessKeyId     string  `json:"access_key_id"`
-	SecretAccessKey string  `json:"secret_access_key"`
-	SnapshotName    *string `json:"snapshot_name,omitempty"`
+	AccessKeyId       string    `json:"access_key_id"`
+	SecretAccessKey   string    `json:"secret_access_key"`
+	ShareWithAccounts *[]string `json:"share_with_accounts,omitempty"`
+	SnapshotName      *string   `json:"snapshot_name,omitempty"`
 }
 
 // AWSUploadRequestOptionsS3 defines model for AWSUploadRequestOptionsS3.
@@ -81,8 +82,10 @@ type ImageStatus struct {
 
 // Repository defines model for Repository.
 type Repository struct {
-	Baseurl string `json:"baseurl"`
-	Rhsm    bool   `json:"rhsm"`
+	Baseurl    *string `json:"baseurl,omitempty"`
+	Metalink   *string `json:"metalink,omitempty"`
+	Mirrorlist *string `json:"mirrorlist,omitempty"`
+	Rhsm       bool    `json:"rhsm"`
 }
 
 // Subscription defines model for Subscription.

--- a/internal/cloudapi/cloudapi_client.yml
+++ b/internal/cloudapi/cloudapi_client.yml
@@ -69,7 +69,7 @@ components:
       properties:
         status:
           type: string
-          enum: ['success', 'failure', 'pending']
+          enum: ['success', 'failure', 'pending', 'running']
           example: 'success'
         image_statuses:
           type: array
@@ -135,15 +135,22 @@ components:
     Repository:
       type: object
       required:
-        - baseurl
         - rhsm
       properties:
+        rhsm:
+          type: boolean
         baseurl:
           type: string
           format: url
           example: 'https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/'
-        rhsm:
-          type: boolean
+        mirrorlist:
+          type: string
+          format: url
+          example: 'https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-33&arch=x86_64'
+        metalink:
+          type: string
+          format: url
+          example: 'https://mirrors.fedoraproject.org/metalink?repo=fedora-32&arch=x86_64'
     UploadRequest:
       type: object
       required:
@@ -203,6 +210,11 @@ components:
         snapshot_name:
           type: string
           example: 'my-snapshot'
+        share_with_accounts:
+          type: array
+          example: ['123456789012']
+          items:
+            type: string
     Customizations:
       type: object
       properties:

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -22,22 +22,7 @@ import (
 
 // AWSUploadRequestOptions defines model for AWSUploadRequestOptions.
 type AWSUploadRequestOptions struct {
-	Ec2    AWSUploadRequestOptionsEc2 `json:"ec2"`
-	Region string                     `json:"region"`
-	S3     AWSUploadRequestOptionsS3  `json:"s3"`
-}
-
-// AWSUploadRequestOptionsEc2 defines model for AWSUploadRequestOptionsEc2.
-type AWSUploadRequestOptionsEc2 struct {
-	AccessKeyId     string `json:"access_key_id"`
-	SecretAccessKey string `json:"secret_access_key"`
-}
-
-// AWSUploadRequestOptionsS3 defines model for AWSUploadRequestOptionsS3.
-type AWSUploadRequestOptionsS3 struct {
-	AccessKeyId     string `json:"access_key_id"`
-	Bucket          string `json:"bucket"`
-	SecretAccessKey string `json:"secret_access_key"`
+	ShareWithAccounts []string `json:"share_with_accounts"`
 }
 
 // ArchitectureItem defines model for ArchitectureItem.
@@ -93,9 +78,9 @@ type HTTPErrorList struct {
 
 // ImageRequest defines model for ImageRequest.
 type ImageRequest struct {
-	Architecture   string           `json:"architecture"`
-	ImageType      string           `json:"image_type"`
-	UploadRequests *[]UploadRequest `json:"upload_requests,omitempty"`
+	Architecture   string          `json:"architecture"`
+	ImageType      string          `json:"image_type"`
+	UploadRequests []UploadRequest `json:"upload_requests"`
 }
 
 // Subscription defines model for Subscription.
@@ -1015,30 +1000,28 @@ func RegisterHandlers(router EchoRouter, si ServerInterface) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9RXXY/TOBf+K5bf92JXSpPSGQHq3exQlsLAoCnLgtBo5ManjSGJM7bTTnfU/76y46Rx",
-	"4n6wAmn3iiE+Puc5j5/z0Ucc86zgOeRK4vEjlnECGTF/Xvw5+6NIOaE3cF+CVNeFYjw3R4XgBQjFwPwP",
-	"4pH+5/8CFniM/xftPEbWXbTH1yQe4W2ABSwZz42rB5IVKeAxhnKwBqkGT3CA1abQn6QSLF/qC/LsHwac",
-	"neGtCXhfMgEUj7/UwY3TwORy20Tk868QKx3xQAI9Pkgcg5R332Bzx6ib1cWb6cX0evby+sW7d88mny7e",
-	"vr+aeBOEWIC623ly3axfk1R8ul9Tdr+mLydvp9GbZ/dsTaP5+4ebBbv8bF2/mXzGAV5wkRGFx7ggUq65",
-	"oP2IHU7cDHxwvoOj2dlPoWhext9AuXezzcB+/i9y2uTkJVfECVMQq1LAVEHm4VTEiZvSw/Ond0/PfVyw",
-	"jCzhTn82V5mCTLp372O+Hvmu2g9ECLLpJ6kxuO6PJeMCOFjTXQp6aAJ8qa9JsArskxSXUvGM/UWaXnYo",
-	"4qVrvQ0wZZqJeal6DUskkA6e7ydbVJBOT3eqr9WJHCPewdUL6XuDhilZ8FxCn6qqMA+LmlF8u/M1U0SV",
-	"ngEhm++HvVk747H3Th2X5VzGghX1Oxwicta23W49XLxosecvLgpOuN2z3wBFr4hCk1yBKASTgK5YXj6g",
-	"X25eTa5+Rc9DbxXlJIPT9NPhyFwMHDy3RzI6XXI9HjwV9urDh/cTIbjwkaQISz3vHGDFVArHFVCZBbWn",
-	"23a8K+YraNBHp2e4Q3+soqxjDcGpRG/frduSN/ddN/Qel2Zmfn9/cGbtSZ25Qelg0hnOOuXUndaKrUwl",
-	"DnpjM9sMqkk2qEbYCYMxwHMiYVCK1HWVKFWMoyimeSiAJkSFMc+itk99xddgc8mWiXInmBIlNLZzzlMg",
-	"uTbmYkly21icC6Ph+fBsdN7cYbmCJYhqdRArEH3E7S4UikRmLeBHK9kBEnRJdoK2GGtl66t7VxS9l+TF",
-	"SXNv3+rfiOwRQ15mRlfrNpB9Za1Pgya6D/hHENIrvtXu4HCQ2vB2uzWaWPBe48YzECsWA1IJUUhASjYS",
-	"mVJA85KlFDVFGOCUxWDnYtWs8UVB4gTQKBziwEixkqwcR9F6vQ6JOQ65WEb2royuppeTd7PJYBQOw0Rl",
-	"aasVVl1lYOKCQLJChoNdwvhJODSKLSAnBcNjfBYOQ/2DqCAqMeRE7bKW0WN7Ddhqg2W1ImtCjbamFI/x",
-	"76DcDUx7FCQDBbqVfumy1vaKFlygdcLiBCmOUs6/obJAZEVYSuYpINJxzHLTC5ReCy2PnV1l94ZVyVYi",
-	"9L33rTau1hWT/Wg4NDsdzxXkJk9SFCmLTabRV1mpZufv1OVSYiMhlwSCUiYV4ot9ySKSU6QSYAIRKXnM",
-	"iAJq1VWtwtqpLLOMiA0e66fR5nudtG62Qmr6CVqyFeTIIVI7rxKzyxyvGoCbhTWonJuSbAvD7nFTe2ir",
-	"4TdONz+M586C7iG6mv1SM20p4GgOyCKnPcVse6p48uPR2iXZA7dmNCESSUWEAqqL9vwHatNdgTwYtIxq",
-	"HPbREJMoI6kenRqQozxXBG3hyOjR/jWl7f7hhqv2dFMKuX2jWnhBv9W4Pw6OtJop1W5rgDaQ4mhpftN7",
-	"mkkD91/TSdx8DyhG1hbdrnCAX/NYtLvc7+vy7q+An5izG+jE7kk7l7zN8YB1ZAdjWGPdR8N1Zfda2nnT",
-	"J8EFK0CVIpdIJUwiyuMy0wT5AVoMSGNAsoCYLSyFegEkSy1ynIEiei8JcNRaZ7y1Vfu1+wCq7T2F9bE5",
-	"+mnvWofwvmgXop+gvtV2+3cAAAD//1bahoZ2FgAA",
+	"H4sIAAAAAAAC/8xX3W7jNhN9FYLfd9ECsuQ4aZr6Lk2DxkXQLeLt9mJhBDQ1trgriQpJ2XEDvXtBipJF",
+	"if4pkAV6Z4jDmTNnzgzHb5jyrOA55Eri6RuWNIGMmJ+3f83/LFJO4id4KUGqD4ViPDdHheAFCMWgvpMQ",
+	"Ac9bppJnQikvrSt4JVmRAp5+xheTy6sfrn+8+Wl8McGLADMFmbFRuwLwFEslWL7GVdB8IEKQHa6qAAt4",
+	"KZmAWLvxBVq0d/jyC1ClndwKmjAFVJUCZgqyIWQiaOJgxK8318/XVzgYQmIZWcOz/myuttj3d18o3058",
+	"V49mYzC47k8l4wL4v4AVnuL/RfsSRrZ+0YCCAZoA3+lrEmx5hyTRUiqesb9JW/djEe9c6yrAMdNMLEv9",
+	"wSVMJJCObg6TLWpI56c709eaRE4R7+AahPTVoGVKFjyXMKSKxR4198KyGC/2vuaKqNLXTO33496snfE4",
+	"qFPPZbmUVLCiqcMxIudd26rycPFLhz1/c8XghNuX/Qli9EAUus8ViEIwCeiR5eUr+u7p4f7xe3QTerso",
+	"Jxmcp58eR+Zi4OBZnMjofMkNePB02MPHj3/cC8GFjyRFWOqfgUylcFoBtVnQeFp04z0yX0ODPjo/wz36",
+	"Ux1lHWsITid6524zlry576eh97g0D9K/nw/OQ3bWZG5ROpiGCHTO816D9XKmim1Mb46+ws4VcrYbSaAC",
+	"lDkK8IqLjCg8xQWRcstF7OuHJZEwKkXqukqUKqZRROM8FBAnRIWUZ1HXp77iG7m5ZOuk92YrUUJru+Q8",
+	"BZJrYy7WJLejxrkwGV+NLydX7R2WK1iDkY4EsQExRNydS6FIZNYBfrK3HSBBn2QnaIexTra+SeDKZFBJ",
+	"Xpz1Eh5anFrZvWHIy8wobdsFcqjRa+U10X3AP4GQXvFt9gfHgzSGi6oymljxwSjHcxAbRgGphCgkICU7",
+	"iUxzoGXJ0hi1TRHglFGwL2U9vvFtQWgCaBKOdRdpLRjJymkUbbfbkJjjkIt1ZO/K6HF2d//7/H40Ccdh",
+	"orK0MxzrOTMycUEgWSPDwT5hfBGOjWILyEnB8BRfhuPwAge4ICox5ETdRpfRW3cxqLTBGlRddxBGW7MY",
+	"T/GvoNydTHsUJAMFerh+7rPW9YpWXKBtwmiCFEcp519RWSCyISwlyxQQ6TlmuZkFSi+Klsfe9rKvYd2y",
+	"tQh99V5o43qBMdlPxmOz5fFcQW7yJEWRMmoyjb7IWjV7f+eumxIbCbkkEJQyqRBfHUoWkTxGKgEmEJGS",
+	"U0YUxFZd9XKsncoyy4jY4akujTY/6KRzsxNS00/Qmm0gRw6R2nmdmF3veD0A3CysQe3ctGRXGHazm9lD",
+	"2w0/83j3bjz3VnYP0fU2IDXTlgKOloAs8nigmGqgiov3R2vXZg/chtGESCQVEQpi3bRX76hNdynyYNAy",
+	"anDYoiEmUUZS/XRqQI7yXBF0hSOjN/trFnfnhxuu3txNK+S2Ro3wguGocf8unBg1s1i7bQDaQIojjcM7",
+	"TFq4/5lJ4uZ7RDGysehPhSP8mmLF/XX/0JR3/xd8w5zdQGdOz7h3yTscj1hH9mEMG6yHaPhQ2/0m7Xsz",
+	"JMEFK0CVIpdIJUyimNMy0wT5AVoMSGNAsgDKVpZCvQCStRY5zkARvZcEOOqsM97eavzafQA19p7G+tQe",
+	"fbO6NiG8Fe1D9BM0tKqqfwIAAP//euQKerQTAAA=",
 }
 
 // GetSwagger returns the Swagger specification corresponding to the generated code

--- a/internal/server/api.yaml
+++ b/internal/server/api.yaml
@@ -187,6 +187,7 @@ components:
       required:
         - architecture
         - image_type
+        - upload_requests
       properties:
         architecture:
           type: string
@@ -216,47 +217,13 @@ components:
     AWSUploadRequestOptions:
       type: object
       required:
-        - region
-        - s3
-        - ec2
+        - share_with_accounts
       properties:
-        region:
-          type: string
-          example: 'eu-west-1'
-        s3:
-          $ref: '#/components/schemas/AWSUploadRequestOptionsS3'
-        ec2:
-          $ref: '#/components/schemas/AWSUploadRequestOptionsEc2'
-    AWSUploadRequestOptionsS3:
-      type: object
-      required:
-        - access_key_id
-        - secret_access_key
-        - bucket
-      properties:
-        access_key_id:
-          type: string
-          example: 'AKIAIOSFODNN7EXAMPLE'
-        secret_access_key:
-          type: string
-          format: password
-          example: 'wJalrXqwdiqwdFEMI/K7qiwd/bPxRfiCYEXAMPLEKEY'
-        bucket:
-          type: string
-          example: 'my-bucket'
-    AWSUploadRequestOptionsEc2:
-      type: object
-      required:
-        - access_key_id
-        - secret_access_key
-      properties:
-        access_key_id:
-          type: string
-          example: 'AKIAIOSFODNN7EXAMPLE'
-        secret_access_key:
-          type: string
-          format: password
-          example: 'wJalrXqwdiqwdFEMI/K7qiwd/bPxRfiCYEXAMPLEKEY'
+        share_with_accounts:
+          type: array
+          example: ['123456789012']
+          items:
+            type: string
     Customizations:
       type: object
       properties:

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -37,28 +37,24 @@ pipeline {
                     agent { label "f32cloudbase && x86_64 && aws" }
                     steps {
                         sh "schutzbot/ci_details.sh"
-                        retry(3) {
-                            sh "schutzbot/build.sh"
-                        }
+                        sh "schutzbot/build.sh"
                         sh "schutzbot/provision-composer.sh"
                         sh "schutzbot/run_tests.sh"
                     }
                 }
                 // TODO osbuild-composer-api isn't available in rhel8
-                // stage('EL8') {
-                //     agent { label "rhel8cloudbase && x86_64 && aws" }
-                //     environment {
-                //         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
-                //     }
-                //     steps {
-                //         sh "schutzbot/ci_details.sh"
-                //         retry(3) {
-                //             sh "schutzbot/build.sh"
-                //         }
-                //         sh "schutzbot/provision-composer.sh"
-                //         sh "schutzbot/run_tests.sh"
-                //     }
-                // }
+                stage('EL8') {
+                    agent { label "rhel8cloudbase && x86_64 && aws" }
+                    environment {
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
+                    }
+                    steps {
+                        sh "schutzbot/ci_details.sh"
+                        sh "schutzbot/build.sh"
+                        sh "schutzbot/provision-composer.sh"
+                        sh "schutzbot/run_tests.sh"
+                    }
+                }
             }
         }
     }

--- a/schutzbot/provision-composer.sh
+++ b/schutzbot/provision-composer.sh
@@ -1,6 +1,32 @@
 #!/bin/bash
 set -euxo pipefail
 
+# Get OS and architecture details.
+source /etc/os-release
+ARCH=$(uname -m)
+
+echo "Enabling fastestmirror to speed up dnf 🏎️"
+echo -e "fastestmirror=1" | sudo tee -a /etc/dnf/dnf.conf
+
+# Set up osbuild-composer repo
+DNF_REPO_BASEURL=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com
+OSBUILD_COMMIT=f5bfb22355befeddfc4f313b753f81fe919b8e98
+OSBUILD_COMPOSER_COMMIT=22c9f6af616ef2dd2704a3b1c1f2db3248f7110c
+sudo tee /etc/yum.repos.d/osbuild.repo << EOF
+[osbuild]
+name=osbuild ${OSBUILD_COMMIT}
+baseurl=${DNF_REPO_BASEURL}/osbuild/${ID}-${VERSION_ID}/${ARCH}/${OSBUILD_COMMIT}
+enabled=1
+gpgcheck=0
+priority=5
+[osbuild-composer]
+name=osbuild-composer ${OSBUILD_COMPOSER_COMMIT}
+baseurl=${DNF_REPO_BASEURL}/osbuild-composer/${ID}-${VERSION_ID}/${ARCH}/${OSBUILD_COMPOSER_COMMIT}
+enabled=1
+gpgcheck=0
+priority=6
+EOF
+
 # Install osbuild-composer
 sudo dnf install -y osbuild-composer composer-cli
 


### PR DESCRIPTION
Secrets should be accessible by image-builder, and added to the request
for composer. The user should only have to give their aws account id to
share the image with.

Region for now should be filled by image-builder as well.