### PR TITLE
prometheus status middleware

### DIFF
--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -1,4 +1,4 @@
-package common
+package prometheus
 
 import (
 	"strings"


### PR DESCRIPTION
This mw should replace the compose request errors. We use this in favour of the gateway metrics because the gateway metrics don't include the path label.