### PR TITLE
server: Fix pagination of the packages endpoint

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -482,7 +482,7 @@ func (h *Handlers) GetPackages(ctx echo.Context, params GetPackagesParams) error
 		Meta: struct {
 			Count int `json:"count"`
 		}{
-			len(packages[offset:upto]),
+			len(packages),
 		},
 		Links: struct {
 			First string `json:"first"`

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -121,14 +121,14 @@ func TestWithoutOsbuildComposerBackend(t *testing.T) {
 		require.Equal(t, 200, response.StatusCode)
 		err = json.Unmarshal([]byte(body), &result)
 		require.NoError(t, err)
-		require.Equal(t, result.Meta.Count, 1)
+		require.Greater(t, result.Meta.Count, 1)
 		require.Equal(t, result.Data[0], p1)
 
 		response, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=x86_64&search=ssh&limit=1&offset=1", &tutils.AuthString0)
 		require.Equal(t, 200, response.StatusCode)
 		err = json.Unmarshal([]byte(body), &result)
 		require.NoError(t, err)
-		require.Equal(t, result.Meta.Count, 1)
+		require.Greater(t, result.Meta.Count, 1)
 		require.Equal(t, result.Data[0], p2)
 
 		response, _ = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=x86_64&search=ssh&limit=-13", &tutils.AuthString0)


### PR DESCRIPTION
.meta.Count should contain the total amount of records, not the amount
of returned records.