### PR TITLE
distributions: fix the centos stream 8 repo

### DIFF
--- a/distributions/centos-8.json
+++ b/distributions/centos-8.json
@@ -7,10 +7,10 @@
   "x86_64": {
     "image_types": [ "ami" ],
     "repositories": [{
-      "mirrorlist": "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS",
+      "baseurl": "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/",
       "rhsm": false
     }, {
-      "mirrorlist": "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream",
+      "baseurl": "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/",
       "rhsm": false
     }]
   }


### PR DESCRIPTION
I made a mistake in my original PR: I used a mirrorlist for a "classic"
Centos 8. I could have fixed it by s/8/8-stream but I decided to drop the
mirrorlist. The reason is that in AWS it returns the
d36uatko69830t.cloudfront.net mirror. This mirror is amazingly fast but from
my experience, it can be often desynchronized. The plain dnf can handle it
but osbuild doesn't really like desynchronized repos. Therefore I switched
to mirror.centos.org which should be much more stable in this regard.

btw from /etc/yum.repos.d/ on centos stream 8:

```
# If the mirrorlist does not work for you, you can try the commented out
# baseurl line instead.

[baseos]
name=CentOS Stream $releasever - BaseOS
mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra
#baseurl=http://mirror.centos.org/$contentdir/$stream/BaseOS/$basearch/os/
```

This means that using mirror.centos.org directly is indeed a recommended
way of dealing with issues with the mirrorlist.