### PR TITLE
Revert "templates: move to ClowdApp for main deployment"

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -1,129 +1,190 @@
----
-apiVersion: template.openshift.io/v1
+apiVersion: v1
 kind: Template
+labels:
+  app: image-builder
+  template: image-builder
 metadata:
+  annotations:
+    description: Backend service for image-builder in console.redhat.com
   name: image-builder
 objects:
-- apiVersion: cloud.redhat.com/v1alpha1
-  kind: ClowdApp
+
+# Deploy the image-builder container.
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
+    labels:
+      service: image-builder
     name: image-builder
   spec:
-    envName: ${ENV_NAME}
-    testing:
-      iqePlugin: image-builder
-    deployments:
-    - name: service
-      replicas: ${{REPLICAS}}
-      podSpec:
-        image: ${IMAGE}:${IMAGE_TAG}
-        resources:
-          requests:
-            cpu: ${CPU_REQUEST}
-            memory: ${MEMORY_REQUEST}
-          limits:
-            cpu: ${CPU_LIMIT}
-            memory: ${MEMORY_LIMIT}
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: ${LIVENESS_URI}
-            port: 8000
-            scheme: HTTP
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 10
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: ${READINESS_URI}
-            port: 8000
-            scheme: HTTP
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 10
-        env:
-          - name: LISTEN_ADDRESS
-            value: ${LISTEN_ADDRESS}
-          - name: COMPOSER_TOKEN_URL
-            value: "${COMPOSER_TOKEN_URL}"
-          - name: DISTRIBUTIONS_DIR
-            value: '/app/distributions'
-          - name: QUOTA_FILE
-            value: "${QUOTA_FILE}"
-          - name: ALLOW_FILE
-            value: "${ALLOW_FILE}"
-          - name: CLOWDER_ENABLED
-            value: ${CLOWDER_ENABLED}
-          - name: OSBUILD_AWS_REGION
-            value: "${OSBUILD_AWS_REGION}"
-          - name: OSBUILD_GCP_REGION
-            value: "${OSBUILD_GCP_REGION}"
-          - name: OSBUILD_GCP_BUCKET
-            value: "${OSBUILD_GCP_BUCKET}"
-          - name: PGSSLMODE
-            value: "${PGSSLMODE}"
-          # Configuration for the osbuild client within image-builder
-          - name: COMPOSER_URL
-            value: "${COMPOSER_URL}"
-          - name: COMPOSER_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                key: client_id
-                name: composer-secrets
-          - name: COMPOSER_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                key: client_secret
-                name: composer-secrets
-          # Credentials/configuration for AWS cloudwatch.
-          - name: CW_AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                key: aws_access_key_id
-                name: image-builder-cloudwatch
-                optional: true
-          - name: CW_AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                key: aws_secret_access_key
-                name: image-builder-cloudwatch
-                optional: true
-          - name: CW_LOG_GROUP
-            valueFrom:
-              secretKeyRef:
-                key: log_group_name
-                name: image-builder-cloudwatch
-                optional: true
-          - name: CW_AWS_REGION
-            valueFrom:
-              secretKeyRef:
-                key: aws_region
-                name: image-builder-cloudwatch
-                optional: true
-          # Splunk forwarding
-          - name: SPLUNK_HEC_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: splunk
-                key: token
-                optional: true
-          - name: SPLUNK_HEC_HOST
-            valueFrom:
-              secretKeyRef:
-                name: splunk
-                key: url
-                optional: true
-          - name: SPLUNK_HEC_PORT
-            value: "${SPLUNK_HEC_PORT}"
-        volumeMounts:
-          - name: config-volume
-            mountPath: /app/config
+    replicas: 3
+    selector:
+      matchLabels:
+        name: image-builder
+    strategy:
+      # Update pods 1 at a time
+      type: RollingUpdate
+      rollingUpdate:
+        # Create at most 1 extra pod over .spec.replicas
+        maxSurge: 1
+        # At all times there should be .spec.replicas available
+        maxUnavailable: 0
+    template:
+      metadata:
+        labels:
+          name: image-builder
+      spec:
+        serviceAccountName: image-builder
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    name: image-builder
+                topologyKey: kubernetes.io/hostname
+        containers:
+        - image: "${IMAGE_NAME}:${IMAGE_TAG}"
+          name: image-builder
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: ${LIVENESS_URI}
+              port: 8086
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: ${READINESS_URI}
+              port: 8086
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10 # The readiness probe is pinging osbuild-composer
+          resources:
+            requests:
+              cpu: "${CPU_REQUEST}"
+              memory: "${MEMORY_REQUEST}"
+            limits:
+              cpu: "${CPU_LIMIT}"
+              memory: "${MEMORY_LIMIT}"
+          ports:
+          - name: api
+            containerPort: 8086
+            protocol: TCP
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/config
+          env:
+            - name: LISTEN_ADDRESS
+              value: "${LISTEN_ADDRESS}"
+            # Credentials/configuration for AWS RDS.
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: image-builder-db
+                  key: db.host
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: image-builder-db
+                  key: db.port
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: image-builder-db
+                  key: db.name
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: image-builder-db
+                  key: db.user
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: image-builder-db
+                  key: db.password
+            - name: PGSSLMODE
+              value: "${PGSSLMODE}"
+            # Configuration for the osbuild client within image-builder
+            - name: COMPOSER_URL
+              value: "${COMPOSER_URL}"
+            - name: COMPOSER_TOKEN_URL
+              value: "${COMPOSER_TOKEN_URL}"
+            - name: COMPOSER_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: client_id
+                  name: composer-secrets
+            - name: COMPOSER_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: client_secret
+                  name: composer-secrets
+            # Credentials/configuration for AWS cloudwatch.
+            - name: CW_AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws_access_key_id
+                  name: image-builder-cloudwatch
+            - name: CW_AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws_secret_access_key
+                  name: image-builder-cloudwatch
+            - name: CW_LOG_GROUP
+              valueFrom:
+                secretKeyRef:
+                  key: log_group_name
+                  name: image-builder-cloudwatch
+            - name: CW_AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: aws_region
+                  name: image-builder-cloudwatch
+            # Secrets used to tell osbuild-composer where to upload images.
+            - name: OSBUILD_AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: aws_region
+                  name: composer-secrets
+            # GCP target specific variables passed to composer
+            - name: OSBUILD_GCP_REGION
+              value: "${OSBUILD_GCP_REGION}"
+            - name: OSBUILD_GCP_BUCKET
+              value: "${OSBUILD_GCP_BUCKET}"
+            - name: ALLOWED_ORG_IDS
+              value: "${ALLOWED_ORG_IDS}"
+            - name: ALLOWED_ACCOUNT_NUMBERS
+              value: "${ALLOWED_ACCOUNT_NUMBERS}"
+            - name: DISTRIBUTIONS_DIR
+              value: "${DISTRIBUTIONS_DIR}"
+            - name: QUOTA_FILE
+              value: "/app/config/quotas.json"
+            - name: ALLOW_FILE
+              value: "/app/config/allow_list.json"
+            - name: SPLUNK_HEC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: splunk
+                  key: token
+                  optional: false
+            - name: SPLUNK_HEC_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: splunk
+                  key: url
+                  optional: false
+            - name: SPLUNK_HEC_PORT
+              value: "${SPLUNK_HEC_PORT}"
         volumes:
           - name: config-volume
             configMap:
               name: image-builder-crc-config-files
-              optional: true
               items:
               - key: quotas.json
                 path: quotas.json
@@ -131,23 +192,92 @@ objects:
                 path: allow_list.json
         initContainers:
         - name: image-builder-migrate
-          image: ${IMAGE}:${IMAGE_TAG}
+          image: "${IMAGE_NAME}:${IMAGE_TAG}"
           command: [ "/app/image-builder-migrate-db-tern" ]
           resources:
             requests:
-              cpu: ${CPU_REQUEST}
-              memory: ${MEMORY_REQUEST}
+              cpu: "${CPU_REQUEST}"
+              memory: "${MEMORY_REQUEST}"
             limits:
-              cpu: ${CPU_LIMIT}
-              memory: ${MEMORY_LIMIT}
-      webServices:
-        public:
-          enabled: true
-          apiPath: image-builder
+              cpu: "${CPU_LIMIT}"
+              memory: "${MEMORY_LIMIT}"
+          env:
+          # Credentials/configuration for AWS RDS.
+          - name: PGHOST
+            valueFrom:
+              secretKeyRef:
+                name: image-builder-db
+                key: db.host
+          - name: PGPORT
+            valueFrom:
+              secretKeyRef:
+                name: image-builder-db
+                key: db.port
+          - name: PGDATABASE
+            valueFrom:
+              secretKeyRef:
+                name: image-builder-db
+                key: db.name
+          - name: PGUSER
+            valueFrom:
+              secretKeyRef:
+                name: image-builder-db
+                key: db.user
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: image-builder-db
+                key: db.password
+          - name: PGSSLMODE
+            value: "${PGSSLMODE}"
+          # Credentials/configuration for AWS cloudwatch.
+          - name: CW_AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: aws_access_key_id
+                name: image-builder-cloudwatch
+          - name: CW_AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: aws_secret_access_key
+                name: image-builder-cloudwatch
+          - name: CW_LOG_GROUP
+            valueFrom:
+              secretKeyRef:
+                key: log_group_name
+                name: image-builder-cloudwatch
+          - name: CW_AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                key: aws_region
+                name: image-builder-cloudwatch
 
-    database:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: image-builder
+  imagePullSecrets:
+  - name: quay-cloudservices-pull
+  - name: quay.io
+
+# Set up a service within the namespace for the backend.
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      service: image-builder
+    name: image-builder
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/scrape: 'true'
+  spec:
+    ports:
+      - name: image-builder
+        protocol: TCP
+        port: ${{BACKEND_LISTENER_PORT}}
+        targetPort: 8086
+    selector:
       name: image-builder
-      version: 12
 
 - apiVersion: metrics.console.redhat.com/v1alpha1
   kind: FloorPlan
@@ -174,45 +304,68 @@ objects:
         from
           composes,jsonb_array_elements(composes.request->'image_requests') as req;
 
+# Parameters for the various configurations shown above.
 parameters:
-  - name: IMAGE
+  - description: image-builder image name
+    name: IMAGE_NAME
     value: quay.io/cloudservices/image-builder
     required: true
-  - name: IMAGE_TAG
+  - description: image-builder image tag
+    name: IMAGE_TAG
     required: true
+  # NOTE(mhayden): This is set to match the ports set up in RHIOPS-953.
+  - description: Backend listener port
+    name: BACKEND_LISTENER_PORT
+    value: "8080"
   - name: LIVENESS_URI
+    description: URI to query for the liveness check
     value: "/status"
   - name: READINESS_URI
+    description: URI to query for the readiness check
     value: "/ready"
   - name: LISTEN_ADDRESS
-    value: "0.0.0.0:8000"
-  - description: Determines Clowder deployment
-    name: CLOWDER_ENABLED
-    value: "true"
-  - description: ClowdEnv Name
-    name: ENV_NAME
+    description: Listening address and port
+    value: "0.0.0.0:8086"
   - name: COMPOSER_URL
-    value: "https://api.stage.openshift.com"
+    description: Url to osbuild-composer instance in AWS
+    value: ""
   - name: COMPOSER_TOKEN_URL
+    description: OpenId token endpoint
     value: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+  - name: ALLOWED_ORG_IDS
+    description: Organization ids allowed to access the api, wildcard means everyone
+    value: ""
+  - name: ALLOWED_ACCOUNT_NUMBERS
+    description: Account numbers allowed to access the api, wildcard means everyone
+    value: ""
+  - name: DISTRIBUTIONS_DIR
+    description: Directory which contains json files detailing available distributions, their repositories, and their packages
+    value: "/app/distributions"
+  - name: OSBUILD_GCP_REGION
+    description: Region in GCP to upload to
+    value: "us-east4"
+  - name: OSBUILD_GCP_BUCKET
+    description: Bucket in GCP to upload to
+    value: "image-upload-bkt-us"
+  - name: PGSSLMODE
+    description: Sslmode for the connection to psql
+    value: "require"
   - name: CPU_REQUEST
     description: CPU request per container
-    value: 200m
+    value: "200m"
   - name: CPU_LIMIT
     description: CPU limit per container
-    value: 1000m
+    value: "1"
   - name: MEMORY_REQUEST
     description: Memory request per container
-    value: 256Mi
+    value: "256Mi"
   - name: MEMORY_LIMIT
     description: Memory limit per container
-    value: 512Mi
-  - name: OSBUILD_AWS_REGION
-    description: default region which is used for s3 and ec2 images
-    value: "us-east-1"
-  - name: REPLICAS
-    description: pod replicas
-    value: "3"
+    value: "512Mi"
+  - description: fluentd-hec splunk port
+    name: SPLUNK_HEC_PORT
+    value: "443"
+    required: true
   - name: FLOORIST_LOGLEVEL
     description: Floorist loglevel config
     value: 'INFO'
@@ -228,19 +381,3 @@ parameters:
   - name: FLOORIST_QUERY_PREFIX
     description: Prefix for separating query data between prod and stage in the bucket
     value: "image-builder"
-  - description: fluentd-hec splunk port
-    name: SPLUNK_HEC_PORT
-    value: "443"
-  - name: OSBUILD_GCP_REGION
-    description: Region in GCP to upload to
-    value: "us-east4"
-  - name: OSBUILD_GCP_BUCKET
-    description: Bucket in GCP to upload to
-    value: "image-upload-bkt-us"
-  - name: PGSSLMODE
-    description: Sslmode for the connection to psql
-    value: "prefer"
-  - name: QUOTA_FILE
-    value: ""
-  - name: ALLOW_FILE
-    value: ""


### PR DESCRIPTION
Reverts osbuild/image-builder#541

---

Clowder expects the cloudwatch secret to be set as "cloudwatch", we do not need to map the variables ourselves.