### PR TITLE
templates/dashboards: Set uid to a fixed string

### DIFF
--- a/internal/composer/openapi.v2.gen.go
+++ b/internal/composer/openapi.v2.gen.go
@@ -259,10 +259,21 @@ type UploadOptions interface{}
 
 // UploadStatus defines model for UploadStatus.
 type UploadStatus struct {
-	Options interface{} `json:"options"`
-	Status  string      `json:"status"`
-	Type    UploadTypes `json:"type"`
+	Options interface{}       `json:"options"`
+	Status  UploadStatusValue `json:"status"`
+	Type    UploadTypes       `json:"type"`
 }
+
+// UploadStatusValue defines model for UploadStatusValue.
+type UploadStatusValue string
+
+// List of UploadStatusValue
+const (
+	UploadStatusValue_failure UploadStatusValue = "failure"
+	UploadStatusValue_pending UploadStatusValue = "pending"
+	UploadStatusValue_running UploadStatusValue = "running"
+	UploadStatusValue_success UploadStatusValue = "success"
+)
 
 // UploadTypes defines model for UploadTypes.
 type UploadTypes string

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -263,7 +263,7 @@ func (h *Handlers) GetComposeStatus(ctx echo.Context, composeId string) error {
 
 	if cloudStat.ImageStatus.UploadStatus != nil {
 		status.ImageStatus.UploadStatus = &UploadStatus{
-			Status:  cloudStat.ImageStatus.UploadStatus.Status,
+			Status:  string(cloudStat.ImageStatus.UploadStatus.Status),
 			Type:    UploadTypes(cloudStat.ImageStatus.UploadStatus.Type),
 			Options: cloudStat.ImageStatus.UploadStatus.Options,
 		}

--- a/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
@@ -1539,6 +1539,6 @@ data:
       },
       "timezone": "",
       "title": "Image Builder CRC",
-      "uid": "yMgD18Knk",
+      "uid": "image-builder-crc",
       "version": 8
     }


### PR DESCRIPTION
This way the generated url on app-sre's grafana instances will always be
`...d/image-builder-crc`.


---

I plan to update all references to the dashboard after this, and then we'll hopefully never have to make sure the urls are up to date ever again :)