### PR TITLE
templates: Bump osbuild-composer version

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -246,5 +246,5 @@ parameters:
     value: "quay.io/cloudservices/osbuild-composer"
     description: osbuild-composer image name
   - name: COMPOSER_TAG
-    value: "73deee0"
+    value: "946a0b4"
     description: osbuild-composer version


### PR DESCRIPTION
We need 946a0b4 so we can run the composer-api on a non-privileged port.