### PR TITLE
Dockerfile: use ubi9 as the base images

### DIFF
--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -1,13 +1,13 @@
 # Use a builder container to build the Go application (which we extract in
 # the second container).
-FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 WORKDIR $GOPATH/go/src/github.com/osbuild/image-builder
 COPY . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./...
 
 # Build an extremely minimal container that only contains our Go application.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN mkdir /app
 COPY --from=builder /opt/app-root/src/go/bin/image-builder /app/
 COPY --from=builder /opt/app-root/src/go/bin/image-builder-migrate-db /app/


### PR DESCRIPTION
I don't see a reason why not to be honest. As Red Hatters, we should promote
using our latest and greatest technologies in tech stacks so choosing UBI9
as the base for our deployments seems natural. Also, it's just golang,
I'm pretty sure that this will work just fine.