### PR TITLE
internal/composer: spec update

### DIFF
--- a/internal/composer/openapi.v2.gen.go
+++ b/internal/composer/openapi.v2.gen.go
@@ -299,7 +299,7 @@ type Filesystem struct {
 // GCPUploadOptions defines model for GCPUploadOptions.
 type GCPUploadOptions struct {
 	// Name of an existing STANDARD Storage class Bucket.
-	Bucket string `json:"bucket"`
+	Bucket *string `json:"bucket,omitempty"`
 
 	// The name to use for the imported and shared Compute Engine image.
 	// The image name must be unique within the GCP project, which is used

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -590,7 +590,7 @@ func (h *Handlers) buildUploadOptions(ur UploadRequest, it ImageTypes) (composer
 			return nil, "", echo.NewHTTPError(http.StatusBadRequest, "Unable to unmarshal into GCPUploadRequestOptions")
 		}
 		return composer.GCPUploadOptions{
-			Bucket:            h.server.gcp.Bucket,
+			Bucket:            &h.server.gcp.Bucket,
 			Region:            h.server.gcp.Region,
 			ShareWithAccounts: &gcpOptions.ShareWithAccounts,
 		}, composerImageType, nil


### PR DESCRIPTION
The GCP bucket is no longer a required variable.