### PR TITLE
template: fix iqe-trigger name

### DIFF
--- a/templates/iqe-trigger.yml
+++ b/templates/iqe-trigger.yml
@@ -41,4 +41,4 @@ parameters:
   - name: JOB_SUFFIX
     description: "Random string used as job suffix"
     generate: expression
-    from : "[a-zA-Z0-9]{12}"
+    from : "[a-z0-9]{12}"


### PR DESCRIPTION
Apparently the name can contain only lowercase alphanumeric characters
so removing the uppercase ones.