### PR TITLE
add coverity scan in ci

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,23 @@
+name: Coverity
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+
+jobs:
+  scan:
+    name: "coverity scan"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Run coverify scan script
+        env:
+          COVERITY_SCAN_PROJECT_NAME: ${{ secrets.COVERITY_SCAN_PROJECT_NAME }}
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        run: ./tools/coverity-scan.sh "$COVERITY_SCAN_PROJECT_NAME" "$COVERITY_SCAN_TOKEN"

--- a/tools/coverity-scan.sh
+++ b/tools/coverity-scan.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -eux
+
+# This function is to fix shell check error in line 29
+# SC2211: This is a glob used as a command name. Was it supposed to be in ${..}, array, or is it missing quoting?
+# If anyone know how to fix it in a better way, please update it.
+run() {
+  if (( $# != 1 ))
+  then
+    echo "Expected exactly 1 match but found $#: $*" >&2
+    exit 1
+  elif command -v "$1" > /dev/null 2>&1
+  then
+    "$1"
+  else
+    echo "Glob is not a valid command: $*" >&2
+    exit 1
+  fi
+}
+
+COVERITY_SCAN_PROJECT_NAME=$1
+COVERITY_SCAN_TOKEN=$2
+
+echo "COVERITY_SCAN_PROJECT_NAME=${COVERITY_SCAN_PROJECT_NAME}"
+echo "COVERITY_SCAN_TOKEN=${COVERITY_SCAN_TOKEN}"
+
+# Following code will do:
+# 1. Download coverity scan tool
+# 2. Run coverity scan
+# 3. Upload scan result for analysis
+# Then we can check defect details at https://scan.coverity.com
+echo "Downloading coverity scan package."
+curl -o /tmp/cov-analysis-linux64.tgz https://scan.coverity.com/download/linux64 \
+        --form project="$COVERITY_SCAN_PROJECT_NAME" \
+        --form token="$COVERITY_SCAN_TOKEN"
+tar xfz /tmp/cov-analysis-linux64.tgz
+echo "Running coverity scan during building."
+mkdir bin
+run cov-analysis-linux64-*/bin/cov-build --dir cov-int go build -o bin/ ./...
+tar cfz cov-int.tar.gz cov-int
+echo "Uploading coverity scan result to http://scan.coverity.com"
+curl https://scan.coverity.com/builds?project="$COVERITY_SCAN_PROJECT_NAME" \
+        --form token="$COVERITY_SCAN_TOKEN" \
+        --form email="$GITLAB_USER_EMAIL" \
+        --form file=@cov-int.tar.gz \
+        --form version="$(git describe --tags)" \
+        --form description="$(git describe --tags) / $CI_COMMIT_TITLE / $CI_COMMIT_REF_NAME:$CI_PIPELINE_ID "


### PR DESCRIPTION
Added coverity scan step in pipeline to check source code defects, per jira ticket https://issues.redhat.com/browse/COMPOSER-1052.
Coverity Scan is a free static code analysis tool. It analyzes every line of code and potential execution path and produces a list of potential code defects. Many open-source projects are using it to check source code defects. https://scan.coverity.com/

This pull request includes:
1. Download coverity scan tool and run coverity scan.
2. Upload scan result to coverify server https://scan.coverity.com/ for analysis. (later maybe we can setup a local server)

Then we can login https://scan.coverity.com/ with github account, find project osbuild/image-builder, click 'View Defects'