### PR TITLE
templates: add openshift service object again

### DIFF
--- a/templates/image-builder-clowder.yml
+++ b/templates/image-builder-clowder.yml
@@ -149,6 +149,24 @@ objects:
         from
           composes,jsonb_array_elements(composes.request->'image_requests') as req;
 
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      service: image-builder
+    name: image-builder
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/scrape: 'true'
+  spec:
+    ports:
+      - name: image-builder
+        protocol: TCP
+        port: 8080
+        targetPort: 8000
+    selector:
+      name: image-builder
+
 parameters:
   - name: IMAGE
     value: quay.io/cloudservices/image-builder

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -149,6 +149,24 @@ objects:
         from
           composes,jsonb_array_elements(composes.request->'image_requests') as req;
 
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      service: image-builder
+    name: image-builder
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/scrape: 'true'
+  spec:
+    ports:
+      - name: image-builder
+        protocol: TCP
+        port: 8080
+        targetPort: 8000
+    selector:
+      name: image-builder
+
 parameters:
   - name: IMAGE
     value: quay.io/cloudservices/image-builder


### PR DESCRIPTION
Clowder webServices creates a service on port 8000, but the gateway has image-builder routed to 8080. Readd the old service object for now.