### PR TITLE
ci: make every job interruptible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ stages:
   after_script:
     - schutzbot/update_github_status.sh update
     - schutzbot/save_journal.sh
+  interruptible: true
   tags:
     - terraform
   artifacts:


### PR DESCRIPTION
with #326, every testing resources will be removed by scheduled cloud
cleaner running on osbuild-composer. We can enable auto-cancel redundant
pipelines. To do so, every job must be interruptible