### PR TITLE
templates: Use default service port

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -235,7 +235,6 @@ objects:
     name: image-builder
     annotations:
       prometheus.io/path: /metrics
-      prometheus.io/port: '8086'
       prometheus.io/scrape: 'true'
   spec:
     ports:


### PR DESCRIPTION
The port on which `/metrics` is served does not differ from the rest.