### PR TITLE
templates: make service selector less strict

### DIFF
--- a/templates/image-builder-clowder.yml
+++ b/templates/image-builder-clowder.yml
@@ -165,7 +165,6 @@ objects:
         port: 8080
         targetPort: 8000
     selector:
-      app: image-builder
       pod: image-builder-service
 
 parameters:

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -165,7 +165,6 @@ objects:
         port: 8080
         targetPort: 8000
     selector:
-      app: image-builder
       pod: image-builder-service
 
 parameters:


### PR DESCRIPTION
The app and pod labels are set by Clowder when deploying the ClowdApp. While these shouldn't change, let's minimize the chance of breakage in case they do, and mimic other service's selector by only leaving the pod selector.