### PR TITLE
composer: re-generate the API types

### DIFF
--- a/internal/composer/openapi.v2.gen.go
+++ b/internal/composer/openapi.v2.gen.go
@@ -43,6 +43,9 @@ const (
 	ImageTypesGcpRhui        ImageTypes = "gcp-rhui"
 	ImageTypesGuestImage     ImageTypes = "guest-image"
 	ImageTypesImageInstaller ImageTypes = "image-installer"
+	ImageTypesIotCommit      ImageTypes = "iot-commit"
+	ImageTypesIotContainer   ImageTypes = "iot-container"
+	ImageTypesIotRawImage    ImageTypes = "iot-raw-image"
 	ImageTypesVsphere        ImageTypes = "vsphere"
 )
 


### PR DESCRIPTION
IoT was added here:
https://github.com/osbuild/osbuild-composer/commit/fc4450cfbf73b361f180276d6c154a21326a3edc