### PR TITLE
openshift-startup: remove obsolete condition

### DIFF
--- a/distribution/openshift-startup.sh
+++ b/distribution/openshift-startup.sh
@@ -4,11 +4,6 @@ set -euo pipefail
 if [[ -z "${KUBERNETES_PORT:-}" ]]; then
     echo "Starting image-builder inside container..."
 # we don't use cloudwatch in ephemeral environment for now
-elif [[ "${CLOWDER_ENABLED:=false}" == "true" ]]; then
-    echo "Starting image-builder inside ephemeral environment..."
-    echo "Composer URL: ${COMPOSER_URL}"
-    echo "Composer token URL: ${COMPOSER_TOKEN_URL}"
-    echo "Distributions dir: ${DISTRIBUTIONS_DIR}"
 else
     echo "Starting image-builder inside OpenShift..."
     echo "Cloudwatch: ${CW_LOG_GROUP} in ${CW_AWS_REGION}"


### PR DESCRIPTION
We are now using the same template for crc and ephemeral.