### PR TITLE
Compose: No cross user compose access

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -52,7 +52,7 @@ func (db *dB) InsertCompose(jobId, accountId, orgId string, request json.RawMess
 	}
 	defer conn.Release()
 
-	_, err = conn.Query(ctx, "INSERT INTO composes(job_id, request, created_at, account_id, org_id) VALUES ($1, $2, CURRENT_TIMESTAMP, $3, $4);", jobId, request, accountId, orgId)
+	_, err = conn.Exec(ctx, "INSERT INTO composes(job_id, request, created_at, account_id, org_id) VALUES ($1, $2, CURRENT_TIMESTAMP, $3, $4)", jobId, request, accountId, orgId)
 	return err
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,11 +3,16 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 )
+
+// ComposeNotFoundError occurs when no compose request is found for a user.
+var ComposeNotFoundError = errors.New("Compose not found")
 
 type dB struct {
 	Pool *pgxpool.Pool
@@ -22,6 +27,7 @@ type ComposeEntry struct {
 type DB interface {
 	InsertCompose(jobId, accountId, orgId string, request json.RawMessage) error
 	GetComposes(accountId string, limit, offset int) ([]ComposeEntry, int, error)
+	GetCompose(jobId string, accountId string) (*ComposeEntry, error)
 }
 
 func InitDBConnectionPool(connStr string) (DB, error) {
@@ -48,6 +54,30 @@ func (db *dB) InsertCompose(jobId, accountId, orgId string, request json.RawMess
 
 	_, err = conn.Query(ctx, "INSERT INTO composes(job_id, request, created_at, account_id, org_id) VALUES ($1, $2, CURRENT_TIMESTAMP, $3, $4);", jobId, request, accountId, orgId)
 	return err
+}
+
+func (db *dB) GetCompose(jobId string, accountId string) (*ComposeEntry, error) {
+	ctx := context.Background()
+	conn, err := db.Pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Release()
+
+	result := conn.QueryRow(ctx, "SELECT job_id, request, created_at FROM composes WHERE account_id=$1 and job_id=$2",
+		accountId, jobId)
+
+	var compose ComposeEntry
+	err = result.Scan(&compose.Id, &compose.Request, &compose.CreatedAt)
+	if err != nil {
+		if errors.As(err, &pgx.ErrNoRows) {
+			return nil, ComposeNotFoundError
+		} else {
+			return nil, err
+		}
+	}
+
+	return &compose, nil
 }
 
 func (db *dB) GetComposes(accountId string, limit, offset int) ([]ComposeEntry, int, error) {

--- a/internal/tutils/tutils.go
+++ b/internal/tutils/tutils.go
@@ -98,3 +98,7 @@ func (d *dB) InsertCompose(jobId, accountId, orgId string, request json.RawMessa
 func (d *dB) GetComposes(accountId string, limit, offset int) ([]db.ComposeEntry, int, error) {
 	return d.entries, len(d.entries), nil
 }
+
+func (db *dB) GetCompose(jobId string, accountId string) (*db.ComposeEntry, error) {
+	return nil, nil
+}

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -140,6 +140,7 @@ sudo podman run --pull=never --security-opt "label=disable" --net=host \
      -e MIGRATIONS_DIR="/app/migrations" \
      --name image-builder-migrate \
      image-builder-test:"${QUAY_REPO_TAG}" /app/image-builder-migrate-db
+sudo podman logs image-builder-migrate
 
 # Start Image Builder container
 sudo podman run -d -p 8086:8086 --pull=never --security-opt "label=disable" --net=host \

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -84,6 +84,7 @@ function cleanupAzure() {
 # terminates in any way.
 WORKDIR=$(mktemp -d)
 function cleanup() {
+  sudo podman logs image-builder
   case $CLOUD_PROVIDER in
     "$CLOUD_PROVIDER_AWS")
       cleanupAWS

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -102,15 +102,13 @@ trap cleanup EXIT
 
 ############### Common functions and variables ################
 
-# org_id 000000 (valid org_id)
-VALIDAUTHSTRING="eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAwIn19fQ=="
-
-# org_id 000001 (invalid org_id)
-INVALIDAUTHSTRING="eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAxIn19fQ=="
+ACCOUNT0_ORG0="eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAwIn19fQ=="
+ACCOUNT1_ORG0="eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDEiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAwIn19fQo="
+ACCOUNT0_ORG1="eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJzbWFydF9tYW5hZ2VtZW50Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwibWlncmF0aW9ucyI6eyJpc19lbnRpdGxlZCI6dHJ1ZX0sImFuc2libGUiOnsiaXNfZW50aXRsZWQiOnRydWV9fSwiaWRlbnRpdHkiOnsiYWNjb3VudF9udW1iZXIiOiIwMDAwMDAiLCJ0eXBlIjoiVXNlciIsInVzZXIiOnsidXNlcm5hbWUiOiJ1c2VyIiwiZW1haWwiOiJ1c2VyQHVzZXIudXNlciIsImZpcnN0X25hbWUiOiJ1c2VyIiwibGFzdF9uYW1lIjoidXNlciIsImlzX2FjdGl2ZSI6dHJ1ZSwiaXNfb3JnX2FkbWluIjp0cnVlLCJpc19pbnRlcm5hbCI6dHJ1ZSwibG9jYWxlIjoiZW4tVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDAxIn19fQ=="
 
 PORT="8086"
 CURLCMD='curl -w %{http_code}'
-HEADER="x-rh-identity: $VALIDAUTHSTRING"
+HEADER="x-rh-identity: $ACCOUNT0_ORG0"
 ADDRESS="localhost"
 BASEURL="http://$ADDRESS:$PORT/api/image-builder/v1.0"
 BASEURLMAJORVERSION="http://$ADDRESS:$PORT/api/image-builder/v1"
@@ -429,6 +427,12 @@ function Test_waitForCompose() {
   done
 }
 
+function Test_wrong_user_get_compose_status() {
+  RESULT=$($CURLCMD -H "x-rh-identity: $ACCOUNT1_ORG0" --request GET "$BASEURL/composes/$COMPOSE_ID")
+  EXIT_CODE=$(getExitCode "$RESULT")
+  [[ $EXIT_CODE == 404 ]]
+}
+
 ### Case: verify the result (image) of a finished compose in AWS
 function Test_verifyComposeResultAWS() {
   UPLOAD_OPTIONS="$1"
@@ -638,7 +642,7 @@ function Test_getComposes() {
 }
 
 function Test_getOpenapiWithWrongOrgId() {
-  RESULT=$($CURLCMD -H "x-rh-identity: $INVALIDAUTHSTRING" "$BASEURL/openapi.json")
+  RESULT=$($CURLCMD -H "x-rh-identity: $ACCOUNT0_ORG1" "$BASEURL/openapi.json")
   EXIT_CODE=$(getExitCode "$RESULT")
   [[ "$EXIT_CODE" == 404 ]]
   MSG=$(getResponse "$RESULT" | jq -r '.errors[0].detail')
@@ -646,7 +650,7 @@ function Test_getOpenapiWithWrongOrgId() {
 }
 
 function Test_postToComposerWithWrongOrgId() {
-  RESULT=$($CURLCMD -H "x-rh-identity: $INVALIDAUTHSTRING" -H 'Content-Type: application/json' --request POST --data @"$REQUEST_FILE" "$BASEURL/compose")
+  RESULT=$($CURLCMD -H "x-rh-identity: $ACCOUNT0_ORG1" -H 'Content-Type: application/json' --request POST --data @"$REQUEST_FILE" "$BASEURL/compose")
   EXIT_CODE=$(getExitCode "$RESULT")
   [[ "$EXIT_CODE" == 404 ]]
   MSG=$(getResponse "$RESULT" | jq -r '.errors[0].detail')
@@ -691,6 +695,7 @@ Test_getOpenapi "$BASEURL"
 Test_getOpenapi "$BASEURLMAJORVERSION"
 Test_postToComposer
 Test_waitForCompose
+Test_wrong_user_get_compose_status
 Test_verifyComposeResult
 Test_verifyComposeMetadata
 Test_getComposes


### PR DESCRIPTION
Before accessing a compose status, the value of the identity header is
checked against the database to ensure that the user getting the
information is the same that made the request.