### PR TITLE
v1: fix nil pointer dereference in compose handler

### DIFF
--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -625,7 +625,7 @@ func (h *Handlers) buildUploadOptions(ctx echo.Context, ur UploadRequest, it Ima
 				}
 
 				if aID.Aws == nil || aID.Aws.AccountId == nil || len(*aID.Aws.AccountId) != 12 {
-					return nil, "", echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unable to resolve source %s to an aws account id: %v", source, aID.Aws.AccountId))
+					return nil, "", echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unable to resolve source %s to an aws account id", source))
 				}
 
 				ctx.Logger().Info(fmt.Sprintf("Resolved source %s, to account id %s", strings.Replace(source, "\n", "", -1), *aID.Aws.AccountId))


### PR DESCRIPTION
In this case the response from sources is empty anyway, so let's just leave it out.