### PR TITLE
Dockerfile-ubi: chown the copied files and unpin go 

### DIFF
--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -1,10 +1,11 @@
 # Use a builder container to build the Go application (which we extract in
 # the second container).
-# TODO latest go toolset (1.19) is broken
-# FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
-FROM registry.access.redhat.com/ubi9/go-toolset:1.18.10 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 WORKDIR $GOPATH/go/src/github.com/osbuild/image-builder
-COPY . .
+# ubi9/go-toolset defaults to uid 1001. Let's copy the files with this UID as well.
+# Otherwise, VCS stamping will fail because git >= 2.35.2 refuses to work in
+# a repository owned by a different user.
+COPY --chown=1001 . .
 ENV GOFLAGS=-mod=vendor
 RUN go install ./...
 


### PR DESCRIPTION
When `go install` is called, go tries to get the git commit hash and embed it
into the built binary. Internally, go just calls the git executable.

The newer go-toolset seems to be based on RHEL 9.2 that ships a newer version
of git (2.39.1). This version contains the safe directory patch that
disallows git from operating on repositories owned by different users.

Thus, we need to chown the files when copying.

See

https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory