### PR TITLE
update to go 1.19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.18
+      - name: Set up Go 1.19
         uses: actions/setup-go@v4.0.1
         with:
-          go-version: 1.18
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/checkout@v3.0.2
     - uses: actions/setup-go@v4.0.1
       with:
-        go-version: 1.18
+        go-version: 1.19
     - env:
         MIGRATIONS_DIR: internal/db/migrations
         TERN_MIGRATIONS_DIR: internal/db/migrations-tern

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/image-builder
 
-go 1.18
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.44.299

--- a/internal/common/allow.go
+++ b/internal/common/allow.go
@@ -17,11 +17,12 @@ type AllowList map[string][]string
 // string is given as the argument, returns an empty AllowList.
 //
 // The allow file must conform to the following json schema:
-// {
-// 	"000000": ["fedora-*"]
-//  "000001": ["fedora-34", "fedora-35", "fedora-36"]
-//  "000002": []
-// }
+//
+//	{
+//		"000000": ["fedora-*"]
+//	 "000001": ["fedora-34", "fedora-35", "fedora-36"]
+//	 "000002": []
+//	}
 func LoadAllowList(allowFile string) (AllowList, error) {
 	if allowFile == "" {
 		return AllowList{}, nil

--- a/internal/common/quota.go
+++ b/internal/common/quota.go
@@ -20,20 +20,20 @@ const (
 
 // the QUOTA_FILE needs to contain data arranged as such:
 //
-// {
-//     "000000":{
-//         "quota":2,
-//         "slidingWindow":1209600000000000
-//     },
-//     "000001":{
-//         "quota":0,
-//         "slidingWindow":1209600000000000
-//     },
-//     "default":{
-//         "quota":100,
-//         "slidingWindow":1209600000000000
-//     }
-// }
+//	{
+//	    "000000":{
+//	        "quota":2,
+//	        "slidingWindow":1209600000000000
+//	    },
+//	    "000001":{
+//	        "quota":0,
+//	        "slidingWindow":1209600000000000
+//	    },
+//	    "default":{
+//	        "quota":100,
+//	        "slidingWindow":1209600000000000
+//	    }
+//	}
 //
 // The unit for the sliding window is the nanosecond.
 type Quota struct {

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-GO_VERSION=1.18.10
+GO_VERSION=1.19.11
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
UBI and the oldest support Fedora (37) now all have go 1.19, so we are cleared to switch.

gofmt now reformats comments in certain cases, so that explains the formatting changes in this commit.
See https://go.dev/doc/go1.19#go-doc