### PR TITLE
ci: Remove EXTRA_REPO_PATH_SEGMENT variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,8 +25,6 @@ start:
 Test EL8:
   stage: test
   extends: .terraform
-  variables:
-    EXTRA_REPO_PATH_SEGMENT: "gitlab/"
   script:
     - schutzbot/ci_details.sh
     # TODO: move build step as separate section


### PR DESCRIPTION
Removed in osbuild-composer repo and doesn't seem to actually be used
here.