### PR TITLE
v1: cleanup OpenAPI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Image Builder is intended to be run within the
 
 ### OpenAPI spec
 
-The [latest api
-specification](https://github.com/osbuild/image-builder/blob/main/internal/v1/api.yaml).
+The latest OpenAPI specification:
+
+* [raw YAML](https://github.com/osbuild/image-builder/blob/main/internal/v1/api.yaml)
+* [on-line version](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml)
 
 ### Contributing
 

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -327,7 +327,7 @@ type GCPUploadRequestOptions struct {
 	//     the users of that domain. For example, 'google.com' or 'example.com'.
 	//     If not specified, the imported Compute Node image is not shared with any
 	//     account.
-	ShareWithAccounts *[]string `json:"share_with_accounts,omitempty"`
+	ShareWithAccounts []string `json:"share_with_accounts"`
 }
 
 // GCPUploadStatus defines model for GCPUploadStatus.
@@ -494,10 +494,10 @@ type ComposeImageJSONBody = ComposeRequest
 
 // GetComposesParams defines parameters for GetComposes.
 type GetComposesParams struct {
-	// max amount of composes, default 100
+	// Max amount of composes.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 
-	// composes page offset, default 0
+	// Composes page offset.
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 
 	// Filter the composes on image type. The filter is optional and can be specified multiple times.
@@ -545,46 +545,46 @@ type CloneComposeJSONRequestBody = CloneComposeJSONBody
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// get the architectures and their image types available for a given distribution
+	// get architectures for distribution
 	// (GET /architectures/{distribution})
 	GetArchitectures(ctx echo.Context, distribution Distributions) error
-	// get status of a compose clone
+	// get clone status
 	// (GET /clones/{id})
 	GetCloneStatus(ctx echo.Context, id openapi_types.UUID) error
 	// compose image
 	// (POST /compose)
 	ComposeImage(ctx echo.Context) error
-	// get a collection of previous compose requests for the logged in user
+	// get composes
 	// (GET /composes)
 	GetComposes(ctx echo.Context, params GetComposesParams) error
-	// delete a compose
+	// delete compose
 	// (DELETE /composes/{composeId})
 	DeleteCompose(ctx echo.Context, composeId openapi_types.UUID) error
-	// get status of an image compose
+	// get compose status
 	// (GET /composes/{composeId})
 	GetComposeStatus(ctx echo.Context, composeId openapi_types.UUID) error
-	// clone a compose
+	// clone compose
 	// (POST /composes/{composeId}/clone)
 	CloneCompose(ctx echo.Context, composeId openapi_types.UUID) error
-	// get clones of a compose
+	// get compose clones
 	// (GET /composes/{composeId}/clones)
 	GetComposeClones(ctx echo.Context, composeId openapi_types.UUID, params GetComposeClonesParams) error
-	// get metadata of an image compose
+	// get compose metadata
 	// (GET /composes/{composeId}/metadata)
 	GetComposeMetadata(ctx echo.Context, composeId openapi_types.UUID) error
-	// get the distributions available to this user
+	// get distributions
 	// (GET /distributions)
 	GetDistributions(ctx echo.Context) error
-	// get the openapi json specification
+	// get spec
 	// (GET /openapi.json)
 	GetOpenapiJson(ctx echo.Context) error
-
+	// get packages
 	// (GET /packages)
 	GetPackages(ctx echo.Context, params GetPackagesParams) error
-	// return the readiness
+	// return readiness
 	// (GET /ready)
 	GetReadiness(ctx echo.Context) error
-	// get the service version
+	// get version
 	// (GET /version)
 	GetVersion(ctx echo.Context) error
 }
@@ -893,123 +893,124 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x8aXPquLboX1FxT9Xu/cJgZpKqrnMJIQkJZAAyHvbNFbawBbbkSDKE9Mt/fyV5wAYT",
-	"SJ+9+5z76vaH3Q6WlpbWWlqz/EdGp45LCSKCZ47+yHDdQg5Uj82HQbtVatmUIPmny6iLmMBIvWTIxJTI",
-	"JwNxnWFXqD8zTeC/AZAD/80YGQCTEbGEcPlRoWBQnefhguehA98pyevUKfhLFWwoEBeFO47YmYcNVPA4",
-	"JmbOh8hzcA6xDcfYxmKZe6cE8bwlHPs/dEp05AoeDhyRTDYjli7KHGW4YJiYmY9shluQoZcFFtYL1HXq",
-	"BRteQ58AyBhcAjoBzYcBCEaCzgn/2o46zd7mdnRKOLVRuH4O2hj6e1AoozfouDbKHP0jUyyVK9VavXGo",
-	"FUuZH9kMFshR6LpQCMQkqv/1Dy13+OOPYunjb2nbdeBbx59U1LTovdrcGjU49Zjuc3Udg8TSG0skYGYz",
-	"HsGvHgoWFcxDHx/ZDEOvHmbIkCADmfkRzaTjKdKFBNV8GAzKd65NodFHrx7i4lqxJL5w6uiBgMLjm/Lp",
-	"MTsF5zWE5KAt2GzDJbnKFpnah5Ffp+Zfx7TtBNlGbujgBCryh5ymN8pa/bBcr1erh1WjMk6T05UiWU1G",
-	"Xm6BuMgVNyescVCum/1UsJhuYYF04TG1yxTUmW4ll39r1F5qlTRksQNN9CJ/VlMjKq/mvup0UUqbun4A",
-	"GXIpx4KyAI2kHjqGHIH4EDChDAgLARPPEQEGlpDHnlCqlhgAxvaZz8QE4G8MTTJHmf8orPR8IVDyhX64",
-	"wHITw3VCSyolCbC2h13UT1LsM7Q2eJZCvua7x9B+h9THmUAHbdL5CjpI6npJWZ0hKKRql+PzI9LzuABj",
-	"ZGIC5JEDENhIKl9AGSCeM0YsCxAxki+zwSs5yCMGYlynDGUVjxy4BDolAmICKLGXwRQezuHZ2BSeBS5i",
-	"mBo8K2FZS9dChOdHZGghIKiANrARMYUFMAc2drBEXVBQ04BuQQZ1CTmftCuZLibeW0fuL6MsRFdByBzV",
-	"tGzGwST8s5iN2Znf/usfMPfezD1Lc/O37/838ffq8WU0yud+/J/YDz/+9j39wPu668Vk1HM/Z0k4Fqix",
-	"YGEhhtQLxSPALerZBhgj4ClJQMb6hofU0yHpB2DO1IppvoGPETY20emchMgEqAgLCrDAtq3W5T7VJaL2",
-	"3MdNIAKJUBzn3jiCJX2I/IicUECoAC6jc2wgAIPhL9iQbI5PkD8tLESCsZiYAIII0/Wd+qo/bW9JkNt2",
-	"mEB1L0I/bOCWXCkLoM2pnMQ9CY2mblqSyfBpgolue+r11l1WUNVojEt6Do5LlVylUiznDjW9mqsVS2Wt",
-	"hhraIUrXvuF6nzE4YNwemwdDS506MgPozbUhJhxYdDEigoIJJgbAcjcKhlJU4IYyAe2jNZ/RwTqjnE6E",
-	"chkRyXm8AOX4AtQFnqOcgRnSpX4uTDxiQAcRAW2+8TZn0UVO0JxcOufvIoU9EQ0+Y8y6AH6NPVW9jibV",
-	"cS1X1MuTXMWAWg7WSqWcNtZqWql8aNSN+k6bvqYgUu3KSvtv80iSWn+ForPM4UABfo5GDEAaCiouCkyP",
-	"XIESdD3JHP1jh2mLxVQfP1ZguEsJTwmzfIFNnHIk/ckcahyOc8WSUc7BSrWWq5RqtWq1UtE0TctkMxPK",
-	"HCgyRxnPw8bunRqZCBW+HRcDCri3DU8C22bF5QlK4d0EM5+oq40XoIsLiiW5sYdtA7HCvOgvzBH/uzKA",
-	"vxe1kadppRqdTDgSv2tpmsCGPwN0UdtJVX8TwYJpEuQgn57JvasoIua5YyKQidgGeH/cJty1YWqRkNBZ",
-	"n4ebzE73jAMSpGrNu7uV3nQhQ0SAYHjkTikh3ymL2Uzgd71AkRqw+KvvhMJWR3GnXIbHNuUgZOO7XkFN",
-	"YKno54/qIQHDc5EkHuWCIfSiU8fBItXq/GZBbn0PySVFT9FQDk/Znwv1GTTTYoUb/w2wMQ+VtFT4V+37",
-	"fnPfSCCAEW0nLRzYVIE+DWJKEBoGllhB+yZGjAm0OcquC5fHBXXwO4y89k/Zlhz9kc3EI6Bds09iY/kq",
-	"jkuQMa4RekvlI5/E3ifc5VJV2xocblqcAJr0a5Ng4omZdTCB4KWlqML8FHqDurCXgJLQUwkm5cE5nEsR",
-	"cChbe8WBij1QdFgxB7rH5Pm1l8rKc891KROhK72X9Kj9RYcqkXtSccXqj6+mjBJc3qDNj8+E8nOT+ucs",
-	"pA/7c5eDR293kiwA9AXtlTxx6S5LgMAK6AbqbcYoSzHwSEBsy8dI7a4bIQkUcv+87CRZNDiGwE/zL9bA",
-	"/a+H8W/nYaRxaBOZn2L8k6r3T/sGO07X5w6BslCxjNqG4l69AzolE2x6TJkzldrzzWEi5ZcfkaYANoJc",
-	"KJUdOArfxpAjj9nfsuCbg+VJloZf/YUElGz4BlY0Bo7HxYjIWM9FOp5gGb12Jr5p8CE6ALLY66xahTID",
+	"H4sIAAAAAAAC/+x8+3PiOJfov6Jiv6qevuFh3qSrpnYJIQkJ5AHkOfRmhS1sgS05kgwhc/t/vyX5gQ3m",
+	"kfm6Z7+9tfNDj4Olo6Nzjs5b/jOjU8elBBHBM9/+zHDdQg5Uj83HQbtVatmUIPmny6iLmMBIvWTIxJTI",
+	"JwNxnWFXqD8zTeC/AZAD/80YGQCTEbGEcPm3QsGgOs/DBc9DB35QktepU/CXKthQIC4K9xyxcw8bqOBx",
+	"TMycD5Hn4BxiG46xjcUy90EJ4nlLOPa/6ZToyBU8HDgimWxGLF2U+ZbhgmFiZn5kM9yCDL0usLBeoa5T",
+	"L9jwGvoEQMbgEtAJaD4OQDASdE7553bUafY2t6NTwqmNwvVz0MbQ34NCGb1Dx7VR5tsfmWKpXKnW6o1j",
+	"rVjKfM9msECOQteFQiAmUf3PP7Tc8fc/i6Uf/0jbrgPfO/6koqZF79Xm1qjBqcd0n6vrGCSW3lgiATOb",
+	"8Qh+81CwqGAe+vEjm2HozcMMGRJkIDPfo5l0PEW6kKCaj4NB+d61KTT66M1DXNwolsQXTh09EFB4fFM+",
+	"PWan4LyGkBy0BZttuCRX2SJThzDy89T8+5i2nSDbyA0dnEBF/pDT9EZZqx+X6/Vq9bhqVMZpcrpSJKvJ",
+	"yMstEBe54uaENQ7KdbM7BYvpFhZIFx5Tu0xBnelWcvn3Ru21VklDFjvQRK/yZzU1ovJq7ptOF6W0qesH",
+	"kCGXciwoC9BI6qETyBGIDwETyoCwEDDxHBFgYAl57AmlaokBYGyf+UxMAP7B0CTzLfNvhZWeLwRKvtAP",
+	"F1huYrhOaEmlJAHW9rCP+kmK7UJrg2cp5Gt+eAwddkh9nAl00Cadr6GDpK6XlNUZgkKqdjk+PyI9jwsw",
+	"RiYmQB45AIGNpPIFlAHiOWPEsgARI/kyG7ySgzxiIMZ1ylBW8ciBS6BTIiAmgBJ7GUzh4RyejU3hWeAi",
+	"hqnBsxKWtXQtRHh+RIYWAoIKaAMbEVNYAHNgYwdL1AUFNQ3oFmRQl5DzSbuS6WLivXfk/jLKQnQVhMy3",
+	"mpbNOJiEfxazMTvz23/+AXMfzdyLNDf/+Pp/E3+vHl9Ho3zu+/+J/fD9H1/TD7yvu15NRj13N0vCsUCN",
+	"BQsLMaReKB4BblHPNsAYAU9JAjLWNzykng5JPwBzrlZM8w18jLCxiU7nNEQmQEVYUIAFtm21LvepLhG1",
+	"5z5uAhFIhOI498YRLOlD5EfklAJCBXAZnWMDARgMf8WGZHN8gvxpYSESjMXEBBBEmK7v1Ff9aXtLgty2",
+	"wwSqBxH6cQO35EpZAG1O5STuSWg0ddOSTIZPE0x021Ovt+6ygqpGY1zSc3BcquQqlWI5d6zp1VytWCpr",
+	"NdTQjlG69g3X28XggHEHbB4MLXXqyAygd9eGmHBg0cWICAommBgAy90oGEpRgVvKBLS/rfmMDtYZ5XQi",
+	"lMuISM7jBSjHF6Au8BzlDMyQLvVzYeIRAzqICGjzjbc5iy5ygubk0jl/FynsiWiwizHrAvg59lT1OppU",
+	"x7VcUS9PchUDajlYK5Vy2liraaXysVE36ntt+pqCSLUrK+2/zSNJav0Vis4yhwMFuBuNGIA0FFRcFJge",
+	"uQIl6GaS+fbHHtMWi6l+fF+B4S4lPCXM8gU2ccqR9CdzqHE8zhVLRjkHK9VarlKq1arVSkXTNC2TzUwo",
+	"c6DIfMt4Hjb279TIRKjw7bgYUMCDbXgS2DYrLk9QCu8mmPlEXW28AF1cUCzJjT1sG4gV5kV/YY74vysD",
+	"+HtRG3maVqrRyYQj8buWpgls+DNAF7W9VPU3ESyYJkEO8umZ3LuKImKeOyYCmYhtgPfHbcJdG6YWCQmd",
+	"9Xm4yex0zzggQarWvL9f6U0XMkQECIZH7pQS8r2ymM0EftcrFKkBi7/6XihsdRT3ymV4bFMOQja+6xXU",
+	"BJaKfv6oHhIwPBdJ4lEuGEKvOnUcLFKtzm8W5NbXkFxS9BQN5fCU/blQn0EzLVa49d8AG/NQSUuFf91+",
+	"6DcPjQQCGNF20sKBTRXo0yCmBKFhYIkVtG9jxJhAm6PsunB5XFAHf8DIa9/JtuToH9lMPALaN/s0Npav",
+	"4rgEGeMaobdUPvJp7H3CXS5Vta3B4abFCaBJvzYJJp6YWQcTCF5aiirMT6F3qAt7CSgJPZVgUh5cwLkU",
+	"AYeytVccqNgDRYcVc6B7TJ5fe6msPPdclzIRutIHSY/aX3SoErknFVes/vhsyijB5Q3afN8llLtN6l+z",
+	"kD7s3S4Hj97uJVkA6BPaK3ni0l2WAIEV0A3U24xRlmLgkYDYlo+R2l03QhIo5P552UuyaHAMgZ/mX6yB",
+	"+18P41/Ow0jj0CYyP8X4J1XvX/YN9pyu3Q6BslCxjNqG4l69AzolE2x6TJkzldrzzWEi5ZcfkaYANoJc",
+	"KJUdOApfxpAjj9lfsuCLg+VJloZf/YUElGz4AlY0Bo7HxYjIWM9FOp5gGb12Jr5p8CE6ALLY66xahTID",
 	"MTnAZUhHBiK6tBUjohIh0EEAcuVwIAPAMZ2jPOgY0piEBPOtR5LXAeJrOeswItYNkmfIsKAfDeuUCERE",
-	"QVqAArOQ3Sg0Cn5mtiABUV6gvJDIda/EhOF9UrC6hfTZi+maMaEZU2ojSFavJUe2j0EEjm1kpL+cYBtt",
-	"lUnTNWcoRUrObs7ADC2jzBLHJgGh8+cnFRSZQ1nKgxYkMpaHwHRNNZUyAMFdv5ssKeXkf8fts84VuDm7",
-	"ATd3x91OC1y2n8Bx97p1qV6PyIg4t52r47OmPtDpcbt50p00ns5n6P2iBg2797Sow7Ozjn0BbdG4mJbe",
-	"CselywOrM+l4b2fCvZ/W0Yh0++bJXb02hcOqe39SdU57F2V3hgjqF/Sh8/p6O7ta3nLrsURvHxft97vB",
-	"uNi66rUmrTNz9ti4LY3I+/OMdfQWO9VuSwt2ObahZ1h3B/gekuYJd4qNp/YrH1ebd+W6Ie5Yr3z7ZDyY",
-	"h/2DR3wzuW/0R+TyeDrUyvP742ujN+BP5cMubJFaxy1ez91Gp00LHdS+fyq+Oq3rmya81MYX52VvYlZa",
-	"Hprxg+FgRBa3D0PU6r55z93ade+RXt9cLua928nb2Cw+njTm3rN2KaYF/eq89AY97c3hTe/w/MJFs/n1",
-	"Tf/NHpHlq5gunyeM3mN0unQXz+b8diEI6TUK5qDtFS7uh+xJq5ac9t2w3tLH9cpMPz8dnk56M5vMzgoj",
-	"ok3uKs0+rGqV8/LbVJuJMSrPL/WbR3pz7V0e3/PzwVzT7s6emssb5C0PGnX9rvDUtnr1WXlwfzkdkRrq",
-	"PJtL3LvWFnbx6eykf6l79mLGD5sHnj0zi3Q4rvDyu/M8v9HqZ3T49lApTeFl9WFwcGU9IzQijZr2SO+t",
-	"sV68dAcH08kznXLWFs+Nm/Hd88HT/LTRd5nx0GTT8/HFrHTh9i+bb0Prjd82+bF1VhwRreu9lR5g71gz",
-	"S53qjd4zLgr665RqDV1n0+NHD789MFzF3mHv0W28DguTwfuVw42OSRqF1+fLEcGNW8+eePW692o9FBai",
-	"NBYEC7PPX6fWW8+bPt1VnscVayZOG9blXeHxsV4pvVrd6uWi2W/eNo9HRJycnj0/9Oe60zYvT3rFy0Gz",
-	"8ezcz8blC6s77BW7j8dL+FC0dGI3w9/184s5dO6nRqs6HxHd0Q/w7cX18XHvuNVsVk5xu43Oaw6zTs/r",
-	"3j2/7fZ6Je2pqj9b5O2pcdp01BlqnS0ap63FrDMix4vO2ektvWg1eev4+KnVXLRb52a7dVppNlvm7HY1",
-	"++DqqVmoHz+5pr0cNJ+fzq3p8tIakcLBpPZ+M7mfj89LWvu1POvUr0+PrzTSfTw4vis63nxw8Dr0BuWH",
-	"LjsuO+UzzxbuZb99cdkVTrV9MiJFdvb+2KTD4tI9fOo0us0To9dqXS+nzSmnD3eN+tOd1zoojMmUDVG/",
-	"1O1ftybLm1a99nDYqOLr+xFxqoODMb89WdRbpS6zjWav0jvx6PK5OMDiDD5XLm+79+Jg2IbFCuZPg7PW",
-	"9J3Wb54a9+WL61lVGxHz9cFslK4KY6fUfh/Uh43yQ/tkXLTn00rHnr+ZnddLZBaL749Pbw57GjxfXLQm",
-	"8/fJgX01qHlv5vmITN8KF9rSfi518fiM1c6azeX14d0Daz4PFoOe1tanw8ai3SJvs8GJt3x1Hhb386vj",
-	"R6/duW9co/LTiPTwXXFycdXgRv3E5adv1d7Bo0F65HZwcM6mw5vLk7LzwOymQdpDy3i6b0yfZ+6DdbLk",
-	"5cLhIboeEWumsS5ZatOrxQx6kwK+a1zrtcd5bzbt9nsXZvXu8P5yeeE9PIj3xSOZ9q6qD/3T49fLCn+m",
-	"Tq83IhMxHp4XD6rLcf+h0CzPj8fwrf9QEvW796up/o5mg+c2ht2rw27hXL9odfrF29NGrVE6MZp2+/TQ",
-	"GJFZybzFT4PbJoQX2sVF8/183p/1L7pd87L0dPuEz6/ulyVRvlieTjiDTnUxaD1cT6wb1Fl2j4fPFyMy",
-	"Z+6VfTNGEz48rNaHk9LxVccz359Zq3r/djK4nD2bfat4fzYfdG5Ja/k+u13W2nel1xsXP1QPpY6ybjqP",
-	"z+yS6pfly+7gsIDfL26HfVtMe83fR+T3m8mwPiLKurSvTj4zPV+oW6/HJ7G2h8AHSjrgoY/h+0s8P0EG",
-	"ZdBlVHq0ecrMQjjv79Ky/u6/z5VLvksOmW79HlWFd7kZK6dsE4kIB/k6ryMiKFfr/50h6emh3xs5LhiC",
-	"TmxlKP+tVfxfFH7HkKPrwR64bHU/XIYpw2KZHuRxbr/MEcOTZZpnkxIcpwXiGwmetATQy3odfL/ob93Z",
-	"ThEQ6X3xJQ+ijr3Anq6mJLMYpcYmfOoiwnXo7gJ67SIyaDVv1pN4MdfMpVyYDPFX+/MzkOjpSevqceHS",
-	"ptD4c0T9nJzxwtAuSIP42I9sxuOIpWSyVMKSToB67ddVYRAIIQZ0SAA0wmKVH54sMTFleIIZYEj+JPA8",
-	"KA5zVaoaDM6lC8z3zVzdcV/gdyc74znE9FB2azqxjwxwDgVoE4GYyzBHQBXiwW/983b3O2jkK5+d3RUg",
-	"GQblGpWdiQHipxrjCP3YsaUU9nQD9kDbTvSbBKzy84pBPiNMG/I8aCp+AgebllAZRQvOEYC6jjgHgo4I",
-	"QxKWLkPHBNi8jD76W15G1UcZgEqyASIXsGWIKxkvfz5VWnsDqAyDiOeo0qIioAzj1UPOh7GMfqhET9Xo",
-	"qRY91aOnCMRh9LAO61CLnorRUymTzfhKX2ERPEogocWpx54bsefYmIoW4+ZKXBLcjGfZ0rm6zlHMfb5h",
-	"LhlOF370qdj7hUzwxilJ0SSnCcWcPEMOJi8cv6fgLX8NUyAr1S4D4vFSqG6k6JyUipV6pVGuVRrZzFvO",
-	"pLkAAw8TUasoRUo9IlyKyXqibg7ZztMVm5xdIZx2wM5aN/9UH2E65+bQxgY4o9S0UdigylWqQEIJGhf8",
-	"HD5oUcf1BAJX1AgrAXKV/Ii0oW4Bf4cqRxR1JsEoFcRCeoddsHKDeXCv1vc9Dw4gQ0cjAkAOfJPyc/QH",
-	"ciC2sfHx7Qg0CVB/ST3O1PGXioMhlyEuxWa1li5BgLVN5cEpZSDgThZ8gzbW0X8Gf+d16nzLBytzxOZY",
-	"R01/3hdx8JcOQGxb21nmqLAQy0HX/U/outylIm8Gk8I5cZSUUfoqNYL9q7l5H681EhgOJjyVBgZ1ICZH",
-	"f/j/lwsOLQTOwMDDAgH/V/Cby7AD2fL75uK27S8oGe5bZMV9KIK56xQxFa4KBUAZ+LaBEwCdiV9SSqYW",
-	"PxNOzP0ZUpLDzjqy9KGFVF7vlVZityEbmWxmTSr2ZWEmm/GZt0lsaVR9Msd//Pn9tpHi+HndLSoZK+G/",
-	"rPeUQK4jYkAicmMGsZEra+VqsbxTDcbAZXc1y5wPhzefFp3SSYeFjXZXmvxh2RDSj/h63SAKS66JVBS4",
-	"t2O8wn5Xl2wAWKKQqIl+rTQe7+XdNAOtm7tEt2+opBULssAPU/2eYD9uVOn9VZF3rcAbukZReBvMSvUx",
-	"Vu2/e9U3h6pPWMZKqhliZ6Q0GMpRMthIdQEGgQsQ7DQ0/XmgWt04EtIIavHOPTlBOjTAwQQ7njMiBppg",
-	"ggwwXsbGKbuWVCuV0mHlsFYvHda2+RB+M+DLnrWlhB+Q2l0dcTxB5o110o5XvJicLux7lr7i5WHJhghk",
-	"KCXcU368dEYhtn1sXUQMKR/ZjPIW/Ucfa/+ZIRNzgZQQ/Yi3C66gbUhasOv9iukJXblO2wBEdCaHYfd+",
-	"uCe4kBiovkspAYaJclEbjvoLEy6gbSPpGpq6K/+VrIg0rV/ZjY+ac9dCClzwlKNzmMlmFtyWS/mXFmRE",
-	"kFxt9VMCmGWkHsbguKTUd1XlLKi0rV/Puut3wcLCupUFeCIPTRb4rr9y6cAECd2SPmEAJQ86jquiLOUK",
-	"/LfH7P+WE+RpgxwskG1nR0QBTDZFS2BO0E6kut3z6dey/OaxFDXnV7UQliYbwKAzCvwWSM8R0Eo1rTIu",
-	"GbCGDquVsVGujBvjRgk2ylVUhfW6URrXtMkEfs/6BbExg0S3cjaeIcDQBDFV01zBk8RflRglF76vdbdu",
-	"jkhvRJtsRu17TLO4s0mFEyQQczBBHCwsFJDCDwASDdsOJNBEDPymQ2LYyMXkO8AGIgKLZbwsqwLwMBbf",
-	"KCRSwj2VepHCNME6FHLdOFchB7qNVbdfYoyFyIhEshPxXVqhUJDi7I8VSbde1NrQclEibUPiXUZlSLjh",
-	"2bzpujF5oczMc26G2d4An5dwko75Pr5OuECa/g265zYR25p+5Z4j3fDdzk2QygnH/1ittr31MLzRtLEq",
-	"cumWN5+0Tqi0dPomsOkY1W2vCAz9ly0+ccqLOWIc79NdFNjGgDrhtBW62fDCUoBjjG4/qwMpZPovaDoK",
-	"08Rbmo78v+IJnHw+n/9nWpE+X7C494r/cxqUUpDpI+mwSH8k5bZz7NWu2wvh0PQ14v1Bu9tj/snumN0F",
-	"oi/3wBhoAj1bRKFL0l61VT8MV60oqoAkDYQ0UNGFrqgHKjQSW+zCqj9mMwoxCWXohXM7Hen/rQGmehY7",
-	"ynhqWJrMDtYqP2vGRhd4rnicC/iVyEZwpDMk1KsYpi7kfEFZai+fFN9c6jnYPAapvYCEY9Nau4gtmIfS",
-	"pIwyE5KgRpmYUNIqWrlUyaZ1wFr67oPgp3qhDSY2NGVc6nEEmKX7lwX9eMi/Vajy2FnfJ/drXdBewCUH",
-	"KDhLnWBDaxHqti1xxOaIbVIw7i/mJbNjhNypyRN0yq4zPbFojIMxZqQJVjIm3rxBscqWQ7Lc73JVarr9",
-	"I7tz3paPD+yauS3Bv3PFrbeX1aWwfRIs/uwgw5LuHYUE3E77bTmDGOn3vteWDML3J/meM9ZTol8gcTjj",
-	"x59IaTCPkCBvsdWN/bNsihr11/kV8WdLrsJPQoQZC7jgeV5OxVCVt7dGJSvd4HHEiqmXh7n1sqHWObdy",
-	"jEPQbDabx+Wrd9gq7luSDuGlieT9yvlP4rt3VBAO/PHxoQzBhKYkEYM6T1D/sKWmjZWyo4syymPUURAn",
-	"+CTLNF2oWwiU8lomiFwjt2KxWOSheq1seTCXF7qdVvtq0M6V8pr60kssse3no3JRCd3HLBbPHGWKeS3s",
-	"NYEuzhxlynktL6ntQmEp4hTiuUNe+CPupH/IASby76e6yG837xiZo8wZEslvM6hEDHSQUJ0a/1inWuJ7",
-	"ExPKAnMlKLApnQHPBcHHeWyUSE7zjQSKX2THRHkBwgqDuKP1qz4rvvqGzj9QX7zp9fFDfW9AhXuKWiVN",
-	"i6XIlGlxXTtwUgvT4GbLfmslCahELkk0CMIOly3ECTsXMAOQc6rj1fcngAhz5xWt/NNQTtZFUlAOWwAI",
-	"FRttAIAy8OohtvQzRwl+fcRzGlLk/Lrxls3GdhgjzUSl6Ta/b6KAF9R1Ul74AxtxqV7rEVAKVRE8un66",
-	"IffqBuggVL2fSn3HkLAUJBDAFhTIpVMlOLogki63P/0W968U7rWU+oagxImSwv0EJ4Krhj5HfGb6PylV",
-	"T3kKJ6PriUGKPcnFoFoRfsgkUNnH1Fj+tP1v3AXaoEBwWy4qSKlzEl2s3BSFjw1uFX8+tkFmK41hAUUt",
-	"yCV3mECGr120v067qGvhAR4B06SycaAtRT1E6N9F3e3SckkZjcs1/8zuhvfidikfB74BqHqNlBIKZmVB",
-	"EHeCotIRSg0prbzSQyqJl4mrnihWVVeOHfiGHelP+n/5pdH49dxYwm3LweTAlSLvJwhXOG3DyB+XjlIc",
-	"BW0fFE6xHQbPETaUxEu5qvNl4g/DHNAwFlflCL+uFPWkAMezBXZtBAR2UBBkp+3BzzrFSojx3ex/TTqq",
-	"ia81EvxKZb5x9/ZTZyUS4k21LpW5bSM9TOm5DM0x9fj6qV59rsympqk+l6h6ipKnpPBH8NTxbbqBbCRQ",
-	"WhFM/s5XpiQbZ75foOJC/hu0qdEFZAYHrx4V0Gdo8hT6AAOqZNIJv5bOuVyjho/rCiWVstzhk4QyqkcL",
-	"b1MOg9UV7l8rEp8Y+IC6+5j49Y197OdXRWRI8aUiyfiLXapt8un7n9sdFv97Kit5yINrYi9XCkq1sqnr",
-	"u3DBv8WU1WZnjnKUMDHTJFctsxLc/akszVroEv8bkfsXOW/Jj7x85rpJlhC0iGjzF/psiS8/bXGxMTGT",
-	"HlvSA1FOeEwHfS69fGvg1EfCY0SKrx1r+o++4sODcH+BGApRCcK1YI0UUV1pM/9sfFlcwygyQIFO/q1E",
-	"N7vDX1NI/8u9NZ90f5mv9kudmOTnyT4xWYGwb5qsSJL2OjNOrMEi9dREbS7qKOxv3aPOjS+diGi1z1IQ",
-	"/0o9/ms9ldWnqbYz3lmNWWf9qhUtzV+RMmCs34baFsAlc4y/cOfpN3pS9t+M1Pa2Wz3ShkRXsPJgQB20",
-	"NhYy9bnV4PJVFnA6IsL/yiUXsdtcOmX+hlWkLPVzAk3wGyKe8x34e0jk9CQi0qdJzxWuYRNlBdUiwTZ8",
-	"RgXJ8HxIzG18uvbHXfAgn/xPcGm9wWSDAywwoH7OgOqeI+Gm7zTAH8hlovsvYWVVQJNHTSs/1H7jl0a3",
-	"7TXsbfpSHj+WvY8+MDKhbItd+CX5+Q2Llehs/xqCa03Un6i//VveNxGMEAmR244QR0ET2nZUvuhVhIv/",
-	"q/2KiAj/X3gWG42Bn6ZHouP4P6c2o9QIQ9APsbbpkFX/2y+k9WqRVC26ehnXnL52DRrI4kMKsdJwqosW",
-	"6tzwdt+qU3Rj+/exJtJftPlwiVT5Wkcx3Xhsjopafnx971elU9s8Vc/EJ+/zWubjx8f/CwAA///+qf7q",
-	"EmYAAA==",
+	"QVqAArOQ3Sg0Cn5mtiABUV6gvJDIda/EhOFDUrC6hfTZq+maMaEZU2ojSFavJUe2j0EEjm1kpL+cYBtt",
+	"lUnTNWcoRUrOb8/BDC2jzBLHJgGh8+cnFRSZQ1nKgxYkMpaHwHRNNZUyAMF9v5ssKeXkfyft8841uD2/",
+	"Bbf3J91OC1y1n8FJ96Z1pV6PyIg4d53rk/OmPtDpSbt52p00ni9m6OOyBg2797yow/Pzjn0JbdG4nJbe",
+	"CyelqyOrM+l47+fCfZjW0Yh0++bpfb02hcOq+3Badc56l2V3hgjqF/Sh8/Z2N7te3nHrqUTvnhbtj/vB",
+	"uNi67rUmrXNz9tS4K43Ix8uMdfQWO9PuSgt2NbahZ1j3R/gBkuYpd4qN5/YbH1eb9+W6Ie5Zr3z3bDya",
+	"x/2jJ3w7eWj0R+TqZDrUyvOHkxujN+DP5eMubJFaxy3ezN1Gp00LHdR+eC6+Oa2b2ya80saXF2VvYlZa",
+	"Hprxo+FgRBZ3j0PU6r57L93aTe+J3txeLea9u8n72Cw+nTbm3ot2JaYF/fqi9A497d3hTe/44tJFs/nN",
+	"bf/dHpHlm5guXyaMPmB0tnQXL+b8biEI6TUK5qDtFS4fhuxZq5ac9v2w3tLH9cpMvzgbnk16M5vMzgsj",
+	"ok3uK80+rGqVi/L7VJuJMSrPr/TbJ3p7412dPPCLwVzT7s+fm8tb5C2PGnX9vvDctnr1WXnwcDUdkRrq",
+	"vJhL3LvRFnbx+fy0f6V79mLGj5tHnj0zi3Q4rvDyh/Myv9Xq53T4/lgpTeFV9XFwdG29IDQijZr2RB+s",
+	"sV68cgdH08kLnXLWFi+N2/H9y9Hz/KzRd5nx2GTTi/HlrHTp9q+a70Prnd81+Yl1XhwRreu9lx5h70Qz",
+	"S53qrd4zLgv625RqDV1n05MnD78/MlzF3nHvyW28DQuTwce1w42OSRqFt5erEcGNO8+eePW692Y9Fhai",
+	"NBYEC7PP36bWe8+bPt9XXsYVaybOGtbVfeHpqV4pvVnd6tWi2W/eNU9GRJyenb889ue60zavTnvFq0Gz",
+	"8eI8zMblS6s77BW7TydL+Fi0dGI3w9/1i8s5dB6mRqs6HxHd0Y/w3eXNyUnvpNVsVs5wu40uag6zzi7q",
+	"3gO/6/Z6Je25qr9Y5P25cdZ01BlqnS8aZ63FrDMiJ4vO+dkdvWw1eevk5LnVXLRbF2a7dVZpNlvm7G41",
+	"++j6uVmonzy7pr0cNF+eL6zp8soakcLRpPZxO3mYjy9KWvutPOvUb85OrjXSfTo6uS863nxw9Db0BuXH",
+	"LjspO+VzzxbuVb99edUVTrV9OiJFdv7x1KTD4tI9fu40us1To9dq3SynzSmnj/eN+vO91zoqjMmUDVG/",
+	"1O3ftCbL21a99njcqOKbhxFxqoOjMb87XdRbpS6zjWav0jv16PKlOMDiHL5Uru66D+Jo2IbFCubPg/PW",
+	"9IPWb58bD+XLm1lVGxHz7dFslK4LY6fU/hjUh43yY/t0XLTn00rHnr+bnbcrZBaLH0/P7w57HrxcXrYm",
+	"84/JkX09qHnv5sWITN8Ll9rSfil18fic1c6bzeXN8f0ja74MFoOe1tanw8ai3SLvs8Gpt3xzHhcP8+uT",
+	"J6/deWjcoPLziPTwfXFyed3gRv3U5Wfv1d7Rk0F65G5wdMGmw9ur07LzyOymQdpDy3h+aExfZu6jdbrk",
+	"5cLxMboZEWumsS5ZatPrxQx6kwK+b9zotad5bzbt9nuXZvX++OFqeek9PoqPxROZ9q6rj/2zk7erCn+h",
+	"Tq83IhMxHl4Uj6rLcf+x0CzPT8bwvf9YEvX7j+up/oFmg5c2ht3r427hQr9sdfrFu7NGrVE6NZp2++zY",
+	"GJFZybzDz4O7JoSX2uVl8+Ni3p/1L7td86r0fPeML64fliVRvlyeTTiDTnUxaD3eTKxb1Fl2T4YvlyMy",
+	"Z+61fTtGEz48rtaHk9LJdcczP15Yq/rwfjq4mr2Yfav4cD4fdO5Ia/kxu1vW2velt1sXP1aPpY6ybjtP",
+	"L+yK6lflq+7guIA/Lu+GfVtMe83fR+T328mwPiLKurSvT3eZnk/Urdfjk1jbQ+ADJR3w0Mfw/SWenyCD",
+	"MugyKj3aPGVmIZz379Ky/u6/z5VLvksOmW79HlWF97kZK6dsE4kIB/k6ryMiKFfr/ztD0tNDvzdyXDAE",
+	"ndjKUP5bq/i/KPxOIEc3gwNw2ep+uAxThsUyPcjj3H6dI4YnyzTPJiU4TgvENxI8aQmg1/U6+GHR37qz",
+	"nSIg0vviSx5EHQeBPVtNSWYxSo1N+NRFhOvQ3Qf0xkVk0GrerifxYq6ZS7kwGeJv9u4zkOjpSevqceHS",
+	"ptD4a0TdTc54YWgfpEF87I9sxuOIpWSyVMKSToB67ddVYRAIIQZ0SAA0wmKVH54sMTFleIIZYEj+JPA8",
+	"KA5zVaoaDC6kC8wPzVzdc1/g9yc74znE9FB2azqxjwxwAQVoE4GYyzBHQBXiwW/9i3b3K2jkK7vO7gqQ",
+	"DINyjcrexADxU41xhL7v2VIKe7oBe6BtJ/pNAlb5ecUgnxGmDXkeNBU/gYNNS6iMogXnCEBdR5wDQUeE",
+	"IQlLl6FjAmxeRh/9LS+j6qMMQCXZAJEL2DLElYyXP58prb0BVIZBxHNUaVERUIbx6iHnw1hGP1Sip2r0",
+	"VIue6tFTBOI4eliHdaxFT8XoqZTJZnylr7AIHiWQ0OLUY8+N2HNsTEWLcXMlLgluxrNs6Vxd5yjmPt8w",
+	"lwynCz/6VOz9RCZ445SkaJKzhGJOniEHk1eOP1Lwlr+GKZCVapcB8XgpVDdSdE5KxUq90ijXKo1s5j1n",
+	"0lyAgYeJqFWUIqUeES7FZD1RN4ds7+mKTc6uEE47YOet23+qjzCdc3NoYwOcU2raKGxQ5SpVIKEEjQt+",
+	"Dh+0qON6AoFraoSVALlKfkTaULeAv0OVI4o6k2CUCmIhvcMuWLnBPHhQ6/ueBweQoW8jAkAOfJHy8+1P",
+	"5EBsY+PHl2+gSYD6S+pxpo6/VBwMuQxxKTartXQJAqxtKg/OKAMBd7LgC7Sxjv4j+DuvU+dLPliZIzbH",
+	"Omr68z6Jg790AGLb2s4yR4WFWA667n9A1+UuFXkzmBTOiaOkjNJnqRHsX83N+3itkcBwMOGpNDCoAzH5",
+	"9qf/f7ng0ELgHAw8LBDwfwW/uQw7kC2/bi5u2/6CkuG+RVbchyKYu04RU+GqUACUgS8bOAHQmfglpWRq",
+	"cZdwYu7PkJIcdtaRpQ8tpPJ6r7QSuw3ZyGQza1JxKAsz2YzPvE1iS6Pqkzn+409tkk5TBTt1y89rgFH5",
+	"Wgn/db3tBHIdEQMSkRsziI1cWStXi+W9mjIGLruvn+ZiOLzdWZdKpy4WNtpfjPKHZUNI3+PrdYNALbkm",
+	"UoHiwb7zCvt9jbQBYIlComz6uep5vN1301K0bu8TDcGhHlcsyAI/kvXbhv3QUlUAVnXgtRpw6D1FEXAw",
+	"K9UNWXUIH1QCHapWYhlOqX6JvcHUYChHyXgk1UsYBF5CsNPQO8gD1Q3HkZB2Uos398kJ0ucBDibY8ZwR",
+	"MdAEE2SA8TI2Tpm+pOaplI4rx7V66bi2zc3w+wVfDyw/JVyF1AbsiOMJMm+sk3a84vXmdGE/sDoWryBL",
+	"NkQgQynhnnL1pb8Kse1j6yJiSPnIZpRD6T/6WPvPDJmYC6SE6Hu8o3AFbUPSgl0fVm9P6MoNnev/HJ3J",
+	"YdjgH+4JLiQGqjVTSoBholzUqaP+woQLaNtIeo+m7sp/JSsiTesXf+Oj5ty1kAIXPOXoHGaymQW35VL+",
+	"vQYZNCRXW/2UAGYZqYcxOC4pJWBVXAuKces3uO77XbCwsG5lAZ7IQ5MFfnSgvD4wQUK3pNsYQMmDjuOq",
+	"QEx5C//lMfu/5AR52iAHC2Tb2RFRAJN90xKYE3QcqYb4fPrNLb+/LEXN+YUvhKVVBzBongK/BdLzDWil",
+	"mlYZlwxYQ8fVytgoV8aNcaMEG+UqqsJ63SiNa9pkAr9m/ZrZmEGiWzkbzxBgaIKYKnuu4Enir6qQkgtf",
+	"1xpgN0ek96pNNgP7A6ZZ3NmkwikSiDmYIA4WFgpI4ccIiZ5uBxJoIgZ+0yExbORi8hVgAxGBxTJeuVUx",
+	"ehiub9QaKeGeys5IYZpgHQq5bpyrkAPdxqohMDHGQmREItmJ+C6tUChIcfbH6qhb73JtaLko17Yh8S6j",
+	"Mmrc8Gzedd2YvFJm5jk3w4RwgM9rOEnH/BBfJ1wgTf8GDXabiG3N0HLPkZ76fucmyPaE47+vVtvenRhe",
+	"etpYFbl0y5sd3RUqc52+CWw6RnXbKwJD/2WL25zyYo4Yx4c0IAW2MaBOOG2Fbja80xTgGKPbz2pSCpn+",
+	"C/qSwkzylr4k/694jiefz+f/mW6l3QsWD17xf04PUwoyfSQdFumPpFyIjr3ad8EhHJq+RryFaH8HzT/Z",
+	"QLO/hvTpNhkDTaBniyh0SdqrtmqZ4apbRdWYpIGQBiq68xW1SYVGYotdWLXQbEYhJqEMvXJupyP9v2XC",
+	"VM9iT6VPDUuT2cFacWjN2OgCzxWPcwG/EtkIjnSGhHoVw9SFnC8oS233k+KbSz0Hm8cgtV2QcGxaa3e1",
+	"BfNQmpRRZkISlDETE0paRSuXKtm0JllL338Q/GwwtMHEhqaMSz2OALN0/z6hHw/5Fw9Vqjvr++R+OQza",
+	"C7jkAAVnqRNsaC1C3bYljtgcsU0Kxv3FvGR2jJB7NXmCTtl1picWjXEwxow0wUrGxJuXLFYJdUiWh92/",
+	"Ss3I/8junbfl+wT7Zm6rAexdcesFZ3Vv7JAEiz87yLCke0chAbfTflvOIEb6g6++JYPww0l+4Iz1lOgn",
+	"SBzO+P4XUhrMIyTIW2x1Y/8qm6Je/nV+RfzZkqvwkxBhxgIueJ6XUzFUFfCtUclKN3gcsWLq/WJuvW6o",
+	"dc6tHOMQNJvN5kn5+gO2iodWrUN4aSL5sHL+k/geHBWEA7//+KEMwYSmJBGDUlBQIrGlpo1Vu6O7NMpj",
+	"1FEQJ/gkyzRdqFsIlPJaJohcI7disVjkoXqtbHkwlxe6nVb7etDOlfKa+hhMLLHt56NyUZXdxywWz3zL",
+	"FPNa2I4CXZz5linntbyktguFpYhTiOcOeeHPuJP+Qw4wUUp25RwJv/gXnxzW2jGL5UU5CL7MYyOV04Ep",
+	"H6nIK+FFfsd7x/DhJz8PoRI90EFCNYv8sZHniH/yQi7jm0NBgU3pDHhuDIsEzvmNDI1f6MdEuRnCCqPE",
+	"b+vXjVaC41tS/8R+8rbZj+/qmwcqnlTsKGlaLAenbJfr2oEXXJgGt2sOWytJQSXTSapBEHbZbKFOjKOQ",
+	"c6rj1TcwfOZK4apo5Z+GcrLwkoJy2IZAqNhoRQCUgTcPsaWfmkrw60c8aSJlem2jUmbWGCygyVOumSVy",
+	"7d8l3IK6zcoLf2Jj94nxFbaid3THTs1NPQDqNuog1PE7xb9jSKAKVLiIoEDikSrJ0WWVdPn96TfKf6WQ",
+	"r+XuNwQmTpQUKUi8XvHcv58ccNfnlLIrlKelmgNWQhJ8HmaDm8GI8OMqgY04ocbyp9Fh437SBiWCG3xR",
+	"BUydm+iy56ZI/NjgWvHnYxuk0tIYF1DVglzyhwlk+NpG+/u0jbqqHuARME0qHwfaUuRDhP5V1N8+rRdd",
+	"6w0r/KGwBwKeEHe+U5NJ/WXbSA9zMy5Dc0w9vk6t1aepbGqa6tN4qn8kXeGFK+/Rdj34DqBqtFJaL5iV",
+	"D3WdMgErZadSkpm4fosib3XH2oHv2JHesf+XX+iN30eOpQ+3nHwOXHme/HTnNjz8t+mIxBfWDln4DNth",
+	"AiDcP6AkXo5WDT4TfxjmgIb5BFVS8WtjUesNcDxbYNdGQGAHBYmCtD34mbNYGTS+m8Nvg0d1/bVmiF9p",
+	"JzauGO/0h6JDkGIxVlK6+wAV/gyeOr5bYCAbCZRWo5O/85VPkI3z1a+fcSH/DRrt6AIyg4M3jwro8yp5",
+	"lHyAwYYz6TRdyzZdrW3UxzXEIXWr2XTtMFj5OKE8BnN2nfnB6lr6r+X/DkchoPd2VyE5IJ0mu92005hs",
+	"pbtmkcj8zR7aNsH1fdsdvo9yfVeymwc3xF6ulJLq0lM3k+GCf4kpqM2OIuWLYWKmibRaZiXRh1NZWsfw",
+	"YzP/QuT+RT5g8vs1uzxAyRKCFhFt/kbXL/FRqy0eOyZm0vFLOjJ27Csln9LDQai21bfpI+ExIuXZjl1w",
+	"iL5YxIO8wgIxFOIWZDVC+U8R3pWa80/LgdHcSoDNINsS4EAn/1LCvOGcOEn/TCGdBYGzA4oK6N/tqQWk",
+	"i/lpK4y0X+Cx/VJXJvktth22LJD27bZMDwXyE0fIiTWObA0QVq1bn3MEoq6UT52RaLVdWY//Tl3/a52a",
+	"1Ze5touCsxqzTRicFe3TxcFYvxO2MzecvES0yjAKurpRlCoKyRzpLyRf+q2oFCI2I3Ow7WaUNFbRNbY8",
+	"GFBngwBMfbI2uMCWBZyOiPC/FMpF7EacTpm/YcOnFAIJNMFviHjOV+DvIZFSVwQdpeU6jTWKpqY2fR4H",
+	"pYJ8SMmdLL5xEWnedsDl4OY6uq0Dt6b0b3zYlzxIoP8TbF1v2dlgGQssuZ8UobrnSLibpJFYxyiimn18",
+	"SsTv426lQjgodb9hx9g+ZZb4YHesZhF92WVC2RYb9UuKEhvWM3Ff4HMIrrWm71C8h18k2EQwQiREbjtC",
+	"HAWtfdtR+aSHEy7+3+3jRET4/8LL2Wi33JmwiQ7r/9yClLvSFqE2Cn4KFBJD0A8Wd4Qufk9QUKOOeglT",
+	"tdOqX/EXcnG1SKqOXr2MU8PX3Sv00/VzrKy/00iF1AjGp9LiIdYB/IsoES6RKsZrOKZIx6pHeZ0UUc+W",
+	"b1r8toLUPl3V9LLjfV7L/Pj+4/8FAAD//6jQsCb2ZwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -15,9 +15,11 @@ servers:
 paths:
   /version:
     get:
-      summary: get the service version
-      description: "get the service version"
+      summary: get version
+      description: "Get the service version."
       operationId: getVersion
+      tags:
+        - meta
       responses:
         '200':
           description: a service version
@@ -27,8 +29,11 @@ paths:
                 $ref: '#/components/schemas/Version'
   /ready:
     get:
-      summary: return the readiness
+      summary: return readiness
+      description: "Return the service readiness."
       operationId: getReadiness
+      tags:
+        - meta
       responses:
         '200':
           description: readiness
@@ -38,7 +43,8 @@ paths:
                 $ref: '#/components/schemas/Readiness'
   /openapi.json:
     get:
-      summary: get the openapi json specification
+      summary: get spec
+      description: "Get the OpenAPI JSON specification."
       operationId: getOpenapiJson
       tags:
         - meta
@@ -51,8 +57,11 @@ paths:
                 type: object
   /distributions:
     get:
-      summary: get the distributions available to this user
+      summary: get distributions
+      description: "Get the distributions available to this user."
       operationId: getDistributions
+      tags:
+        - distribution
       responses:
         '200':
           description: |
@@ -64,16 +73,20 @@ paths:
                 $ref: '#/components/schemas/DistributionsResponse'
   /architectures/{distribution}:
     get:
-      summary: get the architectures and their image types available for a given distribution
+      summary: get architectures for distribution
+      description: "Get the architectures and their image types available for a given distribution."
       parameters:
         - in: path
           name: distribution
           schema:
             $ref: '#/components/schemas/Distributions'
           required: true
-          description: distribution for which to look up available architectures
+          description: "Distribution for which to look up available architectures."
           example: 'rhel-84'
       operationId: getArchitectures
+      tags:
+        - distribution
+        - architecture
       responses:
         '200':
           description: a list of available architectures and their associated image types
@@ -89,7 +102,11 @@ paths:
                 $ref: '#/components/schemas/HTTPErrorList'
   /composes:
     get:
-      summary: get a collection of previous compose requests for the logged in user
+      summary: get composes
+      description: "Get a collection of previous compose requests for the logged in user."
+      operationId: getComposes
+      tags:
+        - compose
       parameters:
         - in: query
           name: limit
@@ -98,14 +115,14 @@ paths:
             default: 100
             minimum: 1
             maximum: 100
-          description: max amount of composes, default 100
+          description: "Max amount of composes."
         - in: query
           name: offset
           schema:
             type: integer
             default: 0
             minimum: 0
-          description: composes page offset, default 0
+          description: "Composes page offset."
         - in: query
           name: ignoreImageTypes
           required: false
@@ -132,11 +149,13 @@ paths:
           format: uuid
           example: '123e4567-e89b-12d3-a456-426655440000'
         required: true
-        description: Id of compose
+        description: ID of compose
     get:
-      summary: get status of an image compose
-      description: "status of an image compose"
+      summary: get compose status
+      description: "Status of an image compose."
       operationId: getComposeStatus
+      tags:
+        - compose
       responses:
         '200':
           description: compose status
@@ -145,16 +164,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/ComposeStatus'
     delete:
-      summary: delete a compose
+      summary: delete compose
       description: |
         Deletes a compose, the compose will still count towards quota.
       operationId: deleteCompose
+      tags:
+        - compose
       responses:
         200:
           description: OK
   /composes/{composeId}/metadata:
     get:
-      summary: get metadata of an image compose
+      summary: get compose metadata
+      description: "Get metadata of an image compose."
+      tags:
+        - compose
       parameters:
         - in: path
           name: composeId
@@ -164,7 +188,6 @@ paths:
             example: '123e4567-e89b-12d3-a456-426655440000'
           required: true
           description: Id of compose metadata to get
-      description: "metadata for an image compose"
       operationId: getComposeMetadata
       responses:
         '200':
@@ -175,7 +198,9 @@ paths:
                 $ref: '#/components/schemas/ComposeMetadata'
   /composes/{composeId}/clone:
     post:
-      summary: clone a compose
+      summary: clone compose
+      tags:
+        - compose
       description: |
         Clones a compose. Only composes with the 'aws' image type currently support cloning.
       parameters:
@@ -186,7 +211,7 @@ paths:
             format: uuid
             example: '123e4567-e89b-12d3-a456-426655440000'
           required: true
-          description: Id of compose to clone
+          description: ID of compose to clone
       operationId: cloneCompose
       requestBody:
         required: true
@@ -204,7 +229,7 @@ paths:
                 $ref: "#/components/schemas/CloneResponse"
   /composes/{composeId}/clones:
     get:
-      summary: get clones of a compose
+      summary: get compose clones
       parameters:
         - in: path
           name: composeId
@@ -230,8 +255,10 @@ paths:
             minimum: 0
           description: clones page offset, default 0
       description: |
-        Returns a list of all the clones which were started for a compose
+        Returns a list of all the clones which were started for a compose.
       operationId: getComposeClones
+      tags:
+        - compose
       responses:
         '200':
           description: compose clones
@@ -241,7 +268,7 @@ paths:
                 $ref: '#/components/schemas/ClonesResponse'
   /clones/{id}:
     get:
-      summary: get status of a compose clone
+      summary: get clone status
       parameters:
         - in: path
           name: id
@@ -251,8 +278,10 @@ paths:
             example: '123e4567-e89b-12d3-a456-426655440000'
           required: true
           description: Id of clone status to get
-      description: status of a clone
+      description: "Get status of a compose clone."
       operationId: getCloneStatus
+      tags:
+        - clone
       responses:
         '200':
           description: clone status
@@ -263,8 +292,10 @@ paths:
   /compose:
     post:
       summary: compose image
-      description: "compose image"
+      description: "Compose an image."
       operationId: composeImage
+      tags:
+        - compose
       requestBody:
         required: true
         description: details of image to be composed
@@ -328,6 +359,11 @@ paths:
             default: 0
             minimum: 0
           description: packages page offset, default 0
+      summary: get packages
+      description: "Get packages."
+      operationId: getPackages
+      tags:
+        - package
       responses:
         '200':
           description: a list of packages
@@ -689,6 +725,8 @@ components:
       type: object
     GCPUploadRequestOptions:
       type: object
+      required:
+        - share_with_accounts
       properties:
         share_with_accounts:
           type: array


### PR DESCRIPTION
Since I was reviewing the API, I noticed many endpoints are missing either "summary", or "description" or even "id". In general, summary should be really short, ideally a title because it is used by many documentation generators as the title for the endpoint.

So I shortened summaries and made sure they match the operation id (e.g. "getComposes" is "get composes"), also added missing elements and description are now sentences.

Finally, I added tags which are super useful not only for browsing generated documentation, but also in client generators (you can easily skip unwanted endpoints).

Also adding a link to ReDoc: an online OpenAPI generation tool.

This is how the API looks before the patch:

https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml#tag/Source/operation/getSourceUploadInfo

And this after the patch:

https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/lzap/image-builder/84780c9ad101413bf9dc314575103f6c0eb49c22/internal/v1/api.yaml