### PR TITLE
test: tag azure resources in api.sh

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -567,8 +567,10 @@ function Test_verifyComposeResultAzure() {
   $AZURE_CMD login --service-principal --username "${V2_AZURE_CLIENT_ID}" --password "${V2_AZURE_CLIENT_SECRET}" --tenant "${AZURE_TENANT_ID}"
   set -x
 
-  # verify that the image exists
+  # verify that the image exists and tag it
   $AZURE_CMD image show --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_IMAGE_NAME}"
+  $AZURE_CMD image update --resource-group "${AZURE_RESOURCE_GROUP}" --name "${AZURE_IMAGE_NAME}" --tags gitlab-ci-test=true
+
 
   # Verify that the image boots and have customizations applied
   # Create SSH keys to use
@@ -576,7 +578,7 @@ function Test_verifyComposeResultAzure() {
   ssh-keygen -t rsa -f "$AZURE_SSH_KEY" -C "$SSH_USER" -N ""
 
   # Create network resources with predictable names
-  $AZURE_CMD network nsg create --resource-group "$AZURE_RESOURCE_GROUP" --name "nsg-$TEST_ID" --location "$AZURE_LOCATION"
+  $AZURE_CMD network nsg create --resource-group "$AZURE_RESOURCE_GROUP" --name "nsg-$TEST_ID" --location "$AZURE_LOCATION" --tags gitlab-ci-test=true
   $AZURE_CMD network nsg rule create --resource-group "$AZURE_RESOURCE_GROUP" \
       --nsg-name "nsg-$TEST_ID" \
       --name SSH \
@@ -587,15 +589,20 @@ function Test_verifyComposeResultAzure() {
       --destination-port-ranges 22 \
       --source-port-ranges '*' \
       --source-address-prefixes '*'
-  $AZURE_CMD network vnet create --resource-group "$AZURE_RESOURCE_GROUP" --name "vnet-$TEST_ID" --subnet-name "snet-$TEST_ID" --location "$AZURE_LOCATION"
-  $AZURE_CMD network public-ip create --resource-group "$AZURE_RESOURCE_GROUP" --name "ip-$TEST_ID" --location "$AZURE_LOCATION"
+  $AZURE_CMD network vnet create --resource-group "$AZURE_RESOURCE_GROUP" \
+    --name "vnet-$TEST_ID" \
+    --subnet-name "snet-$TEST_ID" \
+    --location "$AZURE_LOCATION" \
+    --tags gitlab-ci-test=true
+  $AZURE_CMD network public-ip create --resource-group "$AZURE_RESOURCE_GROUP" --name "ip-$TEST_ID" --location "$AZURE_LOCATION" --tags gitlab-ci-test=true
   $AZURE_CMD network nic create --resource-group "$AZURE_RESOURCE_GROUP" \
       --name "iface-$TEST_ID" \
       --subnet "snet-$TEST_ID" \
       --vnet-name "vnet-$TEST_ID" \
       --network-security-group "nsg-$TEST_ID" \
       --public-ip-address "ip-$TEST_ID" \
-      --location "$AZURE_LOCATION"  
+      --location "$AZURE_LOCATION" \
+      --tags gitlab-ci-test=true 
 
   # create the instance
   AZURE_INSTANCE_NAME="vm-$TEST_ID"
@@ -608,7 +615,8 @@ function Test_verifyComposeResultAzure() {
     --authentication-type "ssh" \
     --location "$AZURE_LOCATION" \
     --nics "iface-$TEST_ID" \
-    --os-disk-name "disk-$TEST_ID"
+    --os-disk-name "disk-$TEST_ID" \
+    --tags gitlab-ci-test=true
   $AZURE_CMD vm show --name "$AZURE_INSTANCE_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --show-details > "$WORKDIR/vm_details.json"
   HOST=$(jq -r '.publicIps' "$WORKDIR/vm_details.json")
 


### PR DESCRIPTION
For now, resources should be tagged with `gitlab-ci-test` in order to get cleaned up by cloud cleaner. This test was not tagging the and some resources were being left behind.