### PR TITLE
Fix new issues reported by ShellCheck 0.9.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,8 +68,9 @@ jobs:
       with:
         ignore: vendor # We don't want to fix the code in vendored dependencies
       env:
-        SHELLCHECK_OPTS: -e SC1091 -e SC2002 # don't check /etc/os-release sourcing and allow useless cats to live inside our codebase
-
+        # don't check /etc/os-release sourcing and allow useless cats to live inside our codebase
+        # allow seemingly unreachable commands
+        SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317
   db-test:
     name: "🗄 DB check"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add ignore rules for cleanup functions called by trap because shellcheck can't distinguish that. Inspired by commit from Alex in osbuild-composer.