### PR TITLE
templates: Grab access tokens from RH SSO

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -51,7 +51,7 @@ echo "{\"000000\":{\"quota\":5,\"slidingWindow\":1209600000000000},\"000001\":{\
 # Start Image Builder container
 sudo podman run -d --pull=never --security-opt "label=disable" --net=host \
      -e COMPOSER_URL=https://api.stage.openshift.com: \
-     -e COMPOSER_TOKEN_URL="https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token" \
+     -e COMPOSER_TOKEN_URL="https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token" \
      -e COMPOSER_CLIENT_SECRET="${COMPOSER_CLIENT_SECRET:-}" \
      -e COMPOSER_CLIENT_ID="${COMPOSER_CLIENT_ID:-}" \
      -e OSBUILD_AWS_REGION="${AWS_REGION:-}" \

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -350,7 +350,7 @@ parameters:
     value: ""
   - name: COMPOSER_TOKEN_URL
     description: OpenId token endpoint
-    value: "https://identity.api.openshift.com/auth/realms/rhoas/protocol/openid-connect/token"
+    value: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
   - name: ALLOWED_ORG_IDS
     description: Organization ids allowed to access the api, wildcard means everyone
     value: ""


### PR DESCRIPTION
Newer service accounts only work with RH SSO. Older accounts work with both Openshift and RH SSO. Let's just switch to using RH SSO in case the service accounts ever need to be reprovisioned.