### PR TITLE
v1: Log errors coming from composer

### DIFF
--- a/internal/composer/openapi.v2.gen.go
+++ b/internal/composer/openapi.v2.gen.go
@@ -142,8 +142,16 @@ type Customizations struct {
 	// any other part of the build process). The package_sets field for these
 	// repositories is ignored.
 	PayloadRepositories *[]Repository `json:"payload_repositories,omitempty"`
-	Subscription        *Subscription `json:"subscription,omitempty"`
-	Users               *[]User       `json:"users,omitempty"`
+	Services            *struct {
+
+		// List of services to disable by default
+		Disabled *[]string `json:"disabled,omitempty"`
+
+		// List of services to enable by default
+		Enabled *[]string `json:"enabled,omitempty"`
+	} `json:"services,omitempty"`
+	Subscription *Subscription `json:"subscription,omitempty"`
+	Users        *[]User       `json:"users,omitempty"`
 }
 
 // Error defines model for Error.

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -262,6 +262,8 @@ func (h *Handlers) GetComposeStatus(ctx echo.Context, composeId string) error {
 		httpError := echo.NewHTTPError(http.StatusInternalServerError, "Failed querying compose status")
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
+			logrus.Errorf("Unable to parse composer's compose response: %v", err)
+		} else {
 			_ = httpError.SetInternal(fmt.Errorf("%s", body))
 		}
 		return httpError
@@ -360,6 +362,8 @@ func (h *Handlers) GetComposeMetadata(ctx echo.Context, composeId string) error 
 		httpError := echo.NewHTTPError(http.StatusInternalServerError, "Failed querying compose status")
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
+			logrus.Errorf("Unable to parse composer's compose response: %v", err)
+		} else {
 			_ = httpError.SetInternal(fmt.Errorf("%s", body))
 		}
 		return httpError
@@ -546,6 +550,8 @@ func (h *Handlers) ComposeImage(ctx echo.Context) error {
 		httpError := echo.NewHTTPError(http.StatusInternalServerError, "Failed posting compose request to osbuild-composer")
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
+			logrus.Errorf("Unable to parse composer's compose response: %v", err)
+		} else {
 			_ = httpError.SetInternal(fmt.Errorf("%s", body))
 		}
 		return httpError


### PR DESCRIPTION
The internal error wasn't set properly, resulting in the error handler
not logging it.

---

I want to replace this with the composer client being able to parse the error fully. But this will do for now.