### PR TITLE
devcontainer: add VSCode devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM fedora:35
+
+# Install:
+#  - a few packages for convenient usage
+#  - RPM tooling
+#  - the go compiler
+RUN dnf install -y \
+    fish \
+    fd-find \
+    ripgrep \
+    jq \
+    go
+# install the language server
+RUN go install -v golang.org/x/tools/gopls@latest
+RUN go install -v github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest
+RUN go install -v github.com/ramya-rao-a/go-outline@latest
+RUN go install -v github.com/go-delve/delve/cmd/dlv@latest
+RUN go install -v honnef.co/go/tools/cmd/staticcheck@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "image-builder",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "extensions": [
+    "golang.Go",
+    "GitHub.vscode-pull-request-github"
+  ]
+}

--- a/internal/composer/openapi.v2.gen.go
+++ b/internal/composer/openapi.v2.gen.go
@@ -314,9 +314,11 @@ type PackageMetadata struct {
 
 // Repository defines model for Repository.
 type Repository struct {
-	Baseurl    *string `json:"baseurl,omitempty"`
-	CheckGpg   *bool   `json:"check_gpg,omitempty"`
-	GpgKey     *string `json:"gpg_key,omitempty"`
+	Baseurl  *string `json:"baseurl,omitempty"`
+	CheckGpg *bool   `json:"check_gpg,omitempty"`
+
+	// GPG key used to sign packages in this repository.
+	Gpgkey     *string `json:"gpgkey,omitempty"`
 	IgnoreSsl  *bool   `json:"ignore_ssl,omitempty"`
 	Metalink   *string `json:"metalink,omitempty"`
 	Mirrorlist *string `json:"mirrorlist,omitempty"`


### PR DESCRIPTION
This allows development in VSCode without anything to the host. It also makes
getting started with development more straight-forward, as no setup is required.