### PR TITLE
Expose upload options via API and extend integration testing for all cloud providers

### DIFF
--- a/internal/cloudapi/cloudapi_types.go
+++ b/internal/cloudapi/cloudapi_types.go
@@ -25,6 +25,12 @@ type AWSUploadRequestOptionsS3 struct {
 	SecretAccessKey string `json:"secret_access_key"`
 }
 
+// AWSUploadStatus defines model for AWSUploadStatus.
+type AWSUploadStatus struct {
+	Ami    string `json:"ami"`
+	Region string `json:"region"`
+}
+
 // AzureUploadRequestOptions defines model for AzureUploadRequestOptions.
 type AzureUploadRequestOptions struct {
 
@@ -48,6 +54,11 @@ type AzureUploadRequestOptions struct {
 	// to find it in the Azure Portal:
 	// https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant
 	TenantId string `json:"tenant_id"`
+}
+
+// AzureUploadStatus defines model for AzureUploadStatus.
+type AzureUploadStatus struct {
+	ImageName string `json:"image_name"`
 }
 
 // ComposeRequest defines model for ComposeRequest.
@@ -106,6 +117,12 @@ type GCPUploadRequestOptions struct {
 	ShareWithAccounts *[]string `json:"share_with_accounts,omitempty"`
 }
 
+// GCPUploadStatus defines model for GCPUploadStatus.
+type GCPUploadStatus struct {
+	ImageName string `json:"image_name"`
+	ProjectId string `json:"project_id"`
+}
+
 // ImageRequest defines model for ImageRequest.
 type ImageRequest struct {
 	Architecture   string          `json:"architecture"`
@@ -145,8 +162,9 @@ type UploadRequest struct {
 
 // UploadStatus defines model for UploadStatus.
 type UploadStatus struct {
-	Status string      `json:"status"`
-	Type   UploadTypes `json:"type"`
+	Options interface{} `json:"options"`
+	Status  string      `json:"status"`
+	Type    UploadTypes `json:"type"`
 }
 
 // UploadTypes defines model for UploadTypes.

--- a/internal/cloudapi/cloudapi_types.yml
+++ b/internal/cloudapi/cloudapi_types.yml
@@ -110,24 +110,47 @@ components:
       required:
         - status
         - type
+        - options
       properties:
         status:
           type: string
           enum: ['success', 'failure', 'pending', 'running']
         type:
           $ref: '#/components/schemas/UploadTypes'
+        options:
+          oneOf:
+            - $ref: '#/components/schemas/AWSUploadStatus'
+            - $ref: '#/components/schemas/GCPUploadStatus'
+            - $ref: '#/components/schemas/AzureUploadStatus'
     AWSUploadStatus:
       type: object
+      required:
+        - ami
+        - region
       properties:
-        ami_id:
+        ami:
           type: string
           example: 'ami-0c830793775595d4b'
+        region:
+          type: string
+          example: 'eu-west-1'
     GCPUploadStatus:
       type: object
+      required:
+        - project_id
+        - image_name
       properties:
         project_id:
           type: string
           example: 'ascendant-braid-303513'
+        image_name:
+          type: string
+          example: 'my-image'
+    AzureUploadStatus:
+      type: object
+      required:
+        - image_name
+      properties:
         image_name:
           type: string
           example: 'my-image'

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -20,6 +20,12 @@ type AWSUploadRequestOptions struct {
 	ShareWithAccounts []string `json:"share_with_accounts"`
 }
 
+// AWSUploadStatus defines model for AWSUploadStatus.
+type AWSUploadStatus struct {
+	Ami    string `json:"ami"`
+	Region string `json:"region"`
+}
+
 // ArchitectureItem defines model for ArchitectureItem.
 type ArchitectureItem struct {
 	Arch       string   `json:"arch"`
@@ -42,6 +48,11 @@ type AzureUploadRequestOptions struct {
 	// to find it in the Azure Portal:
 	// https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant
 	TenantId string `json:"tenant_id"`
+}
+
+// AzureUploadStatus defines model for AzureUploadStatus.
+type AzureUploadStatus struct {
+	ImageName string `json:"image_name"`
 }
 
 // ComposeRequest defines model for ComposeRequest.
@@ -92,6 +103,12 @@ type GCPUploadRequestOptions struct {
 	//     If not specified, the imported Compute Node image is not shared with any
 	//     account.
 	ShareWithAccounts []string `json:"share_with_accounts"`
+}
+
+// GCPUploadStatus defines model for GCPUploadStatus.
+type GCPUploadStatus struct {
+	ImageName string `json:"image_name"`
+	ProjectId string `json:"project_id"`
 }
 
 // HTTPError defines model for HTTPError.
@@ -159,8 +176,9 @@ type UploadRequest struct {
 
 // UploadStatus defines model for UploadStatus.
 type UploadStatus struct {
-	Status string      `json:"status"`
-	Type   UploadTypes `json:"type"`
+	Options interface{} `json:"options"`
+	Status  string      `json:"status"`
+	Type    UploadTypes `json:"type"`
 }
 
 // UploadTypes defines model for UploadTypes.
@@ -388,45 +406,47 @@ func RegisterHandlers(router EchoRouter, si ServerInterface) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xae28buRH/KsS2QO6AfUiy4zgCDj035+ZcBEkQu+kfsWFQy5GWl11yQ3Lt+Ax994KP",
-	"fXMl+ZIA/SuyOJz5zYPzUh6DlBclZ8CUDJaPgUwzKLD5ePbfy/+UOcfkA3ypQKp3paKcmaNS8BKEomDv",
-	"ZFjA7T1V2S1OU145VvAVF2UOwfJTMF8cHT8/eXH6cjZfBDdhQBUUhkY9lBAsA6kEZZtgG9ZfYCHwQ7Dd",
-	"hoGALxUVQDQbn6Cb5g5f/QGp0kzORJpRBamqBFwoKMaQsUizHsbg6+nJ7clxEI4h0QJv4FZ/ba422Nu7",
-	"X1J+v/Bd3amNwdBnv0+ZPoC/C1gHy+BvSevCxPkvGZlghCYMzv6sBBzmYgGSVyKF243gVam/ISBTQQ19",
-	"sAze4gIQXyOVAappkaFF9xkIMAdGUyQzXuUErQBVRjSQ+JoFYcecV7xKMfvg2Lw2Ej3GldWqgXBLyRjU",
-	"xW8aUpfsL4A5hufkdLVII7xaHEfHx/Oj6OUsfR6dzBdHsxM4nb0Ev+uBYaZ24NIgLNEhqNBVRiXKKfuM",
-	"4GuZY8okyvj9NVMcrSkjiCpEmeFh3Irec6FwvrxmmVKlXCYJ4amMC5oKLvlaxSkvEmBRJROs6ROcKnoH",
-	"EaECUsXFQ7KuGMEFMIVzOTqNMn4fKR5p0ZHVYmC35+kLWD9fnUTz9GgdHRM8i/DJYhHNVrOT2eLoJXlB",
-	"XoztNngirRHH7g6HQel7PK/0y5Dgwnsc12klFS/on7iJ+12P6lWfehsGhGrkq8p6tpsTRAZ5dDqdT4SF",
-	"dPiLvtDXakX25ZYerpHInZaSJWcSxqaykbzbX5QENy2vS4VV5UkmFo1sTvdq7RiNpHX5GLkjb/YFlzj9",
-	"jDcwrE4ll2ojQH7Jn1Kb+hG5T4/LLu1263HAbx2X+YtWL4t0Y+0DEPQ7VuicKRCloBLQG8qqr+inD7+f",
-	"v/kZncbeFMVwAYcF7cDw5mLYw3OzR6PD43xkB4/lX796/02tST8fv6FS6Yx8h3NK0GvONzmgmhwpjgwX",
-	"l59LLhQQpEO8UoDeclJnbS0lvmbnOM2QNRwqKqlQypnClCGMZAkpXVMQdf53QpDWL0Yfjfw1FwVWEmEB",
-	"y2uGUISeVRLE8hEKTHNKts+W6Iwh8xfChAiQEqkMKySgFCC1MVtZqWaBBkrF6F9cIOf2ED3DOU3hV/e3",
-	"rgzPYidZgrijKZzZe0/EYEU7FlOyi4eIqwxEhMvyV1yWsuQq3rhL9Z0uJJPsn2oNp7+5G1tcAxOQgjLp",
-	"tQHhBaZs+Wj/1QKvMkCv0WVFFSD7LfqpFLTA4uHnsfA8twK1w7UnpfU+Vu7u0CIbg9VAQFygZyNMCF2s",
-	"EeOqiScS7g1OKu0NHcnEhCrC7MFyq63cr+CfAhN2o9jQpbgfFYe6MAgD67yxsXU2sWbufvnjJ4Xfr67e",
-	"nwvBhS/bKkxzv2iqcthfDS1ZWHO66crTOWcsE/TR4amyRb/PHo6xhtDrI7yDUT03eHVvxxXvsW1Yn97d",
-	"9NL5QaNTg7KHaYyg0XmqHWkbEWBVYaKnSlOQMgiDNaa5lVECI1rHMFhVNHcfrSz7WcCGSgXGEDfdTrjl",
-	"NmWtw1oha6KJXqjTBb23Xc5Y0breeyapQucu79kdCOkajoOagppXe7ODSU63lwQrfHC01Cp6WgM9Inmc",
-	"vKbChnvrlwSXNDGhExmXgkju5kndI/4jpwVVv8xn19Vstjjh67UE9Yv7q9tex3Ec+3yb4+8hcH6wxIE7",
-	"rMIOhi/1FWANPhiIdK7sOJsyBRsQI/aWbsx3QGaE1E4JrZN9YD6Afkb6lXhWD52j3Tq3pD4Zl4N2fZD4",
-	"9IRrBofoMzz0HVc8RBJSAcochYFt0YJlUGIp77kgPv+vsISoEnmflZ7Gl0mSEhYLIBm2g3iXp77imxqZ",
-	"pJtssFlTooKGdsV5DphpYi42mLk5qHdhMTueHS2Ow5F7bVEHMUbcnXJikcmiA3xvFPaAhEMj94R2LNbR",
-	"1ufIfq0YeZK3wwBn8G4dLD/t2ZVNLDq34e57U1PIvnvTe7ftTZPRDqkFV2ZpOGo7bB2szTBtwe9VEEXF",
-	"mKt6E13aX1fGYXGMbhrsV/U6toaI7zXVJi11mGkDe+F8bKtZX+eDy1xb1bbmVa75eKC8dCOPGwVy/CBd",
-	"G27yPmp6E50ZU3D10Jbn4KzEaQZoEc90g6FfY1Cv8O7v72NsjmMuNom7K5M3F6/O316eR4t4FmeqyDs9",
-	"qm196npTD2Od6rwM5vHM5IwSGC5psAyO4lk81x7GKjPGSbr9lkweu8Voqwk2oOzLA2Fe9wUJlsFrUP3d",
-	"teYocAEKdI/7aWi1Llc9BaP7jKaZnr9zzj+jqkT4DtMcr/QgO2BMmcnGKgvqtcZwBdb60CZNG3w+f9+Y",
-	"zaJpU4z2i9nMVkamwNZGXJY5TY2myR/SRk3L79C1vA72bTgwAka520ZMKIswI3raowJhKXlKsZ74bHSp",
-	"5gk1HZ12jV01TDDp3OyI1ObHaEPvgKGeITVzq5hr4rhNwX0tHIFlbnJRNzDcevDCHbrX8E9OHr6bnQd7",
-	"X4+h7VBmZnFnAo5WgBxyMoqY7Sgq5t8frWuOPXBri2ZYIqmwHvP1oz3+jrHZn009GHQY1Tic0xCVqMC5",
-	"bl40oF7k9YOgGzgyeXSfLkg3f/TF2dRvngJzPqoDLxynmv7OeU+quSCabQ3QCVIcaRzeZNLA/b/JJH19",
-	"d0SMbAfGflbYYV/jLDJc305l+f6e9wfq3Bd0YPYkg0ve5LiDOnGFMa6xTpnhnaX7t3T1ZmyEPlgBqhJM",
-	"IpVRiQhPq0IbyA/QYUAaQ7ParbtqhTeyGbZuDObuLx1TeOuZ/El1uVONaxm6WNSv5ksFZvb/1hocDkF0",
-	"y9cTQQyWRd8AohFWA5gWKsH9vP8N4gr8FeHC/EDA142mISKwxlWu0Hw2m5BuVgmBR1hnnJ9UrtSZwK4f",
-	"WllTkizdblE/Mg2OFks7s0LzLLaGLBGAbdMx9UbavcQP1KEV4gEvOofdzGCzh/sPF12SpDPKeOtqnVPq",
-	"H2Zqek9R/dgc/TDlaxFevw0h+pPjmGq7/V8AAAD//1yW9J7YJAAA",
+	"H4sIAAAAAAAC/8xaeW8bNxb/KsTsAmmBuST5ioBim029qRdBG8Te7h+xYVDDJw2bGXJCcqy4hr77gseM",
+	"5qAO5wD2r8ji43u/d/BdylOQ8bLiDJiSwfwpkFkOJTYfX/33+j9VwTF5D59qkOr3SlHOzFEleAVCUbB3",
+	"cizgfk1Vfo+zjNeOFXzGZVVAMP8QTKazk9Oz84uX6WQa3IUBVVAaGvVYQTAPpBKUrYJN2HyBhcCPwWYT",
+	"BgI+1VQA0Wx8gu7aO3zxJ2RKM2mRXyusag9iXNIeQv1FlGYXs/T85ez8/PT05Sk5WQThGJ+AFeWsfxnq",
+	"aA1SRZPxhYECWm7Lw4tcZDlVkKlawJWC0gNdZHlf/OeLs/uzEx9YWuIV3OuvzdXW6tu7nzK+nvqu7vWD",
+	"wdBnf0iZPoC/C1gG8+BvyTb4Ehd5ycgEIzRh8OqvWsBxwSlA8lpkcL8SvK70NwRkJqihD+bBb7gExJdI",
+	"5YAaWmRo0ToHAebAaIpkzuuCoAWg2ogGEt+yIOyY84bXGWbvHZs3RqLHuLJetBDuKRmDuvpFQ+qSfQGY",
+	"EzglF4tpFuHF9CQ6OZnMopdpdhqdTaaz9Awu0pfgdz0wzNQeXBqEJToGFbrJqUQFZR8RfK4KTJlEOV/f",
+	"MsXRkjKCqEKUGR7GregdFwoX81uWK1XJeZIQnsm4pJngki9VnPEyARbVMsGaPsGZog8QESogU1w8Jsua",
+	"EVwCU7iQo9Mo5+tI8UiLjqwWA7udZuewPF2cRZNstoxOCE4jfDadRukiPUuns5fknJwffOlbI47dHQ6D",
+	"0vt4tiG+K4vZ98dwCf1HXT5G5uggyA4DH4TX+nFKcC9sLD+rpeIl/Qu3T2/fu37dp96EAaEa16JWo4wq",
+	"ciiii90pTVhIxyeVK32tUeRQeuvhGoncaylZcSbB4yriqXZDb5Dgbstrv9Nle3pQa8fI73vHx8gdebMv",
+	"uMLZR7yCYWmvuFQrAfJT8ZzC3n8Uh/S47tJuNh4H/NJxmb9u9hJZN9beA0G/YoUumQJRCSoBvaWs/ox+",
+	"eP/r5dsf0UXszZLjZ7craAeGNxfDHp67AxodH+cjO3gs/+b1u6/q6/ol4S2VSheFB1xQgt5wvioANeRI",
+	"cWS4uBJRcaGAIB3itQL0GydN4dBS4lt2ibMcWcOhspYKZZwpTBnCSFaQ0SUF0ZQgJwRp/WL0h5G/5KLE",
+	"SiIsYH7LEIrQi1qCmD9BiWlByebFHL1iyPyFMCECpEQqxwoJqARIbcytrEyzQAOlYvQvLpBze4he4IJm",
+	"8LP7WxenF7GTLEE80Axe2XvPxGBFOxa7ZJePEVc5iAhX1c+4qmTFVbxyl5o7XUim3jzXGk5/cze2uAYm",
+	"ICVl0msDwktM2fzJ/qsF3uSA3qDrmipA9lv0QyVoicXjj2PhRWEFaodrT0rrfazc3aFFVgargYC4QC9G",
+	"mBC6WiLGVRtPJDwYnFTaGzqSiQlVhNmj5dZYud9EfAhM2I1iQ3cD/ag41oVBGFjnjY2ts4k1c/fL7z9m",
+	"tYnk2zUooeag+bv2szOhyQwYwUxFC4EpiWbp7HQyO5htO+zCQ/3Orzc37y6F4MJXPRSmhd+UVBVwuLpb",
+	"srDhdNeVp3PoWCboo+NT/xb9If86xhpCry/yzprNKObVfTsBeo/tDPD8bq1Xno6aRluUPUxjBK3Ou0J2",
+	"21gBq0vzGuosAymDMFhiWlgZFTCidQyDRU0L99HKsp/1iC8VGEPcdYeLLbdd1jqutes9vNED3nZ172zX",
+	"Nla0eZWe4bTUudh79gBCugbqqCan4bW92cEkd7fLBCt8dLQ0KnpaHT11epy8pMKG+9YvCa5oYkInMi4F",
+	"kTxMkqbn/UdBS6p+mqS3dZpOz/hyKUH95P7qjgtxHMc+3xb4WwicHC1x4A6rsIPhS30lWIMPBjyd+zvO",
+	"pkzBCsSIvaUb8x2QGSGNU0LrZB+Y96CfkX4lnm1O52i/zltSn4zrwfgxSHyZog9mEIo+wuOoeEnIBChz",
+	"FAa25QzmQYWlXHNBfP5fYAlRLYo+q1ypap4kGWGxAJJju9vo8tRXfFMwk3SVD9asStTQ0i44LwAzTczF",
+	"CjM31/UuTNOTdDY9CUfutU0KiDHi7tQWi1yWHeAHo7AHJBwauSe0Y7GOtj5H9mvFyJN8O9xwBr8vg/mH",
+	"A+vHHVvvTbj/3q6p6tC93avMzV2b0Y6pBTdmDztqO2wdbMyw24K7CuKXG7ApTsca7kj68WLMGOq5hVvU",
+	"jLnqvKM7/nKjOyzhyPqttW+anXwDFq81/Sqr9MPQGnqB/bGtv30vHV2Yt3V4Y/LIko9H+ms3dLphrMCP",
+	"0g1CplKhtpvSuTwDV8FtQxG8qnCWA5rGqW6JdP4Imj3uer2OsTmOuVgl7q5M3l69vvzt+jKaxmmcq7Lo",
+	"dNW2WWsqZDMOd/qJeTCJU5PlKmC4osE8mMVpPNG+xio3xkm6HaJMnrrlc6MJVqBsqIMw+eiKBPPgDaj+",
+	"Dxiao8AlKNBd+Yeh1bpc0ZILtM5pliPFUcH5R1RXCD9gWuBFAQgPGFNm6ofKg2axNFxCbn1o07wNQ5+/",
+	"78x62TRWRvtpmtpazhTYao6rqqCZ0TT5U9qo2fI79rcZHfabcGAEjAq3D9qhLMKM6HmbCoSl5BnFeua2",
+	"0aXax9T2oNo1dtmzg0nnZkekNj9GK/oADPUMqZlbxVzbyW3R6GvhCFAzpPYDwy1or9yhew3/5OTxm9l5",
+	"sHn3GNqOkWYb4kzA0QKQQ05GEbMZRcXk26N17bwHbmPRHEskFRYKiH60J98wNvvTtAeDDqMGh3MaohKV",
+	"uNDtlgbUi7x+EHQDRyZP7tMV6eaPvjhbBMxTYM5HTeCF41TT3/ofSDVXRLNtADpBiiONw5tMWrj/N5mk",
+	"r++eiJHbEbefFfbY1ziLDBfou7J8f9P+HXXuCzoye5LBJW9y3EOduMIYN1h3meF3S/dv6erN2Ah9sAJU",
+	"LZhEKqcSEZ7VpTaQH6DDgDSGdrnezAEKr2Q7Ht4ZzN3fmnbhbbYIz6rLnWrcyNDFonk1n2ow24qvrcHh",
+	"EES3fD0TxGC99RUgWmENgN1CJbj/4/EV4kr8GeHS/ETDl62mISKwxHWh0CRNd0g3y4/AI6yzgNipXKUz",
+	"gV2YbGXtkmTp9ov6nmlwtArbmxXaZ7ExZIkAbJuOXW9ku0n5jjpshXjAi85hNzPY7OH+102XJOmMMt66",
+	"2uSU5qexht5TVP9oj76b8o0Ir9+GEP3JcUy12fwvAAD//wBuUSGXJwAA",
 }
 
 // GetSwagger returns the Swagger specification corresponding to the generated code

--- a/internal/server/api.yaml
+++ b/internal/server/api.yaml
@@ -239,21 +239,50 @@ components:
       required:
         - status
         - type
+        - options
       properties:
         status:
           type: string
           enum: ['success', 'failure', 'pending', 'running']
         type:
           $ref: '#/components/schemas/UploadTypes'
-    UploadTypes:
-      type: string
-      enum: ['aws', 'gcp', 'azure']
+        options:
+          oneOf:
+            - $ref: '#/components/schemas/AWSUploadStatus'
+            - $ref: '#/components/schemas/GCPUploadStatus'
+            - $ref: '#/components/schemas/AzureUploadStatus'
     AWSUploadStatus:
       type: object
+      required:
+        - ami
+        - region
       properties:
-        ami_id:
+        ami:
           type: string
           example: 'ami-0c830793775595d4b'
+        region:
+          type: string
+          example: 'eu-west-1'
+    GCPUploadStatus:
+      type: object
+      required:
+        - project_id
+        - image_name
+      properties:
+        project_id:
+          type: string
+          example: 'ascendant-braid-303513'
+        image_name:
+          type: string
+          example: 'my-image'
+    AzureUploadStatus:
+      type: object
+      required:
+        - image_name
+      properties:
+        image_name:
+          type: string
+          example: 'my-image'
     ComposeRequest:
       type: object
       required:
@@ -302,6 +331,9 @@ components:
             - $ref: '#/components/schemas/AWSUploadRequestOptions'
             - $ref: '#/components/schemas/GCPUploadRequestOptions'
             - $ref: '#/components/schemas/AzureUploadRequestOptions'
+    UploadTypes:
+      type: string
+      enum: ['aws', 'gcp', 'azure']
     AWSUploadRequestOptions:
       type: object
       required:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -188,8 +188,9 @@ func (h *Handlers) GetComposeStatus(ctx echo.Context, composeId string) error {
 
 	if cloudStat.ImageStatus.UploadStatus != nil {
 		status.ImageStatus.UploadStatus = &UploadStatus{
-			Status: cloudStat.ImageStatus.UploadStatus.Status,
-			Type:   UploadTypes(cloudStat.ImageStatus.UploadStatus.Type),
+			Status:  cloudStat.ImageStatus.UploadStatus.Status,
+			Type:    UploadTypes(cloudStat.ImageStatus.UploadStatus.Type),
+			Options: cloudStat.ImageStatus.UploadStatus.Options,
 		}
 	}
 

--- a/schutzbot/Jenkinsfile
+++ b/schutzbot/Jenkinsfile
@@ -27,21 +27,58 @@ pipeline {
             }
         }
 
-        stage("Test ✅") {
+        stage("Test EL8 ✅") {
             parallel {
-                stage('F33') {
-                    agent { label "f33cloudbase && x86_64 && aws" }
-                    steps {
-                        run_project_tests('image-builder', 'api.sh')
-                    }
-                }
-                stage('EL8') {
+                stage('AWS') {
                     agent { label "rhel8cloudbase && x86_64 && aws" }
+
                     environment {
                         RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
+
+                        AWS_REGION = "us-east-2"
+                        AWS_BUCKET = "imagebuilder-jenkins-testing-use2"
+                        AWS_CREDS = credentials('aws-credentials-osbuildci')
+                        AWS_API_TEST_SHARE_ACCOUNT = credentials('aws-credentials-share-account')
                     }
+
                     steps {
-                        run_project_tests('image-builder', 'api.sh')
+                        run_project_tests('image-builder', 'api.sh', 'aws')
+                    }
+                }
+
+                stage('GCP') {
+                    agent { label "rhel8cloudbase && x86_64 && aws" }
+
+                    environment {
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
+
+                        GCP_BUCKET = "image-builder-testing"
+                        GCP_REGION = "us-east4"
+                        GOOGLE_APPLICATION_CREDENTIALS = credentials('gcp-credentials-osbuildci')
+                        GCP_API_TEST_SHARE_ACCOUNT = credentials('gcp-credentials-share-account')
+                    }
+
+                    steps {
+                        run_project_tests('image-builder', 'api.sh', 'gcp')
+                    }
+                }
+
+                stage('Azure') {
+                    agent { label "rhel8cloudbase && x86_64 && aws" }
+
+                    environment {
+                        RHN_REGISTRATION_SCRIPT = credentials('rhn-register-script-production')
+
+                        AZURE_TENANT_ID = "1710d22c-ccf0-4421-8ba7-0135cfaecb90"
+                        AZURE_SUBSCRIPTION_ID = "8d026bb1-2a65-454d-a88f-c896db94c4f8"
+                        AZURE_RESOURCE_GROUP = "sharing-research"
+                        AZURE_LOCATION = "eastus"
+                        AZURE_CLIENT_ID = credentials('azure-client-id')
+                        AZURE_CLIENT_SECRET = credentials('azure-client-secret')
+                    }
+
+                    steps {
+                        run_project_tests('image-builder', 'api.sh', 'azure')
                     }
                 }
             }
@@ -51,9 +88,9 @@ pipeline {
 
 // Similar to run_tests, but with a more general signature: allows setting the
 // project whose -tests package to install, and the name of the test to execute
-void run_project_tests(project, test) {
+void run_project_tests(project, test, provider) {
     sh "schutzbot/ci_details.sh"
     sh "schutzbot/build.sh"
     sh "schutzbot/deploy.sh"
-    sh "/usr/libexec/tests/${project}/${test}"
+    sh "/usr/libexec/tests/${project}/${test} ${provider}"
 }

--- a/test/README.md
+++ b/test/README.md
@@ -13,7 +13,9 @@ go test -v ./...
 ## Integration test
 
 It's recommended to run these inside of a vm as the scripts make extensive
-changes to the host.
+changes to the host. Running integration test requires specific environment
+variables to be set on the system. The specific list for each supported cloud
+provider can be found in the following sub-sections.
 
 1. Build the docker image:
 
@@ -25,7 +27,50 @@ distribution/Dockerfile-ubi .`
 Call `schutzbot/deploy.sh`. This will install composer, generate certificates,
 and start the image-builder container.
 
-3. Call `test/cases/api.sh` to run the integration tests
+3. Call `test/cases/api.sh <cloud_provider>` to run the integration tests for
+a specific cloud provider. Valid values for `<cloud_provider>` are `aws`,
+`azure` and `gcp`.
+
+### Setting up AWS integration test
+
+The following environment variables are required
+
+- `AWS_REGION`
+- `AWS_BUCKET`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_API_TEST_SHARE_ACCOUNT`
+
+To execute the AWS integration test, complete steps 1-2 from the *Integration test*
+section and run `test/cases/api.sh aws`.
+
+### Setting up Azure integration test
+
+The following environment variables are required
+
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+- `AZURE_RESOURCE_GROUP`
+- `AZURE_LOCATION`
+- `AZURE_CLIENT_ID`
+- `AZURE_CLIENT_SECRET`
+
+To execute the AWS integration test, complete steps 1-2 from the *Integration test*
+section and run `test/cases/api.sh azure`.
+
+#### Setting up GCP integration test
+
+The following environment variables are required:
+
+- `GOOGLE_APPLICATION_CREDENTIALS` - path to [Google authentication credentials][gcp_creds] file.
+- `GCP_REGION`
+- `GCP_BUCKET`
+- `GCP_API_TEST_SHARE_ACCOUNT`
+
+To execute the AWS integration test, complete steps 1-2 from the *Integration test*
+section and run `test/cases/api.sh gcp`.
+
+[gcp_creds]: https://cloud.google.com/docs/authentication/getting-started#setting_the_environment_variable
 
 ## Code coverage
 

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -12,9 +12,77 @@
 
 set -euxo pipefail
 
+############### Cleanup functions ################
+
+function cleanupAWS() {
+  # since this function can be called at any time, ensure that we don't expand unbound variables
+  AWS_CMD="${AWS_CMD:-}"
+  AWS_INSTANCE_ID="${AWS_INSTANCE_ID:-}"
+  AMI_IMAGE_ID="${AMI_IMAGE_ID:-}"
+  AWS_SNAPSHOT_ID="${AWS_SNAPSHOT_ID:-}"
+
+  if [ -n "$AWS_CMD" ]; then
+    set +e
+    $AWS_CMD ec2 terminate-instances --instance-ids "$AWS_INSTANCE_ID"
+    $AWS_CMD ec2 deregister-image --image-id "$AMI_IMAGE_ID"
+    $AWS_CMD ec2 delete-snapshot --snapshot-id "$AWS_SNAPSHOT_ID"
+    $AWS_CMD ec2 delete-key-pair --key-name "key-for-$AMI_IMAGE_ID"
+    set -e
+  fi
+}
+
+function cleanupGCP() {
+  # since this function can be called at any time, ensure that we don't expand unbound variables
+  GCP_CMD="${GCP_CMD:-}"
+  GCP_IMAGE_NAME="${GCP_IMAGE_NAME:-}"
+  GCP_INSTANCE_NAME="${GCP_INSTANCE_NAME:-}"
+
+  if [ -n "$GCP_CMD" ]; then
+    set +e
+    $GCP_CMD compute instances delete --zone="$GCP_REGION-a" "$GCP_INSTANCE_NAME"
+    $GCP_CMD compute images delete "$GCP_IMAGE_NAME"
+    set -e
+  fi
+}
+
+function cleanupAzure() {
+  # since this function can be called at any time, ensure that we don't expand unbound variables
+  AZURE_CMD="${AZURE_CMD:-}"
+  AZURE_IMAGE_NAME="${AZURE_IMAGE_NAME:-}"
+
+  # do not run clean-up if the image name is not yet defined
+  if [[ -n "$AZURE_CMD" && -n "$AZURE_IMAGE_NAME" ]]; then
+    set +e
+    $AZURE_CMD image delete --resource-group sharing-research --name "$AZURE_IMAGE_NAME"
+
+    # find a storage account by its tag
+    AZURE_STORAGE_ACCOUNT=$($AZURE_CMD resource list --tag imageBuilderStorageAccount=location="$AZURE_LOCATION" | jq -r .[0].name)
+    $AZURE_CMD storage blob delete --container-name imagebuilder --name "$AZURE_IMAGE_NAME".vhd --account-name "$AZURE_STORAGE_ACCOUNT"
+    set -e
+  fi
+}
+
 # Create a temporary directory and ensure it gets deleted when this script
 # terminates in any way.
 WORKDIR=$(mktemp -d)
+function cleanup() {
+  case $CLOUD_PROVIDER in
+    "$CLOUD_PROVIDER_AWS")
+      cleanupAWS
+      ;;
+    "$CLOUD_PROVIDER_GCP")
+      cleanupGCP
+      ;;
+    "$CLOUD_PROVIDER_AZURE")
+      cleanupAzure
+      ;;
+  esac
+
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+############### Common functions and variables ################
 
 # org_id 000000 (valid org_id)
 ValidAuthString="eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAwIn19fQ=="
@@ -52,9 +120,7 @@ done
 case $(set +x; . /etc/os-release; echo "$ID-$VERSION_ID") in
   "rhel-8.2" | "rhel-8.3" | "rhel-8.4")
     DISTRO="rhel-8"
-  ;;
-  "fedora-33")
-    DISTRO="fedora-33"
+    SSH_USER="cloud-user"
   ;;
 esac
 
@@ -67,6 +133,40 @@ function getResponse() {
 function getExitCode() {
   read -r -d '' -a arr <<<"$1"
   echo "${arr[-1]}"
+}
+
+function instanceWaitSSH() {
+  local HOST="$1"
+
+  for LOOP_COUNTER in {0..30}; do
+      if ssh-keyscan "$HOST" > /dev/null 2>&1; then
+          echo "SSH is up!"
+          break
+      fi
+      echo "Retrying in 5 seconds... $LOOP_COUNTER"
+      sleep 5
+  done
+}
+
+############### AWS-specific functions ################
+
+function checkEnvAWS() {
+  printenv AWS_REGION AWS_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_API_TEST_SHARE_ACCOUNT > /dev/null
+}
+
+function installClientAWS() {
+  if ! hash aws; then
+    mkdir "$WORKDIR/aws"
+    pushd "$WORKDIR/aws"
+      curl -Ls --retry 5 --output awscliv2.zip \
+        https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+      unzip awscliv2.zip > /dev/null
+      sudo ./aws/install > /dev/null
+      aws --version
+    popd
+  fi
+
+  AWS_CMD="aws --region $AWS_REGION --output json --color on"
 }
 
 function createReqFileAWS() {
@@ -96,6 +196,113 @@ function createReqFileAWS() {
 EOF
 }
 
+############### GCP-specific functions ################
+
+function checkEnvGCP() {
+  printenv GOOGLE_APPLICATION_CREDENTIALS GCP_BUCKET GCP_REGION GCP_API_TEST_SHARE_ACCOUNT > /dev/null
+}
+
+function installClientGCP() {
+  if ! hash gcloud; then
+    sudo tee -a /etc/yum.repos.d/google-cloud-sdk.repo << EOM
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+  fi
+
+  sudo dnf -y install google-cloud-sdk
+  GCP_CMD="gcloud --format=json --quiet"
+  $GCP_CMD --version
+}
+
+function createReqFileGCP() {
+  cat > "$REQUEST_FILE" << EOF
+{
+  "distribution": "$DISTRO",
+  "image_requests": [
+    {
+      "architecture": "$ARCH",
+      "image_type": "vhd",
+      "upload_requests": [
+        {
+          "type": "gcp",
+          "options": {
+            "share_with_accounts": ["${GCP_API_TEST_SHARE_ACCOUNT}"]
+          }
+        }
+      ]
+    }
+  ],
+  "customizations": {
+    "packages": [
+      "postgresql"
+    ]
+  }
+}
+EOF
+}
+
+############### Azure-specific functions ################
+
+function checkEnvAzure() {
+  printenv AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_LOCATION AZURE_CLIENT_ID AZURE_CLIENT_SECRET > /dev/null
+}
+
+function installClientAzure() {
+  if ! hash az; then
+    # this installation method is taken from the official docs:
+    # https://docs.microsoft.com/cs-cz/cli/azure/install-azure-cli-linux?pivots=dnf
+    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+    echo -e "[azure-cli]
+name=Azure CLI
+baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc" | sudo tee /etc/yum.repos.d/azure-cli.repo
+  fi
+
+  sudo dnf install -y azure-cli
+  AZURE_CMD="az"
+  $AZURE_CMD version
+}
+
+function createReqFileAzure() {
+  cat > "$REQUEST_FILE" << EOF
+{
+  "distribution": "$DISTRO",
+  "image_requests": [
+    {
+      "architecture": "$ARCH",
+      "image_type": "vhd",
+      "upload_requests": [
+        {
+          "type": "azure",
+          "options": {
+            "tenant_id": "${AZURE_TENANT_ID}",
+            "subscription_id": "${AZURE_SUBSCRIPTION_ID}",
+            "resource_group": "${AZURE_RESOURCE_GROUP}"
+          }
+        }
+      ]
+    }
+  ],
+  "customizations": {
+    "packages": [
+      "postgresql"
+    ]
+  }
+}
+EOF
+}
+
+############### Test cases definitions ################
+
 ### Case: get version
 function Test_getVersion() {
   url="$1"
@@ -114,15 +321,196 @@ function Test_getOpenapi() {
   [[ $exit_code == 200 ]]
 }
 
-
 ### Case: post to composer
 function Test_postToComposer() {
-  url="$1"
-  result=$($CurlCmd -H "$Header" -H 'Content-Type: application/json' --request POST --data @"$REQUEST_FILE" "$url/compose")
+  result=$($CurlCmd -H "$Header" -H 'Content-Type: application/json' --request POST --data @"$REQUEST_FILE" "$BaseUrl/compose")
   exit_code=$(getExitCode "$result")
   [[ $exit_code == 201 ]]
   COMPOSE_ID=$(getResponse "$result" | jq -r '.id')
   [[ "$COMPOSE_ID" =~ ^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{12}\}?$ ]]
+}
+
+### Case: wait for the compose to finish successfully
+function Test_waitForCompose() {
+  while true
+  do
+    result=$($CurlCmd -H "$Header" --request GET "$BaseUrl/composes/$COMPOSE_ID")
+    exit_code=$(getExitCode "$result")
+    [[ $exit_code == 200 ]]
+
+    COMPOSE_STATUS=$(getResponse "$result" | jq -r '.image_status.status')
+    UPLOAD_STATUS=$(getResponse "$result" | jq -r '.image_status.upload_status.status')
+
+    if [[ "$COMPOSE_STATUS" != "pending" && "$COMPOSE_STATUS" != "running" ]]; then
+      [[ "$COMPOSE_STATUS" = "success" ]]
+      [[ "$UPLOAD_STATUS" = "success" ]]
+      break
+    fi
+
+    sleep 30
+  done
+}
+
+### Case: verify the result (image) of a finished compose in AWS
+function Test_verifyComposeResultAWS() {
+  UPLOAD_OPTIONS="$1"
+
+  AMI_IMAGE_ID=$(echo "$UPLOAD_OPTIONS" | jq -r '.ami')
+  # AWS ID consist of resource identifier followed by a 17-character string
+  [[ "$AMI_IMAGE_ID" =~ ami-[[:alnum:]]{17} ]]
+
+  local REGION
+  REGION=$(echo "$UPLOAD_OPTIONS" | jq -r '.region')
+  [[ "$REGION" = "$AWS_REGION" ]]
+
+  # Try to boot the result image with the cloud provider
+  $AWS_CMD ec2 describe-images --image-ids "$AMI_IMAGE_ID" > "$WORKDIR/ami.json"
+
+  AWS_SNAPSHOT_ID=$(jq -r '.Images[].BlockDeviceMappings[].Ebs.SnapshotId' "$WORKDIR/ami.json")
+  SHARE_OK=1
+
+  # Verify that the ec2 snapshot was shared
+  $AWS_CMD ec2 describe-snapshot-attribute --snapshot-id "$AWS_SNAPSHOT_ID" --attribute createVolumePermission > "$WORKDIR/snapshot-attributes.json"
+
+  SHARED_ID=$(jq -r '.CreateVolumePermissions[0].UserId' "$WORKDIR/snapshot-attributes.json")
+  if [ "$AWS_API_TEST_SHARE_ACCOUNT" != "$SHARED_ID" ]; then
+    SHARE_OK=0
+  fi
+
+  # Verify that the ec2 ami was shared
+  $AWS_CMD ec2 describe-image-attribute --image-id "$AMI_IMAGE_ID" --attribute launchPermission > "$WORKDIR/ami-attributes.json"
+
+  SHARED_ID=$(jq -r '.LaunchPermissions[0].UserId' "$WORKDIR/ami-attributes.json")
+  if [ "$AWS_API_TEST_SHARE_ACCOUNT" != "$SHARED_ID" ]; then
+    SHARE_OK=0
+  fi
+
+  if [ "$SHARE_OK" != 1 ]; then
+    echo "EC2 snapshot wasn't shared with the AWS_API_TEST_SHARE_ACCOUNT. 😢"
+    exit 1
+  fi
+
+  # Create key-pair
+  $AWS_CMD ec2 create-key-pair --key-name "key-for-$AMI_IMAGE_ID" --query 'KeyMaterial' --output text > keypair.pem
+  chmod 400 ./keypair.pem
+
+  # Create an instance based on the ami
+  $AWS_CMD ec2 run-instances --image-id "$AMI_IMAGE_ID" --count 1 --instance-type t2.micro --key-name "key-for-$AMI_IMAGE_ID" > "$WORKDIR/instances.json"
+  AWS_INSTANCE_ID=$(jq -r '.Instances[].InstanceId' "$WORKDIR/instances.json")
+
+  $AWS_CMD ec2 wait instance-running --instance-ids "$AWS_INSTANCE_ID"
+
+  $AWS_CMD ec2 describe-instances --instance-ids "$AWS_INSTANCE_ID" > "$WORKDIR/instances.json"
+  HOST=$(jq -r '.Reservations[].Instances[].PublicIpAddress' "$WORKDIR/instances.json")
+
+  echo "⏱ Waiting for AWS instance to respond to ssh"
+  instanceWaitSSH "$HOST"
+
+  # Check if postgres is installed
+  ssh -oStrictHostKeyChecking=no -i ./keypair.pem "$SSH_USER"@"$HOST" rpm -q postgresql
+}
+
+### Case: verify the result (image) of a finished compose in GCP
+function Test_verifyComposeResultGCP() {
+  UPLOAD_OPTIONS="$1"
+
+  GCP_PROJECT=$(jq -r '.project_id' "$GOOGLE_APPLICATION_CREDENTIALS")
+
+  GCP_IMAGE_NAME=$(echo "$UPLOAD_OPTIONS" | jq -r '.image_name')
+  [[ -n "$GCP_IMAGE_NAME" ]]
+
+  local PROJECT_ID
+  PROJECT_ID=$(echo "$UPLOAD_OPTIONS" | jq -r '.project_id')
+  [[ "$PROJECT_ID" = "$GCP_PROJECT" ]]
+
+  # Authenticate
+  $GCP_CMD auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+  # Set the default project to be used for commands
+  $GCP_CMD config set project "$GCP_PROJECT"
+
+  # Verify that the image was shared
+  SHARE_OK=1
+  $GCP_CMD compute images get-iam-policy "$GCP_IMAGE_NAME" > "$WORKDIR/image-iam-policy.json"
+  SHARED_ACCOUNT=$(jq -r '.bindings[0].members[0]' "$WORKDIR/image-iam-policy.json")
+  SHARED_ROLE=$(jq -r '.bindings[0].role' "$WORKDIR/image-iam-policy.json")
+  if [ "$SHARED_ACCOUNT" != "$GCP_API_TEST_SHARE_ACCOUNT" ] || [ "$SHARED_ROLE" != "roles/compute.imageUser" ]; then
+    SHARE_OK=0
+  fi
+
+  if [ "$SHARE_OK" != 1 ]; then
+    echo "GCP image wasn't shared with the GCP_API_TEST_SHARE_ACCOUNT. 😢"
+    exit 1
+  fi
+
+  # Verify that the image boots and have customizations applied
+  # Create SSH keys to use
+  GCP_SSH_KEY="$WORKDIR/id_google_compute_engine"
+  ssh-keygen -t rsa -f "$GCP_SSH_KEY" -C "$SSH_USER" -N ""
+  GCP_SSH_METADATA_FILE="$WORKDIR/gcp-ssh-keys-metadata"
+
+  echo "${SSH_USER}:$(cat "$GCP_SSH_KEY".pub)" > "$GCP_SSH_METADATA_FILE"
+
+  # create the instance
+  # resource ID can have max 62 characters, the $GCP_TEST_ID_HASH contains 56 characters
+  GCP_INSTANCE_NAME="vm-$(uuidgen)"
+
+  $GCP_CMD compute instances create "$GCP_INSTANCE_NAME" \
+    --zone="$GCP_REGION-a" \
+    --image-project="$GCP_PROJECT" \
+    --image="$GCP_IMAGE_NAME" \
+    --metadata-from-file=ssh-keys="$GCP_SSH_METADATA_FILE"
+  HOST=$($GCP_CMD compute instances describe "$GCP_INSTANCE_NAME" --zone="$GCP_REGION-a" --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
+
+  echo "⏱ Waiting for GCP instance to respond to ssh"
+  instanceWaitSSH "$HOST"
+
+  # Check if postgres is installed
+  ssh -oStrictHostKeyChecking=no -i "$GCP_SSH_KEY" "$SSH_USER"@"$HOST" rpm -q postgresql
+}
+
+### Case: verify the result (image) of a finished compose in Azure
+function Test_verifyComposeResultAzure() {
+  UPLOAD_OPTIONS="$1"
+
+  AZURE_IMAGE_NAME=$(echo "$UPLOAD_OPTIONS" | jq -r '.image_name')
+  [[ -n "$AZURE_IMAGE_NAME" ]]
+
+  set +x
+  $AZURE_CMD login --service-principal --username "${AZURE_CLIENT_ID}" --password "${AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}"
+  set -x
+
+  # verify that the image exists
+  $AZURE_CMD image show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_IMAGE_NAME}"
+
+  # Boot testing is currently blocked due to
+  # https://github.com/Azure/azure-cli/issues/17123
+  # Without this issue fixed or worked around, I'm not able to delete the disk
+  # attached to the VM.
+}
+
+### Case: verify the result (image) of a finished compose
+function Test_verifyComposeResult() {
+  result=$($CurlCmd -H "$Header" --request GET "$BaseUrl/composes/$COMPOSE_ID")
+  exit_code=$(getExitCode "$result")
+  [[ $exit_code == 200 ]]
+
+  UPLOAD_TYPE=$(getResponse "$result" | jq -r '.image_status.upload_status.type')
+  [[ "$UPLOAD_TYPE" = "$CLOUD_PROVIDER" ]]
+
+  UPLOAD_OPTIONS=$(getResponse "$result" | jq -r '.image_status.upload_status.options')
+
+  # verify upload options specific to cloud provider
+  case $CLOUD_PROVIDER in
+    "$CLOUD_PROVIDER_AWS")
+      Test_verifyComposeResultAWS "$UPLOAD_OPTIONS"
+      ;;
+    "$CLOUD_PROVIDER_GCP")
+      Test_verifyComposeResultGCP "$UPLOAD_OPTIONS"
+      ;;
+    "$CLOUD_PROVIDER_AZURE")
+      Test_verifyComposeResultAzure "$UPLOAD_OPTIONS"
+      ;;
+  esac
 }
 
 function Test_getOpenapiWithWrongOrgId() {
@@ -141,35 +529,47 @@ function Test_postToComposerWithWrongOrgId() {
   [[ $msg == "Organization not allowed" ]]
 }
 
-function BasicValidation() {
-  url="$1"
-
-  Test_getVersion "$url"
-  Test_getOpenapi "$url"
-  Test_postToComposer "$url"
-}
-
 #
 # Which cloud provider are we testing?
 #
 
 CLOUD_PROVIDER_AWS="aws"
+CLOUD_PROVIDER_GCP="gcp"
+CLOUD_PROVIDER_AZURE="azure"
 
 CLOUD_PROVIDER=${1:-$CLOUD_PROVIDER_AWS}
 case $CLOUD_PROVIDER in
   "$CLOUD_PROVIDER_AWS")
-    AWS_API_TEST_SHARE_ACCOUNT=${AWS_API_TEST_SHARE_ACCOUNT-012345678912}
+    checkEnvAWS
+    installClientAWS
     createReqFileAWS
-  ;;
+    ;;
+  "$CLOUD_PROVIDER_GCP")
+    checkEnvGCP
+    installClientGCP
+    createReqFileGCP
+    ;;
+  "$CLOUD_PROVIDER_AZURE")
+    checkEnvAzure
+    installClientAzure
+    createReqFileAzure
+    ;;
   *)
-  echo "Not supported platform: ${CLOUD_PROVIDER}"
-  exit 1
-  ;;
+    echo "Not supported platform: ${CLOUD_PROVIDER}"
+    exit 1
+    ;;
 esac
 
 ############### Test begin ################
-BasicValidation "${BaseUrl}"
-BasicValidation "${BaseUrlMajorVersion}"
+Test_getVersion "${BaseUrl}"
+Test_getVersion "${BaseUrlMajorVersion}"
+Test_getOpenapi "${BaseUrl}"
+Test_getOpenapi "${BaseUrlMajorVersion}"
+
+Test_postToComposer
+Test_waitForCompose
+Test_verifyComposeResult
+
 Test_getOpenapiWithWrongOrgId
 Test_postToComposerWithWrongOrgId
 


### PR DESCRIPTION
Update composer cloudapi types related to upload options.

Expose upload options, returned from composer, in the image-builder API.
These contain all the necessary information to identify the uploaded
image in the specific cloud provider environment.

Integration testing:
- Test compose request for all supported cloud providers (AWS, Azure,
  GCP).
- Verify the returned upload options for each cloud provider. Use it
  to verify the resulting image from the compose by creating a VM in the
  respective cloud provider environment and connecting to it via SSH
  (except for Azure, where it is not possible because of a bug).
- Modify the way test cases are executed based on PR#79. Specifically
  that the compose is tested only once for `BaseUrl`.
- Clean up WORKDIR at the end of the test run.
- Update test/README.md section on integration testing.

schutzbot/deploy.sh:
- Create osbuild-worker configuration directory.
- Create osbuild-worker's configuration file with necessary credentials
  for Azure or GCP based on available environment variables.
- Pass necessary configuration environment variables to the
  image-builder container.

schutzbot/Jenkinsfile:
- After previous discussion test image-builder only on RHEL-8 in
  parallel for each supported cloud provider.
- Set necessary environment variables for each cloud-provider
  integration testing.