### PR TITLE
dashboards: fix latency graph colours

### DIFF
--- a/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
@@ -871,6 +871,6 @@ data:
       "timezone": "",
       "title": "Image Builder CRC",
       "uid": "image-builder-crc",
-      "version": 10,
+      "version": 11,
       "weekStart": ""
     }

--- a/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
@@ -160,7 +160,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum by (path) (rate(image_builder_crc_request_count{status!~\"5.*\"}[$__rate_interval]))",
+              "expr": "sum by (path) (rate(image_builder_crc_request_count{code!~\"5.*\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{path}}  success/sec",
               "range": true,

--- a/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml
@@ -191,7 +191,7 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "continuous-BlYlRd"
+                "mode": "thresholds"
               },
               "custom": {
                 "axisCenteredZero": false,


### PR DESCRIPTION
The continuous colour mode doesn't take into account the thresholds. Meaning the peaks will always be red, even if they're within the SLO target.