### PR TITLE
server: Fix edge case in organization id filter

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/osbuild/image-builder/internal/cloudapi"
 	"github.com/osbuild/image-builder/internal/logger"
@@ -64,6 +65,12 @@ func main() {
 		panic(err)
 	}
 
-	s := server.NewServer(log, client, config.OsbuildRegion, config.OsbuildAccessKeyID, config.OsbuildSecretAccessKey, config.OsbuildS3Bucket, config.OrgIds)
+	// Make a slice of allowed organization ids, '*' in the slice means blanket permission
+	orgIds := []string{}
+	if config.OrgIds != "" {
+		orgIds = strings.Split(config.OrgIds, ";")
+	}
+
+	s := server.NewServer(log, client, config.OsbuildRegion, config.OsbuildAccessKeyID, config.OsbuildSecretAccessKey, config.OsbuildS3Bucket, orgIds)
 	s.Run(config.ListenAddress)
 }


### PR DESCRIPTION
The previous check to see if the id was contained in a string didn't
take into account that organization ids might differ in length. And thus
if any id was a substring of the allowed ids, it could get acccess.