### PR TITLE
.github/workflows: use go 1.18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,10 @@ jobs:
             exit "0"
           fi
 
-      - name: Install golangci-lint
-        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.30.0
-
-      - name: Run golangci-lint
-        run: $(go env GOPATH)/bin/golangci-lint run --timeout 5m0s
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1
 
       - name: Run unit tests
         run: go test -v -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3.4.0
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
 
       - name: Check out code into the Go module directory
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/checkout@v3.0.2
     - uses: actions/setup-go@v3.4.0
       with:
-        go-version: 1.17
+        go-version: 1.18
     - env:
         MIGRATIONS_DIR: internal/db/migrations
         TERN_MIGRATIONS_DIR: internal/db/migrations-tern

--- a/internal/common/quota.go
+++ b/internal/common/quota.go
@@ -3,7 +3,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -58,7 +58,7 @@ func CheckQuota(orgID string, dB db.DB, quotaFile string) (bool, error) {
 	if _, ok := err.(*os.PathError); ok {
 		return false, fmt.Errorf("No config file for quotas found at %s\n", quotaFile)
 	} else {
-		rawJsonFile, err := ioutil.ReadAll(jsonFile)
+		rawJsonFile, err := io.ReadAll(jsonFile)
 		if err != nil {
 			return false, fmt.Errorf("Failed to read quota file %q: %s", quotaFile, err.Error())
 		}

--- a/internal/composer/client.go
+++ b/internal/composer/client.go
@@ -9,9 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -79,7 +79,7 @@ func createClient(composerURL string, ca string) (*http.Client, error) {
 	}
 
 	var tlsConfig *tls.Config
-	caCert, err := ioutil.ReadFile(filepath.Clean(ca))
+	caCert, err := os.ReadFile(filepath.Clean(ca))
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,6 @@ func createClient(composerURL string, ca string) (*http.Client, error) {
 		RootCAs:    caCertPool,
 	}
 
-	tlsConfig.BuildNameToCertificate()
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	return &http.Client{Transport: transport}, nil
 }

--- a/internal/distribution/distribution.go
+++ b/internal/distribution/distribution.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -137,7 +136,7 @@ func (arch Architecture) validate() error {
 }
 
 func allDistributions(distsDir string) ([]string, error) {
-	files, err := ioutil.ReadDir(distsDir)
+	files, err := os.ReadDir(distsDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tutils/tutils.go
+++ b/internal/tutils/tutils.go
@@ -3,7 +3,7 @@ package tutils
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -44,7 +44,7 @@ func GetResponseBody(t *testing.T, url string, auth *string) (*http.Response, st
 	response, err := client.Do(request)
 	require.NoError(t, err)
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	require.NoError(t, err)
 
 	err = response.Body.Close()
@@ -66,7 +66,7 @@ func PostResponseBody(t *testing.T, url string, compose interface{}) (*http.Resp
 	response, err := client.Do(request)
 	require.NoError(t, err)
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	require.NoError(t, err)
 
 	err = response.Body.Close()

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -35,7 +35,7 @@ func (h *Handlers) GetReadiness(ctx echo.Context) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -172,15 +172,15 @@ func (h *Handlers) GetComposeStatus(ctx echo.Context, composeId string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
 		// Composes can get deleted in composer, usually when the image is expired
-		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("%s", body))
+		return echo.NewHTTPError(http.StatusNotFound, string(body))
 	} else if resp.StatusCode != http.StatusOK {
 		httpError := echo.NewHTTPError(http.StatusInternalServerError, "Failed querying compose status")
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			logrus.Errorf("Unable to parse composer's compose response: %v", err)
 		} else {
@@ -277,14 +277,14 @@ func (h *Handlers) GetComposeMetadata(ctx echo.Context, composeId string) error 
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
-		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("%s", body))
+		return echo.NewHTTPError(http.StatusNotFound, string(body))
 	} else if resp.StatusCode != http.StatusOK {
 		httpError := echo.NewHTTPError(http.StatusInternalServerError, "Failed querying compose status")
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			logrus.Errorf("Unable to parse composer's compose response: %v", err)
 		} else {
@@ -496,7 +496,7 @@ func (h *Handlers) ComposeImage(ctx echo.Context) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		httpError := echo.NewHTTPError(http.StatusInternalServerError, "Failed posting compose request to osbuild-composer")
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			logrus.Errorf("Unable to parse composer's compose response: %v", err)
 		} else {

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,7 +39,7 @@ func initQuotaFile(t *testing.T) (string, error) {
 	}
 
 	// get a temp file to store the quotas
-	file, err := ioutil.TempFile(t.TempDir(), "account_quotas.*.json")
+	file, err := os.CreateTemp(t.TempDir(), "account_quotas.*.json")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
tools/prepare-source uses go 1.18 as well, and the ubi9 container has go 1.18.