### PR TITLE
templates: add TEST_TYPE parameter to testing job name

### DIFF
--- a/templates/iqe-trigger-integration.yml
+++ b/templates/iqe-trigger-integration.yml
@@ -7,7 +7,7 @@ objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    name: image-builder-e2e-${IMAGE_TAG}-${UID}
+    name: image-builder-e2e-${TEST_TYPE}-${IMAGE_TAG}-${UID}
     annotations:
       "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
       "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
@@ -23,7 +23,7 @@ objects:
           emptyDir:
             medium: Memory
         containers:
-        - name: image-builder-e2e-iqe-${IMAGE_TAG}-${UID}
+        - name: image-builder-e2e-iqe-${TEST_TYPE}-${IMAGE_TAG}-${UID}
           image: ${IQE_IMAGE}
           imagePullPolicy: Always
           args:
@@ -90,7 +90,7 @@ objects:
               memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-        - name: image-builder-e2e-sel-${IMAGE_TAG}-${UID}
+        - name: image-builder-e2e-sel-${TEST_TYPE}-${IMAGE_TAG}-${UID}
           image: ${IQE_SEL_IMAGE}
           resources:
             limits:
@@ -137,3 +137,5 @@ parameters:
   value: "1"
 - name: IQE_NETLOG
   value: "1"
+- name: TEST_TYPE
+  value: ''


### PR DESCRIPTION
I want to be able to distinguish between the pods running the service tests or the integration tests. The actual value of the parameter will be set in the corresponding saas files in app-interface.