### PR TITLE
internal/v1: ISO8601 datetime

### DIFF
--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -363,7 +363,7 @@ func (h *Handlers) GetComposes(ctx echo.Context, params GetComposesParams) error
 	var data []ComposesResponseItem
 	for _, c := range composes {
 		data = append(data, ComposesResponseItem{
-			CreatedAt: c.CreatedAt.String(),
+			CreatedAt: c.CreatedAt.Format(time.RFC3339),
 			Id:        c.Id.String(),
 			ImageName: c.ImageName,
 			Request:   c.Request,
@@ -881,7 +881,7 @@ func (h *Handlers) GetComposeClones(ctx echo.Context, composeId string, params G
 		data = append(data, ClonesResponseItem{
 			Id:        c.Id.String(),
 			Request:   c.Request,
-			CreatedAt: c.CreatedAt.String(),
+			CreatedAt: c.CreatedAt.Format(time.RFC3339),
 		})
 	}
 

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -535,7 +535,7 @@ func TestGetComposes(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 3, result.Meta.Count)
-	require.Equal(t, composeEntry.CreatedAt.String(), result.Data[0].CreatedAt)
+	require.Equal(t, composeEntry.CreatedAt.Format(time.RFC3339), result.Data[0].CreatedAt)
 	require.Equal(t, UUIDTest, result.Data[0].Id)
 }
 


### PR DESCRIPTION
Return an ISO8601 compliant datetime to facilitate easier parsing and comparison in the frontend.

Addresses #457
