### PR TITLE
v1: Attempt to parse target error's details as new compose error

### DIFF
--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -306,6 +306,8 @@ func parseComposeStatusError(composeErr *composer.ComposeStatusError) *ComposeSt
 	case 5: // manifest error: depsolve dependency failure
 		fallthrough
 	case 9: // osbuild error: manifest dependency failure
+		fallthrough
+	case 28: // osbuild target errors are added to details
 		if composeErr.Details != nil {
 			intfs := (*composeErr.Details).([]interface{})
 			if len(intfs) == 0 {


### PR DESCRIPTION
This changed in https://github.com/osbuild/osbuild-composer/pull/2748,
where the targeterror is appended to the details instead of being set as
the top-level job error.