### PR TITLE
Add kube-linter check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,3 +86,27 @@ jobs:
       run: |
         make build
         ./image-builder-db-test
+
+  kube-linter:
+    name: "🎀 kube-linter"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: redhat-actions/oc-installer@v1
+    - name: Process template
+      run: |
+        mkdir processed-templates
+        oc process -f templates/image-builder.yml \
+          -p IMAGE_TAG=image_tag \
+          --local \
+          -o yaml > processed-templates/image-builder.yml
+
+        oc process -f templates/iqe-trigger.yml \
+          -p WEBHOOK_URL=webhook_url \
+          --local \
+          -o yaml > processed-templates/iqe-trigger.yml
+
+    - uses: stackrox/kube-linter-action@v1.0.4
+      with:
+        directory: processed-templates
+        config: templates/.kube-linter-config.yml

--- a/templates/.kube-linter-config.yml
+++ b/templates/.kube-linter-config.yml
@@ -1,0 +1,4 @@
+checks:
+  exclude:
+  - "no-read-only-root-fs"
+  - "run-as-non-root"

--- a/templates/iqe-trigger.yml
+++ b/templates/iqe-trigger.yml
@@ -17,6 +17,13 @@ objects:
             name: image-builder-iqe-trigger
             command: ["curl"]
             args: ["-X", "POST", "-H", 'Content-type: application/json', "--data", '{"text":"Trigger IQE pipeline."}', "${WEBHOOK_URL}"]
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                cpu: 200m
+                memory: 256Mi
 
 parameters:
   - name: WEBHOOK_URL


### PR DESCRIPTION
Example runs: https://github.com/Gundersanne/image-builder/actions/workflows/tests.yml.

The 'break template' commits are commits where the check was made to fail on purpose.