### PR TITLE
internal/db: drop account_number_constraint

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -95,7 +95,7 @@ func testInsertCompose(t *testing.T) {
 	err = d.InsertCompose("toto", ANR1, ORGID1, &imageName, []byte("{}"))
 	require.Error(t, err)
 	err = d.InsertCompose(uuid.New().String(), "", ORGID1, &imageName, []byte("{}"))
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 func testGetCompose(t *testing.T) {

--- a/internal/db/migrations-tern/003_drop_account_number_constraint.sql
+++ b/internal/db/migrations-tern/003_drop_account_number_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE composes DROP CONSTRAINT account_number_constraint;


### PR DESCRIPTION
The account number is no longer required for RHEL entitlement by the platform, so it's allowed to be empty.
