### PR TITLE
handler: allow using the user customization everywhere

### DIFF
--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/internal/composer"
 	"github.com/osbuild/image-builder/internal/db"
@@ -802,10 +803,6 @@ func validateCustomizations(cr *ComposeRequest) error {
 		return nil
 	}
 	it := cr.ImageRequests[0].ImageType
-
-	if cust.Users != nil && !strings.Contains(string(it), "installer") {
-		return echo.NewHTTPError(http.StatusBadRequest, "User customization only applies to installer image types")
-	}
 
 	if cust.Filesystem != nil {
 		var totalSize uint64

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -808,44 +808,6 @@ func TestComposeImage(t *testing.T) {
 		require.Contains(t, body, "Error at \\\"/image_requests/0/architecture\\\"")
 	})
 
-	t.Run("ErrorUserCustomizationNotAllowed", func(t *testing.T) {
-		// User customization only permitted for installer types
-		payload := ComposeRequest{
-			Customizations: &Customizations{
-				Packages: &[]string{
-					"some",
-					"packages",
-				},
-				Users: &[]User{
-					{
-						Name:   "user-name0",
-						SshKey: "",
-					},
-					{
-						Name:   "user-name1",
-						SshKey: "",
-					},
-				},
-			},
-			Distribution: "centos-8",
-			ImageRequests: []ImageRequest{
-				{
-					Architecture: "x86_64",
-					ImageType:    ImageTypesAmi,
-					UploadRequest: UploadRequest{
-						Type: UploadTypesAws,
-						Options: AWSUploadRequestOptions{
-							ShareWithAccounts: &[]string{"test-account"},
-						},
-					},
-				},
-			},
-		}
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
-		require.Equal(t, 400, respStatusCode)
-		require.Contains(t, body, "User customization only applies to installer image types")
-	})
-
 	t.Run("ErrorsForUnknownUploadType", func(t *testing.T) {
 		// UploadRequest Type isn't supported
 		payload := ComposeRequest{


### PR DESCRIPTION
I believe there's no reason not to expose the customization for all image types. We actually strive to achieve a functional parity between the hosted service and on-premise IB, so this feels like a low-hanging fruit.

https://issues.redhat.com/browse/HMS-2211