### PR TITLE
server: Allow filtering on org_id from the identity header

### DIFF
--- a/cmd/image-builder-tests/main_test.go
+++ b/cmd/image-builder-tests/main_test.go
@@ -33,7 +33,7 @@ func RunTestWithClient(t *testing.T, ib string)  {
 		tries += 1
 	}
 
-	response, body := tutils.GetResponseBody(t, ib + "/distributions", true)
+	response, body := tutils.GetResponseBody(t, ib + "/distributions", &tutils.AuthString0)
 	require.Equalf(t, http.StatusOK, response.StatusCode, "Error: got non-200 status. Full response: %s", body)
 
 	require.NotNil(t, body)
@@ -44,7 +44,7 @@ func RunTestWithClient(t *testing.T, ib string)  {
 	require.NoError(t, err)
 
 	distro := distributions[0].Name
-	response, body = tutils.GetResponseBody(t, ib + "/architectures/" + distro, true)
+	response, body = tutils.GetResponseBody(t, ib + "/architectures/" + distro, &tutils.AuthString0)
 	require.Equalf(t, http.StatusOK, response.StatusCode, "Error: got non-200 status. Full response: %s", body)
 
 	require.NotNil(t, body)
@@ -86,7 +86,7 @@ func RunTestWithClient(t *testing.T, ib string)  {
 
 	id := composeResp.Id
 
-	response, body = tutils.GetResponseBody(t, ib + "/composes/" + id, true)
+	response, body = tutils.GetResponseBody(t, ib + "/composes/" + id, &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, response.StatusCode, "Error: got non-200 status. Full response: %s", body)
 
 	require.NotNil(t, body)
@@ -99,7 +99,7 @@ func RunTestWithClient(t *testing.T, ib string)  {
 	require.Contains(t, []string{"pending", "running"}, composeStatus.Status)
 
 	// Check if we get 404 without the identity header
-	response, body = tutils.GetResponseBody(t, ib + "/version", false)
+	response, body = tutils.GetResponseBody(t, ib + "/version", nil)
 	require.Equalf(t, http.StatusNotFound, response.StatusCode, "Error: got non-404 status. Full response: %s", body)
 }
 
@@ -117,6 +117,7 @@ func TestImageBuilder(t *testing.T) {
 		"OSBUILD_CA_PATH=/etc/osbuild-composer/ca-crt.pem",
 		"OSBUILD_CERT_PATH=/etc/osbuild-composer/client-crt.pem",
 		"OSBUILD_KEY_PATH=/etc/osbuild-composer/client-key.pem",
+		"ALLOWED_ORG_IDS=*",
 	)
 
 	var buf bytes.Buffer

--- a/cmd/image-builder/config.go
+++ b/cmd/image-builder/config.go
@@ -16,4 +16,5 @@ type ImageBuilderConfig struct {
 	OsbuildCert            *string `env:"OSBUILD_CERT_PATH"`
 	OsbuildKey             *string `env:"OSBUILD_KEY_PATH"`
 	OsbuildCA              *string `env:"OSBUILD_CA_PATH"`
+	OrgIds                 string  `env:"ALLOWED_ORG_IDS"`
 }

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -64,6 +64,6 @@ func main() {
 		panic(err)
 	}
 
-	s := server.NewServer(log, client, config.OsbuildRegion, config.OsbuildAccessKeyID, config.OsbuildSecretAccessKey, config.OsbuildS3Bucket)
+	s := server.NewServer(log, client, config.OsbuildRegion, config.OsbuildAccessKeyID, config.OsbuildSecretAccessKey, config.OsbuildS3Bucket, config.OrgIds)
 	s.Run(config.ListenAddress)
 }

--- a/internal/tutils/tutils.go
+++ b/internal/tutils/tutils.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// org_id 000000
+var AuthString0 = "eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAwIn19fQ=="
+
+// org_id 000001
+var AuthString1 = "eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAxIn19fQ=="
+
 func GetResponseError(url string) (*http.Response, error) {
 	client := &http.Client{}
 	request, err := http.NewRequest("GET", url, nil)
@@ -22,12 +28,12 @@ func GetResponseError(url string) (*http.Response, error) {
 	return client.Do(request)
 }
 
-func GetResponseBody(t *testing.T, url string, auth bool) (*http.Response, string) {
+func GetResponseBody(t *testing.T, url string, auth *string) (*http.Response, string) {
 	client := &http.Client{}
 	request, err := http.NewRequest("GET", url, nil)
 	require.NoError(t, err)
-	if auth {
-		request.Header.Add("x-rh-identity", "eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAwIn19fQ==")
+	if auth != nil {
+		request.Header.Add("x-rh-identity", *auth)
 	}
 
 	response, err := client.Do(request)
@@ -50,7 +56,7 @@ func PostResponseBody(t *testing.T, url string, compose interface{}) (*http.Resp
 	request, err := http.NewRequest("POST", url, bytes.NewReader(buf))
 	require.NoError(t, err)
 	request.Header.Add("Content-Type", "application/json")
-	request.Header.Add("x-rh-identity", "eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAwIn19fQ==")
+	request.Header.Add("x-rh-identity", AuthString0)
 
 	response, err := client.Do(request)
 	require.NoError(t, err)

--- a/schutzbot/run_tests.sh
+++ b/schutzbot/run_tests.sh
@@ -44,6 +44,7 @@ sudo podman run -d --pull=never --security-opt "label=disable" --net=host \
      -e OSBUILD_CA_PATH=/etc/osbuild-composer/ca-crt.pem \
      -e OSBUILD_CERT_PATH=/etc/osbuild-composer/client-crt.pem \
      -e OSBUILD_KEY_PATH=/etc/osbuild-composer/client-key.pem \
+     -e ALLOWED_ORG_IDS="000000" \
      -v /etc/osbuild-composer:/etc/osbuild-composer \
      image-builder
 

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -153,6 +153,8 @@ objects:
                 secretKeyRef:
                   key: aws_s3_bucket
                   name: composer-secrets
+            - name: ALLOWED_ORG_IDS
+              value: "${ALLOWED_ORG_IDS}"
         volumes:
           - name: composer-secrets
             secret:
@@ -210,3 +212,6 @@ parameters:
   - name: OSBUILD_URL
     description: Url to osbuild-composer instance in AWS
     value: "https://aws.composer.osbuild.org:9876/api/composer/v1"
+  - name: ALLOWED_ORG_IDS
+    description: Organization ids allowed to access the api, wildcard means everyone
+    value: "*"


### PR DESCRIPTION
For now when the environment is empty the filter won't apply.