### PR TITLE
Increase memory limit for selenium test container

### DIFF
--- a/templates/iqe-trigger-integration.yml
+++ b/templates/iqe-trigger-integration.yml
@@ -95,7 +95,7 @@ objects:
           resources:
             limits:
               cpu: 500m
-              memory: 1.5Gi
+              memory: 2Gi
             requests:
               cpu: 100m
               memory: 256Mi


### PR DESCRIPTION
We are seeing some OOM errors during browser log collection. I'm hoping that increasing the limit will resolve this.