### PR TITLE
image-types/rhel84: add rhel-edge-container

### DIFF
--- a/distributions/rhel-84.json
+++ b/distributions/rhel-84.json
@@ -5,7 +5,7 @@
     "description": "Red Hat Enterprise Linux (RHEL) 8"
   },
   "x86_64": {
-    "image_types": [ "ami", "vhd", "rhel-edge-commit", "rhel-edge-installer" ],
+    "image_types": [ "ami", "vhd", "rhel-edge-commit", "rhel-edge-installer", "rhel-edge-container" ],
     "repositories": [{
       "baseurl": "https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os",
       "rhsm": true


### PR DESCRIPTION
This is an alternative to rhel-edge-commit, which has the same payload, but in 8.4 it
supports embedding ssh keys, which rhel-edge-commit does not. The Edge API would
like to use this, so add the image type to the allow-list.

cc @aaronh88