### PR TITLE
templates: change grafana folder

### DIFF
--- a/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     grafana_dashboard: "true"
   annotations:
-    grafana-folder: /grafana-dashboard-definitions/Insights
+    grafana-folder: /grafana-dashboard-definitions/Image-Builder
 data:
   grafana.json: |-
     {
@@ -1539,5 +1539,5 @@ data:
       "timezone": "",
       "title": "Image Builder",
       "uid": "91_RmVCMk",
-      "version": 5
+      "version": 6
     }


### PR DESCRIPTION
Unfortunately the image-builder-crc dashboard is no longer visible at all. The app-sre team suggested moving this dashboard over to the newly created Image-Builder folder.