### PR TITLE
distributions: Align available image types with spec

### DIFF
--- a/distributions/rhel-84.json
+++ b/distributions/rhel-84.json
@@ -5,7 +5,7 @@
     "description": "Red Hat Enterprise Linux (RHEL) 8"
   },
   "x86_64": {
-    "image_types": [ "aws", "gcp", "azure", "edge-commit", "edge-installer", "ami", "vhd", "rhel-edge-commit", "rhel-edge-installer", "rhel-edge-container" ],
+    "image_types": [ "aws", "gcp", "azure", "edge-commit", "edge-installer", "ami", "vhd", "rhel-edge-commit", "rhel-edge-installer", "edge-container" ],
     "repositories": [{
       "baseurl": "https://cdn.redhat.com/content/dist/rhel8/8.4/x86_64/baseos/os",
       "rhsm": true

--- a/distributions/rhel-85.json
+++ b/distributions/rhel-85.json
@@ -5,7 +5,7 @@
     "description": "Red Hat Enterprise Linux (RHEL) 8"
   },
   "x86_64": {
-    "image_types": [ "ami", "vhd", "rhel-edge-commit", "rhel-edge-installer", "rhel-edge-container",  "guest-image", "image-installer", "vsphere"],
+    "image_types": [ "ami", "vhd", "aws", "gcp", "azure", "edge-commit", "edge-installer", "edge-container", "rhel-edge-commit", "rhel-edge-installer", "guest-image", "image-installer", "vsphere" ],
     "repositories": [{
       "baseurl": "https://cdn.redhat.com/content/dist/rhel8/8.5/x86_64/baseos/os",
       "rhsm": true


### PR DESCRIPTION
The spec was edited to support these image types, but they're just aliases of older ones as we haven't dropped the upload_request in image-builder. But the distros should be updated to reflect these, otherwise it'll refuse to build the types we advertise as available in the spec.