### PR TITLE
pr_check: add other hms apps to deployment

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -12,6 +12,7 @@ export IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to compl
 export IQE_MARKER_EXPRESSION="api" # run only api test
 export IQE_ENV="ephemeral" # run only api test
 export DOCKERFILE="distribution/Dockerfile-ubi"
+export EXTRA_DEPLOY_ARGS="provisioning sources content-sources"
 
 # Install bonfire repo/initialize
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bootstrap.sh


### PR DESCRIPTION
We now have tests that integrate with other hms apps so we need to deploy them in the ephemeral environment too.