### PR TITLE
internal/v1: correctly cap offset in GetPackages

### DIFF
--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -113,8 +113,8 @@ func (h *Handlers) GetPackages(ctx echo.Context, params GetPackagesParams) error
 
 	offset := 0
 	if params.Offset != nil {
-		if *params.Offset >= len(packages) {
-			offset = len(packages) - 1
+		if *params.Offset > len(packages) {
+			offset = len(packages)
 		} else if *params.Offset > 0 {
 			offset = *params.Offset
 		}
@@ -123,6 +123,11 @@ func (h *Handlers) GetPackages(ctx echo.Context, params GetPackagesParams) error
 	upto := offset + limit
 	if upto > len(packages) {
 		upto = len(packages)
+	}
+
+	lastOffset := len(packages) - 1
+	if lastOffset < 0 {
+		lastOffset = 0
 	}
 
 	return ctx.JSON(http.StatusOK, PackagesResponse{
@@ -135,10 +140,10 @@ func (h *Handlers) GetPackages(ctx echo.Context, params GetPackagesParams) error
 			First string `json:"first"`
 			Last  string `json:"last"`
 		}{
+			fmt.Sprintf("%v/v%v/packages?search=%v&distribution=%v&architecture=%v&offset=0&limit=%v",
+				RoutePrefix(), h.server.spec.Info.Version, params.Search, params.Distribution, params.Architecture, limit),
 			fmt.Sprintf("%v/v%v/packages?search=%v&distribution=%v&architecture=%v&offset=%v&limit=%v",
-				RoutePrefix(), h.server.spec.Info.Version, params.Search, params.Distribution, params.Architecture, offset, limit),
-			fmt.Sprintf("%v/v%v/packages?search=%v&distribution=%v&architecture=%v&offset=%v&limit=%v",
-				RoutePrefix(), h.server.spec.Info.Version, params.Search, params.Distribution, params.Architecture, len(packages)-1, limit),
+				RoutePrefix(), h.server.spec.Info.Version, params.Search, params.Distribution, params.Architecture, lastOffset, limit),
 		},
 		Data: packages[offset:upto],
 	})
@@ -380,8 +385,8 @@ func (h *Handlers) GetComposes(ctx echo.Context, params GetComposesParams) error
 			First string `json:"first"`
 			Last  string `json:"last"`
 		}{
-			fmt.Sprintf("%v/v%v/composes?offset=%v&limit=%v",
-				RoutePrefix(), spec.Info.Version, offset, limit),
+			fmt.Sprintf("%v/v%v/composes?offset=0&limit=%v",
+				RoutePrefix(), spec.Info.Version, limit),
 			fmt.Sprintf("%v/v%v/composes?offset=%v&limit=%v",
 				RoutePrefix(), spec.Info.Version, lastOffset, limit),
 		},

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -219,6 +219,20 @@ func TestWithoutOsbuildComposerBackend(t *testing.T) {
 		p1 := result.Data[0]
 		p2 := result.Data[1]
 
+		response, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=x86_64&search=4e3086991b3f452d82eed1f2122aefeb", &tutils.AuthString0)
+		require.Equal(t, 200, response.StatusCode)
+		err = json.Unmarshal([]byte(body), &result)
+		require.NoError(t, err)
+		require.Empty(t, result.Data)
+
+		response, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/packages?offset=121039&distribution=rhel-8&architecture=x86_64&search=4e3086991b3f452d82eed1f2122aefeb", &tutils.AuthString0)
+		require.Equal(t, 200, response.StatusCode)
+		err = json.Unmarshal([]byte(body), &result)
+		require.NoError(t, err)
+		require.Empty(t, result.Data)
+		require.Equal(t, "/api/image-builder/v1.0/packages?search=4e3086991b3f452d82eed1f2122aefeb&distribution=rhel-8&architecture=x86_64&offset=0&limit=100", result.Links.First)
+		require.Equal(t, "/api/image-builder/v1.0/packages?search=4e3086991b3f452d82eed1f2122aefeb&distribution=rhel-8&architecture=x86_64&offset=0&limit=100", result.Links.Last)
+
 		response, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=x86_64&search=ssh&limit=1", &tutils.AuthString0)
 		require.Equal(t, 200, response.StatusCode)
 		err = json.Unmarshal([]byte(body), &result)


### PR DESCRIPTION
 internal/v1: correctly deal with offsets in GetPackages
    
If the offset was 0, which is the default, and if no packages were
found, it panicked due to an out of bounds index.
    
The reasoning by subtracting one was that even if you chose too large of
an offset, it would still give you back something. Simply cap the offset
in case it's larger than the amount of packages. The data returned will
be empty but that's ok.
    
Also cap the last offset at 0 if no results were found.
