### PR TITLE
prometheus: Custom buckets for http request duration histogram

### DIFF
--- a/internal/common/prometheus.go
+++ b/internal/common/prometheus.go
@@ -10,8 +10,9 @@ import (
 
 var (
 	httpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "image_builder_http_duration_seconds",
-		Help: "Duration of HTTP requests.",
+		Name:    "image_builder_http_duration_seconds",
+		Help:    "Duration of HTTP requests.",
+		Buckets: []float64{.025, .05, .075, .1, .2, .5, .75, 1, 1.5, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16, 20},
 	}, []string{"path"})
 )
 


### PR DESCRIPTION
Compose requests can take anywhere from 3 to 12 seconds, and the default
buckets put everything above 10 in the infinite bucket. By introducing
more buckets compose requests should be captured better.

---

Note that the first 5 buckets are considered acceptable for non-compose requests. And the first 17 acceptable for compose requests. Anything above 12 for compose requests is considered (really) slow.