### PR TITLE
templates: Disable readiness probe

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -50,15 +50,15 @@ objects:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: ${READINESS_URI}
-              port: 8086
-              scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 10 # The readiness probe is pinging osbuild-composer
+          # readinessProbe:
+          #   failureThreshold: 3
+          #   httpGet:
+          #     path: ${READINESS_URI}
+          #     port: 8086
+          #     scheme: HTTP
+          #   periodSeconds: 10
+          #   successThreshold: 1
+          #   timeoutSeconds: 10 # The readiness probe is pinging osbuild-composer
           ports:
           - name: api
             containerPort: 8086


### PR DESCRIPTION
It's currently DDoS-ing the composer deployments.