### PR TITLE
add test case for edge iso image

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -103,6 +103,7 @@ Requires:   qemu-kvm
 Requires:   libvirt-client
 Requires:   libvirt-daemon-kvm
 Requires:   virt-install
+Requires:   wget
 
 %description tests
 Integration tests to be run on a system with image-builder installed.


### PR DESCRIPTION
This pr contains:

Test edge installer iso image, includes:
- call rest api to generate iso image, 
- use mkksiso to put ks file into iso, 
- install edge with iso file
- run ansible scirpt to check edge vm.

