### PR TITLE
🤫 Move secrets to osbuild-composer deployment

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -123,6 +123,7 @@ objects:
                 secretKeyRef:
                   key: aws_region
                   name: image-builder-cloudwatch
+            # Secrets used to tell osbuild-composer where to upload images.
             - name: OSBUILD_AWS_REGION
               valueFrom:
                 secretKeyRef:
@@ -143,14 +144,10 @@ objects:
                 secretKeyRef:
                   key: aws_s3_bucket
                   name: composer-secrets
-            - name: OSBUILD_URL
-              value: "${OSBUILD_URL}"
-            - name: OSBUILD_CERT_PATH
-              value: "${OSBUILD_CERT_PATH}"
-            - name: OSBUILD_KEY_PATH
-              value: "${OSBUILD_KEY_PATH}"
-            - name: OSBUILD_CA_PATH
-              value: "${OSBUILD_CA_PATH}"
+          volumes:
+            - name: composer-secrets
+              secret:
+                secretName: composer-secrets
 
 # Deploy the osbuild-composer container.
 - apiVersion: apps/v1
@@ -170,12 +167,21 @@ objects:
           name: osbuild-composer
       spec:
         containers:
-        - image: "${COMPOSER_IMAGE}:${COMPOSER_TAG}"
-          name: osbuild-composer
-          ports:
-          - name: api
-            containerPort: 443
-            protocol: TCP
+          - image: "${COMPOSER_IMAGE}:${COMPOSER_TAG}"
+            name: osbuild-composer
+            ports:
+            - name: api
+              containerPort: 443
+              protocol: TCP
+            env:
+              - name: OSBUILD_URL
+                value: "${OSBUILD_URL}"
+              - name: OSBUILD_CERT_PATH
+                value: "${OSBUILD_CERT_PATH}"
+              - name: OSBUILD_KEY_PATH
+                value: "${OSBUILD_KEY_PATH}"
+              - name: OSBUILD_CA_PATH
+                value: "${OSBUILD_CA_PATH}"
           volumeMounts:
             - name: composer-secrets
               mountPath: "/etc/osbuild-composer"
@@ -185,13 +191,13 @@ objects:
             - name: osbuild-cache-dir
               mountPath: "/var/cache/osbuild-composer"
         volumes:
-        - name: composer-secrets
-          secret:
-            secretName: composer-secrets
-        - emptyDir: {}
-          name: osbuild-state-dir
-        - emptyDir: {}
-          name: osbuild-cache-dir
+          - name: composer-secrets
+            secret:
+              secretName: composer-secrets
+          - emptyDir: {}
+            name: osbuild-state-dir
+          - emptyDir: {}
+            name: osbuild-cache-dir
 
 # Set up a service within the namespace for the backend.
 - apiVersion: v1


### PR DESCRIPTION
Some of the secrets from the image-builder deployment should have been
moved to the osbuild-composer deployment.