### PR TITLE
templates: change dashboard name & id

### DIFF
--- a/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
@@ -31,7 +31,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1635780181016,
+      "id": 2,
+      "iteration": 1636039881169,
       "links": [],
       "panels": [
         {
@@ -1501,7 +1502,7 @@ data:
             "hide": 2,
             "label": null,
             "name": "noncompose_latency_slo",
-            "query": "0.95",
+            "query": "0.9",
             "skipUrlSync": false,
             "type": "constant"
           }
@@ -1537,7 +1538,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "Image Builder",
-      "uid": "91_RmVCMk",
-      "version": 6
+      "title": "Image Builder CRC",
+      "uid": "yMgD18Knk",
+      "version": 7
     }


### PR DESCRIPTION
The current dashboard is still not showing in stage or production and it's possibly
due to a conflict with the name and id. App-sre has suggested changing this to
resolve the issue.