### PR TITLE
tests: remove hard coded ssh keys

### DIFF
--- a/image-builder.spec
+++ b/image-builder.spec
@@ -49,6 +49,7 @@ export GOFLAGS=-mod=vendor
 install -m 0755 -vd					%{buildroot}%{_libexecdir}/image-builder
 install -m 0755 -vp _bin/image-builder			%{buildroot}%{_libexecdir}/image-builder/
 install -m 0755 -vp _bin/image-builder-migrate-db       %{buildroot}%{_libexecdir}/image-builder/
+install -m 0755 -vp tools/gen-ssh.sh			%{buildroot}%{_libexecdir}/image-builder/
 
 install -m 0755 -vd					%{buildroot}%{_unitdir}
 install -m 0644 -vp distribution/*.{service,socket}	%{buildroot}%{_unitdir}/
@@ -84,6 +85,7 @@ install -m 0600 -vp test/data/keyring/id_rsa                    %{buildroot}%{_d
 %files
 %{_libexecdir}/image-builder/image-builder
 %{_libexecdir}/image-builder/image-builder-migrate-db
+%{_libexecdir}/image-builder/gen-ssh.sh
 %{_unitdir}/image-builder.service
 %{_unitdir}/image-builder.socket
 %{_datadir}/image-builder/distributions/

--- a/test/cases/edge.sh
+++ b/test/cases/edge.sh
@@ -38,7 +38,9 @@ GUEST_ADDRESS=192.168.100.50
 REPO_URL=http://$HOST_ADDRESS/repo
 
 SSH_OPTIONS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5)
-SSH_KEY=${IMAGE_BUILDER_TEST_DATA}/keyring/id_rsa
+SSH_DATA_DIR=$(/usr/libexec/image-builder/gen-ssh.sh)
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
+SSH_KEY_PUB="$(cat "${SSH_KEY}".pub)"
 
 KS_FILE=${WORKDIR}/ks.cfg
 COMMIT_FILENAME="commit.tar"
@@ -313,7 +315,7 @@ timezone --utc Etc/UTC
 selinux --enforcing
 rootpw --lock --iscrypted locked
 user --name=admin --groups=wheel --iscrypted --password=\$6\$1LgwKw9aOoAi/Zy9\$Pn3ErY1E8/yEanJ98evqKEW.DZp24HTuqXPJl6GYCm8uuobAmwxLv7rGCvTRZhxtcYdmC0.XnYRSR9Sh6de3p0
-sshkey --username=admin "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost"
+sshkey --username=admin "${SSH_KEY_PUB}"
 bootloader --timeout=1 --append="net.ifnames=0 modprobe.blacklist=vc4"
 network --bootproto=dhcp --device=link --activate --onboot=on
 zerombr
@@ -465,7 +467,7 @@ useradd -m -d /home/admin -p \$6\$1LgwKw9aOoAi/Zy9\$Pn3ErY1E8/yEanJ98evqKEW.DZp2
 mkdir -p /home/admin/.ssh
 chmod 755 /home/admin/.ssh
 tee /home/admin/.ssh/authorized_keys > /dev/null << EOF
-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC61wMCjOSHwbVb4VfVyl5sn497qW4PsdQ7Ty7aD6wDNZ/QjjULkDV/yW5WjDlDQ7UqFH0Sr7vywjqDizUAqK7zM5FsUKsUXWHWwg/ehKg8j9xKcMv11AkFoUoujtfAujnKODkk58XSA9whPr7qcw3vPrmog680pnMSzf9LC7J6kXfs6lkoKfBh9VnlxusCrw2yg0qI1fHAZBLPx7mW6+me71QZsS6sVz8v8KXyrXsKTdnF50FjzHcK9HXDBtSJS5wA3fkcRYymJe0o6WMWNdgSRVpoSiWaHHmFgdMUJaYoCfhXzyl7LtNb3Q+Sveg+tJK7JaRXBLMUllOlJ6ll5Hod root@localhost
+$SSH_KEY_PUB
 EOF
 chmod 600 /home/admin/.ssh/authorized_keys
 chown admin:admin /home/admin/.ssh/authorized_keys

--- a/tools/gen-ssh.sh
+++ b/tools/gen-ssh.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+# Create SSH key
+SSH_DATA_DIR="$(mktemp -d)"
+SSH_KEY=${SSH_DATA_DIR}/id_rsa
+ssh-keygen -f "${SSH_KEY}" -N "" -q -t rsa
+
+# Return temp directory
+echo "${SSH_DATA_DIR}"


### PR DESCRIPTION
Use newly generated ssh keys instead of hard codded ones