### PR TITLE
composer: add tls config

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -41,7 +41,7 @@ func main() {
 		panic(err)
 	}
 
-	client, err := composer.NewClient(conf.ComposerURL, conf.ComposerTokenURL, conf.ComposerOfflineToken)
+	client, err := composer.NewClient(conf.ComposerURL, conf.ComposerTokenURL, conf.ComposerOfflineToken, conf.ComposerCA)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type ImageBuilderConfig struct {
 	ComposerURL          string  `env:"COMPOSER_URL"`
 	ComposerTokenURL     string  `env:"COMPOSER_TOKEN_URL"`
 	ComposerOfflineToken string  `env:"COMPOSER_OFFLINE_TOKEN"`
+	ComposerCA           *string `env:"COMPOSER_CA_PATH"`
 	OsbuildRegion        string  `env:"OSBUILD_AWS_REGION"`
 	OsbuildGCPRegion     string  `env:"OSBUILD_GCP_REGION"`
 	OsbuildGCPBucket     string  `env:"OSBUILD_GCP_BUCKET"`

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -73,7 +73,7 @@ func startServerWithCustomDB(t *testing.T, url string, orgIds string, accountNum
 		require.NoError(t, err)
 	}))
 
-	client, err := composer.NewClient(url, tokenServer.URL, "offlinetoken")
+	client, err := composer.NewClient(url, tokenServer.URL, "offlinetoken", nil)
 	require.NoError(t, err)
 
 	//store the quotas in a temporary file


### PR DESCRIPTION
@Gundersanne @ondrejbudai I've had to re-add some tls config when creating the composer`client. I've tried to make the changes as noninvasive as possible. The reason for this is that in the dev stack the backend is unable to communicate with the composer instance because of self-signed certs (https://github.com/osbuild/image-builder/issues/291)

I'm not sure if we want to include this "fix", so I've marked it as draft for now and happy to hear your thoughts.



