### PR TITLE
templates: fix service pod selector

### DIFF
--- a/templates/image-builder-clowder.yml
+++ b/templates/image-builder-clowder.yml
@@ -165,7 +165,8 @@ objects:
         port: 8080
         targetPort: 8000
     selector:
-      name: image-builder
+      app: image-builder
+      pod: image-builder-service
 
 parameters:
   - name: IMAGE

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -165,7 +165,8 @@ objects:
         port: 8080
         targetPort: 8000
     selector:
-      name: image-builder
+      app: image-builder
+      pod: image-builder-service
 
 parameters:
   - name: IMAGE


### PR DESCRIPTION
The pods generated by ClowdApp only has the 'app' and 'pod' labels.