### PR TITLE
API: new endpoint '/composes/{id}/metadata'

### DIFF
--- a/internal/cloudapi/client.go
+++ b/internal/cloudapi/client.go
@@ -76,6 +76,15 @@ func (oc *OsbuildClient) ComposeStatus(id string) (*http.Response, error) {
 	return oc.client.Do(req)
 }
 
+func (oc *OsbuildClient) ComposeMetadata(id string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s/compose/%s/metadata", oc.osbuildURL, oc.pathPrefix, id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return oc.client.Do(req)
+}
+
 func (oc *OsbuildClient) Compose(compose ComposeRequest) (*http.Response, error) {
 	buf, err := json.Marshal(compose)
 	if err != nil {

--- a/internal/cloudapi/cloudapi_types.go
+++ b/internal/cloudapi/cloudapi_types.go
@@ -72,6 +72,16 @@ type AzureUploadStatus struct {
 	ImageName string `json:"image_name"`
 }
 
+// ComposeMetadata defines model for ComposeMetadata.
+type ComposeMetadata struct {
+
+	// ID (hash) of the built commit
+	OstreeCommit *string `json:"ostree_commit,omitempty"`
+
+	// Package list including NEVRA
+	Packages *[]PackageMetadata `json:"packages,omitempty"`
+}
+
 // ComposeRequest defines model for ComposeRequest.
 type ComposeRequest struct {
 	Customizations *Customizations `json:"customizations,omitempty"`
@@ -166,6 +176,18 @@ const (
 type OSTree struct {
 	Ref *string `json:"ref,omitempty"`
 	Url *string `json:"url,omitempty"`
+}
+
+// PackageMetadata defines model for PackageMetadata.
+type PackageMetadata struct {
+	Arch      string  `json:"arch"`
+	Epoch     *string `json:"epoch,omitempty"`
+	Name      string  `json:"name"`
+	Release   string  `json:"release"`
+	Sigmd5    string  `json:"sigmd5"`
+	Signature *string `json:"signature,omitempty"`
+	Type      string  `json:"type"`
+	Version   string  `json:"version"`
 }
 
 // Repository defines model for Repository.

--- a/internal/cloudapi/cloudapi_types.yml
+++ b/internal/cloudapi/cloudapi_types.yml
@@ -63,6 +63,39 @@ paths:
             text/plain:
               schema:
                 type: string
+  /compose/{id}/metadata:
+    get:
+      summary: Get the metadata for a compose.
+      operationId: compose_metadata
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: 123e4567-e89b-12d3-a456-426655440000
+          required: true
+          description: ID of compose status to get
+      description: 'Get the metadata of a finished compose. The exact information returned depends on the requested image type.'
+      responses:
+        '200':
+          description: The metadata for the given compose.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeMetadata'
+        '400':
+          description: Invalid compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Unknown compose id
+          content:
+            text/plain:
+              schema:
+                type: string
   /compose:
     post:
       summary: Create compose
@@ -163,6 +196,17 @@ components:
         image_name:
           type: string
           example: 'my-image'
+    ComposeMetadata:
+      type: object
+      properties:
+        packages:
+          type: array
+          items:
+            $ref: '#/components/schemas/PackageMetadata'
+          description: 'Package list including NEVRA'
+        ostree_commit:
+          type: string
+          description: 'ID (hash) of the built commit'
     ComposeRequest:
       type: object
       required:
@@ -442,3 +486,28 @@ components:
           type: string
           format: uuid
           example: '123e4567-e89b-12d3-a456-426655440000'
+    PackageMetadata:
+      required:
+        - type
+        - name
+        - version
+        - release
+        - arch
+        - sigmd5
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        release:
+          type: string
+        epoch:
+          type: string
+        arch:
+          type: string
+        sigmd5:
+          type: string
+        signature:
+          type: string

--- a/internal/server/api.yaml
+++ b/internal/server/api.yaml
@@ -119,6 +119,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ComposeStatus'
+  /composes/{composeId}/metadata:
+    get:
+      summary: get metadata of an image compose
+      parameters:
+        - in: path
+          name: composeId
+          schema:
+            type: string
+          required: true
+          description: Id of compose metadata to get
+      description: "metadata for an image compose"
+      operationId: getComposeMetadata
+      responses:
+        '200':
+          description: compose metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeMetadata'
   /compose:
     post:
       summary: compose image
@@ -570,4 +589,40 @@ components:
         summary:
           type: string
         version:
+          type: string
+    ComposeMetadata:
+      type: object
+      properties:
+        packages:
+          type: array
+          items:
+            $ref: '#/components/schemas/PackageMetadata'
+          description: 'Package list including NEVRA'
+        ostree_commit:
+          type: string
+          description: 'ID (hash) of the built commit'
+    PackageMetadata:
+      required:
+        - type
+        - name
+        - version
+        - release
+        - arch
+        - sigmd5
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        release:
+          type: string
+        epoch:
+          type: string
+        arch:
+          type: string
+        sigmd5:
+          type: string
+        signature:
           type: string

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -9,10 +9,11 @@ echo "Enabling fastestmirror to speed up dnf 🏎️"
 echo -e "fastestmirror=1" | sudo tee -a /etc/dnf/dnf.conf
 
 # Set up osbuild-composer repo
-DNF_REPO_BASEURL=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com
+OSBUILD_DNF_REPO_BASEURL=http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com
+COMPOSER_DNF_REPO_BASEURL=http://osbuild-composer-repos.s3.amazonaws.com
 # Default values
-OSBUILD_COMMIT=3086c7d70c304214e2855cdcf495d4b70f4b04c6
-OSBUILD_COMPOSER_COMMIT=d7b0323a2dec205b7a41bd9b4c5d7e30982fc44f
+OSBUILD_COMMIT=bc7096ab8694a1a0abcf7bf536abee8ea8a6e5ac
+OSBUILD_COMPOSER_COMMIT=419ac4c7699b72cd4ca5fc89c8f46bd579baf06c
 
 # If the GH token is defined, fetch used commits used in production / staging
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"
@@ -51,13 +52,13 @@ fi
 sudo tee /etc/yum.repos.d/osbuild.repo << EOF
 [osbuild]
 name=osbuild ${OSBUILD_COMMIT}
-baseurl=${DNF_REPO_BASEURL}/osbuild/${ID}-${VERSION_ID}/${ARCH}/${OSBUILD_COMMIT}
+baseurl=${OSBUILD_DNF_REPO_BASEURL}/osbuild/${ID}-${VERSION_ID}/${ARCH}/${OSBUILD_COMMIT}
 enabled=1
 gpgcheck=0
 priority=5
 [osbuild-composer]
 name=osbuild-composer ${OSBUILD_COMPOSER_COMMIT}
-baseurl=${DNF_REPO_BASEURL}/osbuild-composer/${ID}-${VERSION_ID}/${ARCH}/${OSBUILD_COMPOSER_COMMIT}
+baseurl=${COMPOSER_DNF_REPO_BASEURL}/osbuild-composer/${ID}-${VERSION_ID}/${ARCH}/${OSBUILD_COMPOSER_COMMIT}
 enabled=1
 gpgcheck=0
 priority=6

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -609,6 +609,21 @@ function Test_verifyComposeResult() {
   esac
 }
 
+### Case: verify package list of a finished compose
+function Test_verifyComposeMetadata() {
+  local RESULT
+  RESULT=$($CURLCMD -H "$HEADER" --request GET "$BASEURL/composes/$COMPOSE_ID/metadata")
+  EXIT_CODE=$(getExitCode "$RESULT")
+  [[ $EXIT_CODE == 200 ]]
+
+  local PACKAGENAMES
+  PACKAGENAMES=$(getResponse "$RESULT" | jq -r '.packages[].name')
+  if ! grep -q postgresql <<< "${PACKAGENAMES}"; then
+      echo "'postgresql' not found in compose package list 😠"
+      exit 1
+  fi
+}
+
 function Test_getComposes() {
   RESULT=$($CURLCMD -H "$HEADER" -H 'Content-Type: application/json' "$BASEURL/composes")
   EXIT_CODE=$(getExitCode "$RESULT")
@@ -673,6 +688,7 @@ Test_getOpenapi "$BASEURLMAJORVERSION"
 Test_postToComposer
 Test_waitForCompose
 Test_verifyComposeResult
+Test_verifyComposeMetadata
 Test_getComposes
 Test_getOpenapiWithWrongOrgId
 Test_postToComposerWithWrongOrgId


### PR DESCRIPTION
Added metadata API endpoint (composes/id/metadata) that returns the information from the equivalent endpoint in osbuild-composer:
- packages: full list of package NEVRAs included in the image.
- ostree_commit: the ID/hash of the ostree commit that was created (for edge types only)

Depends on osbuild/osbuild-composer#1490