### PR TITLE
[QE] Move build.sh to a new stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - start
+  - build
   - test
   - finish
 
@@ -22,13 +23,25 @@ start:
   script:
     - schutzbot/update_github_status.sh start
 
+build:
+  stage: build
+  extends: .terraform
+  script:
+    - schutzbot/build.sh
+  artifacts:
+    paths:
+      - repo/image-builder/${CI_PIPELINE_ID}
+    expire_in: 3 days
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-8-x86_64
+
 Test EL8:
   stage: test
   extends: .terraform
   script:
     - schutzbot/ci_details.sh
-    # TODO: move build step as separate section
-    - schutzbot/build.sh
     - schutzbot/deploy.sh
     - /usr/libexec/tests/image-builder/api.sh ${PROVIDER}
   parallel:
@@ -45,7 +58,6 @@ Test Edge 84:
   extends: .terraform
   script:
     - schutzbot/ci_details.sh
-    - schutzbot/build.sh
     - schutzbot/deploy.sh
     - /usr/libexec/tests/image-builder/edge.sh
   parallel:

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -200,6 +200,7 @@ function checkEnvAWS() {
 
 function installClientAWS() {
   if ! hash aws; then
+    command unzip > /dev/null || sudo dnf install -y unzip
     mkdir "$WORKDIR/aws"
     pushd "$WORKDIR/aws"
       curl -Ls --retry 5 --output awscliv2.zip \


### PR DESCRIPTION
**ready for review now**

Move build.sh out of test stages. 
Push image-builder image into quay.io/osbuild/image-builder-test repo with CI_PIPELINE_ID as tag.
Archive image-builder packages as artifacts and set expire time as 3 days.

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>