### PR TITLE
v1: classify composer's 24 and 29 errors as 400

### DIFF
--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -586,6 +586,16 @@ func (h *Handlers) ComposeImage(ctx echo.Context) error {
 				httpError.Message = "Error resolving OSTree repo"
 				httpError.Code = http.StatusBadRequest
 			}
+			// missing baseurl in payload repository
+			if serviceStat.Id == "24" {
+				httpError.Message = serviceStat.Reason
+				httpError.Code = http.StatusBadRequest
+			}
+			// gpg key not set when check_gpg is true
+			if serviceStat.Id == "29" {
+				httpError.Message = serviceStat.Reason
+				httpError.Code = http.StatusBadRequest
+			}
 		}
 		return httpError
 	}


### PR DESCRIPTION
These errors are due to missing information in the compose request.