### PR TITLE
server: return bad request when distribution unsupported

### DIFF
--- a/internal/server/distribution.go
+++ b/internal/server/distribution.go
@@ -3,12 +3,14 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/labstack/echo/v4"
 	"github.com/osbuild/image-builder/internal/cloudapi"
 )
 
@@ -72,7 +74,7 @@ func RepositoriesForImage(distsDir, distro, arch string) ([]cloudapi.Repository,
 	case "x86_64":
 		return distributions[0].ArchX86.Repositories, nil
 	default:
-		return nil, fmt.Errorf("Architecture not supported")
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "Architecture not supported")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -363,8 +363,8 @@ func TestComposeImage(t *testing.T) {
 			},
 		}
 		response, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
-		require.Equal(t, 500, response.StatusCode)
-		require.Contains(t, body, "Internal Server Error")
+		require.Equal(t, 400, response.StatusCode)
+		require.Contains(t, body, "Architecture not supported")
 	})
 
 	t.Run("ErrorsForUnknownUploadType", func(t *testing.T) {


### PR DESCRIPTION
Return 400 Bad Request instead of 500 when the distribution is
not supported.