### PR TITLE
db: Switch to jackc/tern for migrations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,15 @@ jobs:
         go-version: 1.17
     - env:
         MIGRATIONS_DIR: internal/db/migrations
+        TERN_MIGRATIONS_DIR: internal/db/migrations-tern
+        PGUSER: postgres
+        PGPASSWORD: foobar
+        PGDATABASE: imagebuilder
+        PGHOST: localhost
+        PGPORT: 5432
       run: |
+        go install github.com/jackc/tern@latest
+        tern migrate -m "$TERN_MIGRATIONS_DIR"
         make build
         ./image-builder-db-test
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 rpmbuild
 /image-builder-db-test
 /image-builder-migrate-db
+/image-builder-migrate-db-tern
 dnf-json

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PACKAGE_NAME = image-builder
 build:
 	go build -o image-builder ./cmd/image-builder/
 	go build -o image-builder-migrate-db ./cmd/image-builder-migrate-db/
+	go build -o image-builder-migrate-db-tern ./cmd/image-builder-migrate-db-tern/
 	go test -c -tags=integration -o image-builder-db-test ./cmd/image-builder-db-test/
 
 # pip3 install openapi-spec-validator

--- a/cmd/image-builder-migrate-db-tern/image-builder-migrate-db-tern.go
+++ b/cmd/image-builder-migrate-db-tern/image-builder-migrate-db-tern.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+
+	"github.com/osbuild/image-builder/internal/config"
+	"github.com/osbuild/image-builder/internal/logger"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	conf := config.ImageBuilderConfig{
+		ListenAddress:     "unused",
+		LogLevel:          "INFO",
+		TernExecutable:    "/opt/migrate/tern",
+		TernMigrationsDir: "/app/migrations",
+		PGHost:            "localhost",
+		PGPort:            "5432",
+		PGDatabase:        "imagebuilder",
+		PGUser:            "postgres",
+		PGPassword:        "foobar",
+		PGSSLMode:         "prefer",
+	}
+
+	err := config.LoadConfigFromEnv(&conf)
+	if err != nil {
+		panic(err)
+	}
+
+	err = logger.ConfigLogger(logrus.StandardLogger(), conf.LogLevel, conf.CwAccessKeyID, conf.CwSecretAccessKey, conf.CwRegion, conf.LogGroup, "")
+	if err != nil {
+		panic(err)
+	}
+
+	// #nosec G204 -- the executable in the config can be trusted
+	cmd := exec.Command(conf.TernExecutable,
+		"migrate",
+		"-m", conf.TernMigrationsDir,
+		"--database", conf.PGDatabase,
+		"--host", conf.PGHost,
+		"--port", conf.PGPort,
+		"--user", conf.PGUser,
+		"--password", conf.PGPassword,
+		"--sslmode", conf.PGSSLMode)
+	out, err := cmd.CombinedOutput()
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		logrus.Info(scanner.Text())
+	}
+
+	if err != nil {
+		panic(err)
+	}
+
+	logrus.Info("DB migration successful")
+}

--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -6,14 +6,19 @@ COPY . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./...
 
+FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder2
+RUN go install github.com/jackc/tern@latest
+
 # Build an extremely minimal container that only contains our Go application.
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN mkdir /app
+RUN mkdir -p "/opt/migrate/"
 COPY --from=builder /opt/app-root/src/go/bin/image-builder /app/
-COPY --from=builder /opt/app-root/src/go/bin/image-builder-migrate-db /app/
+COPY --from=builder /opt/app-root/src/go/bin/image-builder-migrate-db-tern /app/
 COPY ./distributions /app/distributions
-COPY ./internal/db/migrations /app/migrations
+COPY ./internal/db/migrations-tern /app/migrations
 COPY ./distribution/openshift-startup.sh /opt/openshift-startup.sh
-ENV MIGRATIONS_DIR=/app/migrations
+COPY --from=builder2 /opt/app-root/src/go/bin/tern /opt/migrate/
+ENV TERN_MIGRATIONS_DIR=/app/migrations
 EXPOSE 8086
 CMD ["/opt/openshift-startup.sh"]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,8 @@ type ImageBuilderConfig struct {
 	OsbuildAzureLocation string `env:"OSBUILD_AZURE_LOCATION"`
 	DistributionsDir     string `env:"DISTRIBUTIONS_DIR"`
 	MigrationsDir        string `env:"MIGRATIONS_DIR"`
+	TernExecutable       string `env:"TERN_EXECUTABLE"`
+	TernMigrationsDir    string `env:"TERN_MIGRATIONS_DIR"`
 	PGHost               string `env:"PGHOST"`
 	PGPort               string `env:"PGPORT"`
 	PGDatabase           string `env:"PGDATABASE"`

--- a/internal/db/migrations-tern/001_create_table_composes.sql
+++ b/internal/db/migrations-tern/001_create_table_composes.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS composes(
+       job_id uuid PRIMARY KEY,
+       request jsonb NOT NULL,
+       created_at timestamp NOT NULL,
+       account_number varchar NOT NULL,
+       org_id varchar NOT NULL,
+       image_name varchar,
+
+       CONSTRAINT account_number_constraint CHECK (account_number NOT SIMILAR TO '[ ]*'),
+       CONSTRAINT org_id_constraint CHECK (org_id NOT SIMILAR TO '[ ]*'),
+       CONSTRAINT check_name_length CHECK (length(image_name) <= 100) NOT VALID
+);

--- a/internal/db/migrations-tern/002_create_table_clones.sql
+++ b/internal/db/migrations-tern/002_create_table_clones.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS clones(
+       id uuid PRIMARY KEY,
+       compose_id uuid NOT NULL REFERENCES composes(job_id) ON DELETE CASCADE,
+       request jsonb NOT NULL,
+       created_at timestamp NOT NULL,
+
+       CONSTRAINT clone_id_differs_from_compose_id CHECK (id != compose_id)
+);

--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -42,9 +42,8 @@ sudo podman pull --creds "${V2_QUAY_USERNAME}":"${V2_QUAY_PASSWORD}" "${QUAY_REP
 sudo podman run --pull=never --security-opt "label=disable" --net=host \
      -e PGHOST=localhost -e PGPORT=5432 -e PGDATABASE=imagebuilder \
      -e PGUSER=postgres -e PGPASSWORD=foobar \
-     -e MIGRATIONS_DIR="/app/migrations" \
      --name image-builder-migrate \
-     image-builder-test:"${QUAY_REPO_TAG}" /app/image-builder-migrate-db
+     image-builder-test:"${QUAY_REPO_TAG}" /app/image-builder-migrate-db-tern
 sudo podman logs image-builder-migrate
 
 echo "{\"000000\":{\"quota\":5,\"slidingWindow\":1209600000000000},\"000001\":{\"quota\":0,\"slidingWindow\":1209600000000000}}" > /tmp/quotas

--- a/templates/image-builder-clowder.yml
+++ b/templates/image-builder-clowder.yml
@@ -68,7 +68,7 @@ objects:
         initContainers:
         - name: image-builder-migrate
           image: ${IMAGE}:${IMAGE_TAG}
-          command: [ "/app/image-builder-migrate-db" ]
+          command: [ "/app/image-builder-migrate-db-tern" ]
           resources:
             requests:
               cpu: ${CPU_REQUEST}
@@ -76,9 +76,6 @@ objects:
             limits:
               cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}
-          env:
-          - name: MIGRATIONS_DIR
-            value: "${MIGRATIONS_DIR}"
       webServices:
         public:
           enabled: true
@@ -109,9 +106,6 @@ parameters:
     value: "https://api.stage.openshift.com"
   - name: COMPOSER_TOKEN_URL
     value: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
-  - name: MIGRATIONS_DIR
-    description: Directory containing migration files for aws rds
-    value: "/app/migrations"
   - name: CPU_REQUEST
     description: CPU request per container
     value: 200m

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -214,7 +214,7 @@ objects:
         initContainers:
         - name: image-builder-migrate
           image: "${IMAGE_NAME}:${IMAGE_TAG}"
-          command: [ "/app/image-builder-migrate-db" ]
+          command: [ "/app/image-builder-migrate-db-tern" ]
           resources:
             requests:
               cpu: "${CPU_REQUEST}"
@@ -223,8 +223,6 @@ objects:
               cpu: "${CPU_LIMIT}"
               memory: "${MEMORY_LIMIT}"
           env:
-          - name: MIGRATIONS_DIR
-            value: "${MIGRATIONS_DIR}"
           # Credentials/configuration for AWS RDS.
           - name: PGHOST
             valueFrom:
@@ -373,9 +371,6 @@ parameters:
   - name: OSBUILD_AZURE_LOCATION
     description: Location in Azure to upload to
     value: "eastus"
-  - name: MIGRATIONS_DIR
-    description: Directory containing migration files for aws rds
-    value: "/app/migrations"
   - name: PGSSLMODE
     description: Sslmode for the connection to psql
     value: "require"


### PR DESCRIPTION
Tern uses transactions for each migration, so a failed migration can just be resolved by pushing a new version. Migrations with `golang-migrate` might result in a broken database which needs to be manually resolved.

This doesn't remove golang-migrate yet, as it runs the db-tests against a database migrated with golang-migrate and tern, and against a database migrated with just tern.

Fixes #197