### PR TITLE
db: check for err after rows closed

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -118,6 +118,9 @@ func (db *dB) GetComposes(accountNumber string, since time.Duration, limit, offs
 			createdAt,
 		})
 	}
+	if err = result.Err(); err != nil {
+		return nil, 0, err
+	}
 
 	var count int
 	err = conn.QueryRow(ctx, sqlCountComposesSince, accountNumber, since).Scan(&count)


### PR DESCRIPTION
Add call to result.Err() after rows are closed by result.Next()
to check for invalid SQL not caught by earlier error handling.