### PR TITLE
ci: speed up integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,9 +55,7 @@ Test EL8:
   parallel:
     matrix:
       - PROVIDER:
-          - aws
           - azure
-          - gcp
         RUNNER:
           - aws/rhel-8.8-ga-x86_64
 


### PR DESCRIPTION
We decided on our previous team meeting call,
https://docs.google.com/document/d/1kKxYEaXMxa85SINBaic8rf5k9twE1cfl3fMvtspzQLE/edit to only keep the azure test for the integration test of image builder as it's the fastest of the 3 in order to speed things up in ci.