### PR TITLE
v1: Attempt to parse error details as compose error for 26

### DIFF
--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -307,6 +307,8 @@ func parseComposeStatusError(composeErr *composer.ComposeStatusError) *ComposeSt
 		fallthrough
 	case 9: // osbuild error: manifest dependency failure
 		fallthrough
+	case 26: // ErrorJobDependency: generic dependency failure
+		fallthrough
 	case 28: // osbuild target errors are added to details
 		if composeErr.Details != nil {
 			intfs := (*composeErr.Details).([]interface{})


### PR DESCRIPTION
26 is a generic dependency failure, similar to 5 and 9 which are for the
manifest's depsolve dependency and osbuild's manifest dependency
failures. Future dependency errors will use 26 unless there's an
indication to capture it separately.