### PR TITLE
distribution/Dockerfile-ubi: pin go toolset to go 1.18.10

### DIFF
--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -1,6 +1,8 @@
 # Use a builder container to build the Go application (which we extract in
 # the second container).
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+# TODO latest go toolset (1.19) is broken
+# FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.10 AS builder
 WORKDIR $GOPATH/go/src/github.com/osbuild/image-builder
 COPY . .
 ENV GOFLAGS=-mod=vendor

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-GO_VERSION=1.18.4
+GO_VERSION=1.18.10
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
The latest 1.19 toolset breaks with:
```
RUN go install ./...
    error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
    error obtaining VCS status: exit status 128
    	Use -buildvcs=false to disable VCS stamping.
```