### PR TITLE
prometheus: Use regular counters instead of countervectors

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -642,7 +642,9 @@ func (s *Server) HTTPErrorHandler(err error, c echo.Context) {
 	// Only log internal errors
 	if he.Code == http.StatusInternalServerError {
 		s.logger.Errorln(fmt.Sprintf("Internal error %v: %v, %v", he.Code, he.Message, err))
-		serverErrors.WithLabelValues(c.Path()).Inc()
+		if strings.HasSuffix(c.Path(), "/compose") {
+			composeErrors.Inc()
+		}
 	}
 
 	errors = append(errors, HTTPError{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -627,5 +627,6 @@ func TestMetrics(t *testing.T) {
 
 	response, body := tutils.GetResponseBody(t, "http://localhost:8086/metrics", nil)
 	require.Equal(t, 200, response.StatusCode)
-	require.Contains(t, body, "image_builder_http_requests_total")
+	require.Contains(t, body, "image_builder_compose_requests_total")
+	require.Contains(t, body, "image_builder_compose_errors")
 }


### PR DESCRIPTION
Regular counters get initiated to 0, and with countervectors we're
collecting a bunch of data we don't want. Let's target the metrics we
want to collect very specifically, and make our job easier when writing
rules around those metrics.