### PR TITLE
[CI] enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: '4:00'
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"
+
+  # Maintain dependencies for Go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: '4:00'
+    open-pull-requests-limit: 1
+    rebase-strategy: "disabled"

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -1,7 +1,13 @@
 # inspired by rhinstaller/anaconda
 
 name: Trigger GitLab CI
-on: [push, pull_request_target]
+
+# do not trigger gitlab CI on pushes to upstream
+on:
+  pull_request_target:
+  push:
+    branches:
+      - main
 
 jobs:
   pr-info:
@@ -30,7 +36,7 @@ jobs:
 
   trigger-gitlab:
     needs: pr-info
-    if: needs.pr-info.outputs.allowed_user == 'true'
+    if: needs.pr-info.outputs.allowed_user == 'true' || ${{ github.event.sender.login }} == 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       SCHUTZBOT_SSH_KEY: ${{ secrets.SCHUTZBOT_SSH_KEY }}


### PR DESCRIPTION
dependabot is an independent security scanning tool which mostly focuses on evaluating the dependency chain. Having the dependabot.yml file on the main branch would enable the bot to test the dependencies and create a pull request for each one, on a specified schedule.

When we finish dependabot configuration tweaking in osbuild-composer repository, we can merge this PR.