### PR TITLE
.github/workflows/spec-update: set pull request token and author

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -26,3 +26,5 @@ jobs:
           title: "internal/composer: update api spec"
           commit-message: "internal/composer: update api spec"
           body: Composer api spec update.
+          token: ${{ secrets.UPDATE_API_SPEC_TOKEN }}
+          author: schutzbot <schutzbot@gmail.com>


### PR DESCRIPTION
The default token can't be used if we want github actions to run, see https://github.com/peter-evans/create-pull-request#action-inputs.

Set the author to schutzbot as well.