### PR TITLE
v1: include compose_id in clone response

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -26,6 +26,14 @@ const (
 	Ui  ClientId = "ui"
 )
 
+// Defines values for CloneStatusResponseStatus.
+const (
+	CloneStatusResponseStatusFailure CloneStatusResponseStatus = "failure"
+	CloneStatusResponseStatusPending CloneStatusResponseStatus = "pending"
+	CloneStatusResponseStatusRunning CloneStatusResponseStatus = "running"
+	CloneStatusResponseStatusSuccess CloneStatusResponseStatus = "success"
+)
+
 // Defines values for CustomizationsPartitioningMode.
 const (
 	AutoLvm CustomizationsPartitioningMode = "auto-lvm"
@@ -115,10 +123,10 @@ const (
 
 // Defines values for UploadStatusStatus.
 const (
-	UploadStatusStatusFailure UploadStatusStatus = "failure"
-	UploadStatusStatusPending UploadStatusStatus = "pending"
-	UploadStatusStatusRunning UploadStatusStatus = "running"
-	UploadStatusStatusSuccess UploadStatusStatus = "success"
+	Failure UploadStatusStatus = "failure"
+	Pending UploadStatusStatus = "pending"
+	Running UploadStatusStatus = "running"
+	Success UploadStatusStatus = "success"
 )
 
 // Defines values for UploadTypes.
@@ -222,6 +230,22 @@ type CloneRequest struct {
 type CloneResponse struct {
 	Id openapi_types.UUID `json:"id"`
 }
+
+// CloneStatusResponse defines model for CloneStatusResponse.
+type CloneStatusResponse struct {
+	ComposeId *openapi_types.UUID         `json:"compose_id,omitempty"`
+	Options   CloneStatusResponse_Options `json:"options"`
+	Status    CloneStatusResponseStatus   `json:"status"`
+	Type      UploadTypes                 `json:"type"`
+}
+
+// CloneStatusResponse_Options defines model for CloneStatusResponse.Options.
+type CloneStatusResponse_Options struct {
+	union json.RawMessage
+}
+
+// CloneStatusResponseStatus defines model for CloneStatusResponse.Status.
+type CloneStatusResponseStatus string
 
 // ClonesResponse defines model for ClonesResponse.
 type ClonesResponse struct {
@@ -688,6 +712,146 @@ func (t CloneRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (t *CloneRequest) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsAWSUploadStatus returns the union data inside the CloneStatusResponse_Options as a AWSUploadStatus
+func (t CloneStatusResponse_Options) AsAWSUploadStatus() (AWSUploadStatus, error) {
+	var body AWSUploadStatus
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAWSUploadStatus overwrites any union data inside the CloneStatusResponse_Options as the provided AWSUploadStatus
+func (t *CloneStatusResponse_Options) FromAWSUploadStatus(v AWSUploadStatus) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAWSUploadStatus performs a merge with any union data inside the CloneStatusResponse_Options, using the provided AWSUploadStatus
+func (t *CloneStatusResponse_Options) MergeAWSUploadStatus(v AWSUploadStatus) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsAWSS3UploadStatus returns the union data inside the CloneStatusResponse_Options as a AWSS3UploadStatus
+func (t CloneStatusResponse_Options) AsAWSS3UploadStatus() (AWSS3UploadStatus, error) {
+	var body AWSS3UploadStatus
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAWSS3UploadStatus overwrites any union data inside the CloneStatusResponse_Options as the provided AWSS3UploadStatus
+func (t *CloneStatusResponse_Options) FromAWSS3UploadStatus(v AWSS3UploadStatus) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAWSS3UploadStatus performs a merge with any union data inside the CloneStatusResponse_Options, using the provided AWSS3UploadStatus
+func (t *CloneStatusResponse_Options) MergeAWSS3UploadStatus(v AWSS3UploadStatus) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsGCPUploadStatus returns the union data inside the CloneStatusResponse_Options as a GCPUploadStatus
+func (t CloneStatusResponse_Options) AsGCPUploadStatus() (GCPUploadStatus, error) {
+	var body GCPUploadStatus
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGCPUploadStatus overwrites any union data inside the CloneStatusResponse_Options as the provided GCPUploadStatus
+func (t *CloneStatusResponse_Options) FromGCPUploadStatus(v GCPUploadStatus) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGCPUploadStatus performs a merge with any union data inside the CloneStatusResponse_Options, using the provided GCPUploadStatus
+func (t *CloneStatusResponse_Options) MergeGCPUploadStatus(v GCPUploadStatus) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsAzureUploadStatus returns the union data inside the CloneStatusResponse_Options as a AzureUploadStatus
+func (t CloneStatusResponse_Options) AsAzureUploadStatus() (AzureUploadStatus, error) {
+	var body AzureUploadStatus
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAzureUploadStatus overwrites any union data inside the CloneStatusResponse_Options as the provided AzureUploadStatus
+func (t *CloneStatusResponse_Options) FromAzureUploadStatus(v AzureUploadStatus) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAzureUploadStatus performs a merge with any union data inside the CloneStatusResponse_Options, using the provided AzureUploadStatus
+func (t *CloneStatusResponse_Options) MergeAzureUploadStatus(v AzureUploadStatus) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsOCIUploadStatus returns the union data inside the CloneStatusResponse_Options as a OCIUploadStatus
+func (t CloneStatusResponse_Options) AsOCIUploadStatus() (OCIUploadStatus, error) {
+	var body OCIUploadStatus
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOCIUploadStatus overwrites any union data inside the CloneStatusResponse_Options as the provided OCIUploadStatus
+func (t *CloneStatusResponse_Options) FromOCIUploadStatus(v OCIUploadStatus) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOCIUploadStatus performs a merge with any union data inside the CloneStatusResponse_Options, using the provided OCIUploadStatus
+func (t *CloneStatusResponse_Options) MergeOCIUploadStatus(v OCIUploadStatus) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+func (t CloneStatusResponse_Options) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *CloneStatusResponse_Options) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -1404,114 +1568,115 @@ var swaggerSpec = []string{
 	"oVxGRAo+L0HZvgQNgaeoYGKGDKmfS2OfmNBFRECHL30t2HRWELQghy7oWWSwJ6LBOsakBfBz7GkYe2jc",
 	"GO0WKkZtXKibsFyAu9VqoTwq75artX1zz9zbaNNTCiLTriy0/yqPJKn1Fyi68wIOFOB6NGIAslBoOxgR",
 	"0Q0Eagx9R0j75El/BBHfVUZT/fJxDMBCJFVgFdguCYQSdDHOff19g22MBWUf3xZguEcJz4jTtMQn1ASS",
-	"DmkBNfdHhUrVrBVgvbFbqFd3dxuNer1cLpdz+dyYMhfKCfk+NjeTysxFqPDVuJhQwK2dgCSwVW6AXIIZ",
-	"zB9jpom6mHgJerikeFoY+dgxEStNK3pgjvg/lQX9rVIe+uVydZeOxxyJ38pZqsSBPwJ0pbyRqnoSwYBZ",
-	"IugiTc/k3FUYEnP9MRHIQmwJvG63DDfVTA0SEjqvebjM7GzXOiBBptq9vV0oXg8yRAQImkf+mBLyjbKY",
-	"zwWO2zMUmRGPHn0jFLZYihvlMly2GQshH5/1AmoCS0U/3aqPBAzXRZJ4lAuG0LNBXReLTLP1iw25/WtI",
-	"Lil6ioayecb8PGhMoJUVbFzqL8DBPNTy0mKcd+6uW9uGEgGMaDpZ8cSyDtU0iClBaJpYYgWdyxgxxtDh",
-	"KJ8WLqWAA9laz7FAU0tR8bmgLn6HUaywtmey9Uc+F4+7NvU+jLXli+gxQfu4GunPlWd+GPuecNKrjfLK",
-	"kHTZzgXQpDedBBNPB6XBBNKalRgLs2LoDRrCmQNKQv8o6FQEJ3Aq5calLPWJAxXxoGiFYw4Mn8lF78yV",
-	"b8F9z6NMhA78ViKn5hetxETGS0Uzix+fTVQluLxEm2/rJHm9Hf4+s6phr3d0ePR1I8kCQJ9Qecllmu0o",
-	"BQgsgC6h3mGMsgyvAAmIHfkY6eq05ZJAIdfrZSPJosYxBH6YU5IC9x+35G/nlmRxaBmZ77IdP8TNSOrr",
-	"7/ZCNizJ9a6H+nng+MhjmIjvNL9/1pKuNoNgFKIGzM8Zwx9gnrcwgUnbtsnuQcAxsRwUm9XPMX+fsnj5",
-	"XJbLACKh2OwzpESOaEcjybD1hnTJHcu0rGlh/RkWVqERy4Yv8X7xDRiUjLHlM4WzSsvrWSTS9cUhaQng",
-	"IMiFcnwCH/3LCHLkM+dLHnxxsbSH0udWv5CAUpl9AYtZAdfnYkhGCHAPGXiMkVkE3bEWNA3RBZDFPufV",
-	"KJSZiMkGHkMGMhExpMc1JCqJCV0EIFe+PjIBHNEpKoKuKWUypIwWwiR1A8RT+01hNsswSZEh04Y6k2VQ",
-	"IhARJcn+ErOR0yw1S3pXpSQBUV6ivJTYp1rwjeFttk8MGxmTZ8uzYlp0RKmDIFl8lhxZ3QYROHKQmf1x",
-	"jB20UklbnjVBGVJyfHkMJmgeZYU5tggI4y6dEFRkDmWpCNqQgBECEFiepbpSBiC4ve4lt4ML8r+DznH3",
-	"HFweX4LL24Netw3OOo/goHfRPlOfh2RI3Kvu+cFxyxgY9KDTOuyNm48nE/R+ugtNp/8424PHx13nFDqi",
-	"efpSfSsdVM927O64678dC+/uZQ8NSe/aOrzd232BNw3v7rDhHvVPa94EEXRdMm7c19eryfn8itsPVXr1",
-	"MOu83w5GlfZ5vz1uH1uTh+ZVdUjenyasa7TZUfmqOmNnIwf6pn27g+8gaR1yt9J87LzyUaN1W9szxS3r",
-	"164ezXtr/3rnAV+O75rXQ3J28HJTrk3vDi7M/oA/1vZ7sE12u17lYuo1ux1a6qLO3WPl1W1fXLbgWXl0",
-	"elLzx1a97aMJ37kZDMns6v4GtXtv/lNv96L/QC8uz2bT/tX4bWRVHg6bU/+pfCZeSsb5SfUN+uU3l7f8",
-	"/ZNTD02mF5fXb86QzF/Fy/xpzOgdRkdzb/ZkTa9mgpB+s2QNOn7p9O6GPZYbVbdze7PXNkZ79YlxcnRz",
-	"NO5PHDI5Lg1JeXxbb13DRrl+Unt7KU/ECNWmZ8blA7288M8O7vjJYFou3x4/tuaXyJ/vNPeM29Jjx+7v",
-	"TWqDu7OXIdlF3SdrjvsX5ZlTeTw+vD4zfGc24futHd+ZWBV6M6rz2rv7NL0s7x3Tm7f7evUFnjXuBzvn",
-	"9hNCQ9LcLT/QO3tkVM68wc7L+Im+cNYRT83L0e3TzuP0qHntMfO+xV5ORqeT6ql3fdZ6u7Hf+FWLH9jH",
-	"lSEp9/y36j3sH5StardxafTN05Lx+kLLTcNgLwcPPn67Z7iB/f3+g9d8vSmNB+/nLje7FmmWXp/OhgQ3",
-	"r3xn7O/t+a/2fWkmqiNBsLCu+euL/db3Xx5v60+juj0RR0377Lb08LBXr77avcbZrHXdumodDIk4PDp+",
-	"ur+eGm7HOjvsV84GreaTezcZ1U7t3k2/0ns4mMP7im0QpxW+N05Op9C9ezHbjemQGK6xg69OLw4O+gft",
-	"Vqt+hDsddLLrMvvoZM+/41e9fr9afmwYTzZ5e2wetVy1htrHs+ZRezbpDsnBrHt8dEVP2y3ePjh4bLdm",
-	"nfaJ1Wkf1VuttjW5WvTeOX9slfYOHj3LmQ9aT48n9sv8zB6S0s549/1yfDcdnVTLndfapLt3cXRwXia9",
-	"h52D24rrTwc7rzf+oHbfYwc1t3bsO8I7u+6cnvWE2+gcDkmFHb8/tOhNZe7tP3abvdah2W+3L+YvrRdO",
-	"72+be4+3fnunNCIv7AZdV3vXF+3x/LK9t3u/32zgi7shcRuDnRG/Opzttas95pitfr1/6NP5U2WAxTF8",
-	"qp9d9e7Ezk0HVuqYPw6O2y/vdO/ysXlXO72YNMpDYr3eW83qeWnkVjvvg72bZu2+cziqONOXeteZvlnd",
-	"1zNkVSrvD49vLnscPJ2etsfT9/GOcz7Y9d+skyF5eSudlufOU7WHR8ds97jVml/s396z1tNgNuiXO8bL",
-	"TXPWaZO3yeDQn7+697O76fnBg9/p3jUvUO1xSPr4tjI+PW9yc+/Q40dvjf7Og0n65Gqwc8Jebi7PDmvu",
-	"PXNaJunc2ObjXfPlaeLd24dzXivt76OLIbEnZdYj8/LL+WwC/XEJ3zYvjN2HaX/y0rvun1qN2/27s/mp",
-	"f38v3mcP5KV/3ri/Pjp4PavzJ+r2+0MyFqObk8pOYz66vi+1atODEXy7vq+Kvdv38xfjHU0GTx0Me+f7",
-	"vdKJcdruXleujpq7zeqh2XI6R/vmkEyq1hV+HFy1IDwtn5623k+m15Pr017POqs+Xj3ik/O7eVXUTudH",
-	"Y86g25gN2vcXY/sSdee9g5un0yGZMu/cuRyhMb/Zb+zdjKsH513fen9i7cbd2+HgbPJkXduVu+PpoHtF",
-	"2vP3ydV8t3Nbfb308H1jX+oo+7L78MTOqHFWO+sN9kv4/fTq5toRL/3Wb0Py2+X4Zm9IlHXpnB+uMz2f",
-	"qDlJR/mxkqXAB0p6paGPof0lXhwjkzLoMSo9xCJlVins909pWX/T3wu1qg5sITPs36KKjk1uxsIpW0Yi",
-	"wkF+LhqICMrV+P9kSHp66LdmgQuGoBsbGcp/d+v6jcLvAHJ0MdgCl5Xuh8cwZVjMs1MlnDvPU8TweJ7l",
-	"2WQ4wFlO91JwlxX8PadrWLbLoaSd7QwBkd4Xn/Mgdt8K7NGiSzIXWG0uw6ceItyA3iagFx4ig3brMp0/",
-	"j7lmHuXCYoi/OuvXQKIeL6siz4NMqOAbE+vZpWZGtcoAOcgQwKYz5eebmE+CgDOsR4iAyFDhC/QFLThT",
-	"94v+7nMEGJwBnziI63iAIRVAqBCF6cDCpT4RHsVEh68zGxs2MCBHAIsFnN5dvwi+KNjQmcE5HxKfIy7f",
-	"5wGaIqJLFxZDEArQm2AwDr8IvjA4+wJUT4lZhD4fkiwgK/AMtqGDXVcGZ7l8zpm6uXwupEDmDqwH5w6F",
-	"5veJ8XoBjm+jb4I0iLf9yOd8jlhG+kHtztAxUJ91FQoMQk/EgAEJgGa4ta8DwjkmliQeZoAh+UrgaVBK",
-	"w9XG/mBwIoMOvm3K4ZZrFbN5ZyeeXMlOwa3M/1wjE5xAATpEIOYxLIUNE/8N/HJ90un9CprF+jptuQAk",
-	"A89Cs577jszFtw1TumRUqqhwZqHkvRmGOX6mzCpyboUWKgiGnz3d5xkSzvHzyKs2nxGxITGQmct/uquN",
-	"Lfs7ukk7wVxkYsjm39HdxQS70Nm2p4H5J5o+c8SmiD07lc90mlE24UIZqj/Ts7p1Tx9v2xQ1t21pYw/C",
-	"bRtj7j7TbRtT7nnbtvUMXDD51izjAhITMnP79tj6TNtna0XlTMZKjKcFk2qzF6jNALIupIUZZbTbZ15X",
-	"aYIMO5BMMq9EDjpOApdAv2vbHmzehEliXgQtZQSAiy1bqPyxDacIQMNAnANBh4QhCcsQyEyCLQ7JkFyv",
-	"+BgVeEnfQupaQOQADkbaWsjXR8q5XgIat75K6+bywUNBw5hHL+rRUyN62o2e9qKnBYj98GnxkIa6X46e",
-	"KtFTNXqq5fI57a8rzIJHCS4MFvZiz83Yc6xNvbxRGPlmMUxzGXPNS8ylENCZThwqlhe/TyJXieJRwqdO",
-	"GmMXk2eO3zPwlm/D7PXCK5eO4WguVBF4ZHCrlfpevVnbrTfzubeCRQsBBj4mYreufODIZUvtVE4h22im",
-	"Y53zC4SzLPVx+/JPHd/I5twUOtgEx5RaDgrPBXGV5ZVQgnpRvYsD2tT1fIHAOTVR5KELuzgkHWjYQM9Q",
-	"pfejgnAYZfFZSO/w8JGcYBHcqfF10MilN/x1SAAogC9Sfr7+gVyIHWx+fPkKWgSoX9IhZEolSGXCkMcQ",
-	"l2KzGMuQIEBqUkVwRBkIuJMHX6CDDfTfwe+iQd0vxWBkabCxgVq63ydx0EMHIFaN7c4LVLr/Beh5/w09",
-	"j3tUFK2gU9gnjpLybj9LjWD+qm9R45UigeliwjNpYFIXYvL1D/1/OeCNjcAxGPhYIKDfgl88hl3I5r8u",
-	"D+44ekDJcO3aK+5DEfRNU8RSuCoUZCj0ZQknALpjvamY3BVaJ5yY6x5SksMDDWSuoYVUTh9RU2K3JBu5",
-	"fC4lFduyMJfPaeYtE1t655rM8Zc//phTpDh+XFGx2keT8J/TlbiQG4iYkIjCiEFsFmrlWqNS26gGY+Dy",
-	"m2qUT25uLtdW3WSTDgsHbS610c3yIaRv8fF6QQItOSZSCbytI+wF9psOJwWAJQqJXfHPVTTEj1Atm4H2",
-	"5W3ikFWopBUL8kBnGPVRLJ3yUwmLxTZ/aos/ChnDzGTQK9PHWJy62qoo4EYdz/rIByWkG5NcgxvZ6iOf",
-	"y3YBBoELEMw0NP1FoE4YcCSkESzHD0zIDtKhASpe9N0hMdEYE2SC0TzWTtm1pFqpV/fr+7t71f3dVT6E",
-	"PoPxvGWdTMIPyDzUFnE8QealcbKWV7yaLlvYtyzjidfHSTZEIEMp4b7y7aUzCrGjsfUQMaV85HPKW9SP",
-	"Gmv9zJCFuUBKiL7FT2ksoC1JWjDr7aoJE7oyTdsARLQmb8JDk9HhiJnEQB13kRJgWqgQFS+rX5hwAR0H",
-	"SdfQMmQUa0lWRJpWl7bFW1FDxuZT7tlIAQ2eCnQqg+sZd+SA+sSojAuSYy5exUFObTNzSV60u1sfV47a",
-	"/pTDysHyzSi4UyF1ADt9Sv/2uqdTu3mAx3IR54EORZSLCcZIGLb0UQMoRdB1PRUJKtfkf33m/K/sIFc/",
-	"5GCGHCc/JDpXnDgbJ4G5QVG4OvRYzD6dr48AZKhdXSCBsHQhAAzq28EvgTR/BeXqbrk+qppwF+036iOz",
-	"Vh81R80qbNYaqAH39szqaLc8HsNf87q2YsQgMeyCgycIMDRGTJXHLOBJMVhUq0h5+DV1yGm5RfZxgvFy",
-	"OnKLbjZ3l6lwiARiLiaIg5mNAlLogCRxbs+FBFqIgV8MSEwHeZj8CrCJiMBiHq/wUUmCMF+wVJNCCfdV",
-	"TlkK0xgbUMhx41yFHOgSylQbG5EhiWQn4ru0iqEgxdkfq7dZuQSW5T3ck1mS+DB5lEotJ0kpvXOHEksG",
-	"UsCjDjbmqSrDLA9OJ97MbHABlIU0dQ8TAvOJXOnKsbOPL8dGD8zWRucxnEmWKgkOcSxTduVWJPddGdds",
-	"1l5Bkj1s/20x2uoTMOHJ/KVRkUdXfFlTV6u2aLMngS3XbKz6RGDoEK4IMjI+TBHjeJt69YBrAXXCbgt0",
-	"8+HB+wDHGN1+VE17yPSfUMYebpmuKGPXv+IZsWKxWPwzxe3rB6xsPeK/T8l7BjLXSHqA0sHLuLUn9mnT",
-	"KdywafYY8VrZzaWif7JSdHOxxKfrQaMzu0EsmFSsHVUbylVZpiqmkBZOWtjoYoKoHji0cisM26JWdDms",
-	"swhl6JlzJxvp/9TDZLpGG0paVLMsmR2k9uRTxsYQeKp4XAj4lUjvcGQwJNSnGKYe5HxGWeZBDym+hcx1",
-	"sLwMMg+KEI4tO3WhkGA+ypIyyixIgnqdRIdquV6uVev5rDNVtrF5Iei4Bjpg7EBLBvqqiMQ29KUXOsDU",
-	"t2OojYF8UC+iqhB0YQhAwVrqBhNKhfyrpqR3g5cpGHd4i5LZMUJu1OQJOuXTTE8MGuNgjBlZgpVMMiwf",
-	"5F2EhpDMtzvjnxlbfuQ39ltxidamnqt2TDaOuPIWnk09V8XP6k6DbTJduneQ6sr2qkLCr+bZqoA8xrKt",
-	"r2VIZkO2Z9WWPdK56U+wZsse6TSFYsVnc1HMJyRIOK10l7+XrdER0zR/I36uSDLp7FGYaoIzXuQ1nS4q",
-	"aonggjLpA2dhrYqeVkZEC73kc8QqmRfwcPt5yaRwbhcYh6DVarUOaufvsF3ZtlAphJcl1neLwCOJ79YR",
-	"Sdjw28eHMkJjmlWHqDftgs0sR2r5WK0CiJ3wcrCBghhFkyzX8qBhI1AtlnNB2B+5NLPZrAjVZ+VHBH15",
-	"qddtd84HnUK1WFa3JcZ2KXRysRDVSGjMYrHU11ylWA5rPqGHc19ztWK5KKntQWEr4pTiiWBe+iMeIHzI",
-	"BhbSV7R4SB/76pq5r7ljJJL3m6ksFnSRUPV7v6eplrizbUxZYCoFBQ6lE+B7ILjg0kGJnQa+lH3SVRSY",
-	"KA9E2GEA+TV93m7BV21k9SL75MHIj2/qzi4VaipqVcvlWH5RmTXPcwIHufQSnNPebqwkAZXIJYkGQVj3",
-	"uII4YWkKZgByTg28uMMNiHAjpF6u/TCUk5tcGSiH9RyEiqWaDkAZePURm+u0W4JfH/F8ihQ5XQSwYrKx",
-	"GcZIs6q4SQEvqRtVeOkPbMalOlXwoZSsInh0A8uS3KtLUAahOl4r9V1TwlKQQABbUCCHzpTg6ORyttz+",
-	"8IuMfqZwp/ZHlgQlTpQM7ic4EVycoTmimalfKVVPeQYno8s2gv2SJBeDrafwMsBAZR9Qc/7D5r90SH2J",
-	"AsHdD4tD1UJdSxZgviwKH0vcqvx4bIOsWhbDAorakEvuMIFMrV3Kf512UTcjBXgETJPKxoWOFPUQob+L",
-	"utuk5ZIyGpdrvs7uhrc8bFI+LnwDUBWOKSUU9MqDIOYFFaUjlBpSWnmhh1QCMRdXPVGcrA7Du/ANu9LH",
-	"1L/0Pnf86H0s2bdiYXLgSZHXyckFTqsw0u2yUYqjUN4GhSPshIF7hA0l8X15VcY01s0wBzTMA6i9HL0p",
-	"FxUYAdd3BPYcBAR2URDgZ81BZ7xi+8Hx2Wx/60FU4JCqCvmZynzpJpm1zkokxMtqXSpzx0FGmE70GJpi",
-	"6vP0ql5c+etQy1JXjqsCseQqKf0RPHW1TTeRgwTK2kGU7/nClOTjzNe7e1zIf4OaQzqDzOTg1acCaoYm",
-	"V6EGGFAll034VCrpLEUNjesCJZUu3eCThDJqRAOvUg6DxYVEP1ck1hj4gLrbmPj0xD6286siMmT4UpFk",
-	"/MUu1Sr51P7naodFXym4kIciuCDOfKGgVF2iukYDzviXmLJaLrNSjhImVpbkqmEWgrs9laVZC13ivxG5",
-	"f5LzlrzncJ3rJllC0CyizV/osyUuP13hYmNiJT22pAeinPCYDlovvXxl4HSNhM+IFF8ndqojusiSB+H+",
-	"DDEUohKEa8EYGaK60GZ6bXxaXMMoMkCBjv9Wopvf4K8ppP/l3pom3V/mq/1UJyZ5Q+8akxUI+7LJiiRp",
-	"qzXjxoo7MldNVCOklsL21j2qGvnUiohGW5eC+Ffq8Z/rqSxuZ13NeHfRJs36RR1flr8iZcBMH3dbFcAl",
-	"c4w/cebZx7My5t+K1PaqI1rShkRn7IpgQF2UaguZ+pMFwem6POB0SIS+KZ6L2HE9gzI9YRUpS/2cQBP8",
-	"gojv/gr0HBI5PYmI9Gmyc4UpbKKsoBokmIZmFHrzEMP6PvlSdDHdmlySuoVtcYXdslOVvKbtZ2WUsm8u",
-	"XO+ejFJI/UWuyYp76zJwXVwMOJNuCpz+C9JKicsJ/3bJpLT4pQ3TkngqIQ92fIohjquU0YVud8qDTZM/",
-	"oYrSFVxLE2SBl6gTY9Tw5RpcsZwD/IEcJjqxF5YuCGjxqCrsm54vN6CX2r0qheee1xJAdrwMG/5F2jh9",
-	"cnutTo5Ob0e3L4a7HUsZxtXqcaEQNx4GD/7ChzrEIpDrUQbZHCBiqgOowEVQ5UjASCp8l06RCTilpJgR",
-	"tv9l23QrReCPYLofpeVLW9eKROoaoJ/poKTuh82ShSTywd/p8z1TbfhFuQGCkIlMgBwkVxZfLQ0pcKsk",
-	"QSU8AwL+G0pFft2fVwqmpWu5BMNoukwWpqqqMtANOv8QTBO3KGhJjl+3tEpIw0roT+28x/bbo6s5x5St",
-	"iOT+GqYkDhZ+DsHUGbY1Acv2Jw6XEYwQCZFbjRBHQcn6alQ+mQcIB/9XZwIiIvx/kQtYOkawdkMjWo7/",
-	"PtUUyidiCOr4Y5UOWVTL/0RaLwbJdAkXH+OGSruKQbl5vEkpVsyVmVQJTVx4ucLiXMnS9O9iR05+0uTD",
-	"ITLlK41itq1ebhUVCGt9r+vIMg+FqLrHNd+L5dzHt4//FwAA///YoFGWCHkAAA==",
+	"DmkBNfdHhUrVrBVgvbFbqFd3dxuNer1cLpdz+dyYMhfKCfk+NjeTysxFqGh+xBGCjhNMLImamh0Pte7m",
+	"EdMsWE+ohHR8fEsiHBs6QpyvJqIJBdzae0kCW+W/SN2RIbVjzLQ0LDhWgh4uKWEsjHzsmIiVppVSMAP+",
+	"T2X6f6uUh365XN2l4zFH4rdylg504I8AXSlvFAc9iWDArLXjIk3PtDz4RMRiFkwEshBbAq/bLcNNNVOD",
+	"hITOax4uMzs7JkiKZtJe3N4uLIYHGSICBM0jR1Ktzo2LKJ8LPM5nKDJDta0Whp50oEM2ymWobzJWcD4+",
+	"6wXUBJaKfrpVHwkYrosk8SgXDKFng7ouFpn29hcbcvvXkFxS9BQNZfOM+XnQmEArK0q61F+Ag3lonqSp",
+	"O+/cXbe2jYECGNF0sgKhZeWvaRDT3tA0scQKOpcxYoyhw1E+LVzKcgSytZ5jgYmRouJzQV38DqMgZ23P",
+	"ZOuPfC4eMG7qfRhryxdhb4L2cTXSn6uQ4jD2PRFdVBvllbH0soEOoMkwIAkmnsdKgwmkNSujF6bz0Bs0",
+	"hDMHlISOXdCpCE7gVMqNS1nqEwcqVEPRCsccGD6Ti96ZK6eI+55HmQgjj61ETs0vWomJVJ0KwxY/Ppth",
+	"S3B5iTbf1knyegfi+/wBDXu9h8ajrxtJFhrz7VVecplme3gBAgugS6h3GKMswytAAmJHPka6Om25JFDI",
+	"9XrZSLKocQyBH+aUpMD9xy3527klWRxaRua7bMcPcTOS+vq7vZANS3K966F+Hjg+8hgm4jvN75+1pKvN",
+	"IBiFqAHzc8bwB5jnLUxg0rZtsnsQcEwsB8Vm9XPM36csXj6X5TKASCg2+wwpkSPa0UgybL0hXXLHMi1r",
+	"Wlh/hoVVaMTS+Eu8X3wDBiVjbPlM4az2E/QsEvsMxSFpCeAgyIVyfAIf/csIcuQz50sefHGxtIfS51a/",
+	"kIBSmX0Bi1kB1+diSEYIcA8ZeIyRWQTdsRY0DdEFkMU+59UolJmIyQYeQwYyETGkxzUkKvsKXQQgV74+",
+	"MgEc0Skqgq4pZTKkjBbCJHUDxFMbZWEazjBJkSHThjoFZ1AiEBElyf4Ss5HTLDVLejuoJAFRXqK8lNhg",
+	"W/CN4W32fQwbGZNny7NiWnREqYMgWXyWHFndBhE4cpCZ/XGMHbRSSVueNUEZUnJ8eQwmaB6lszm2CAjj",
+	"Lp3JVGQOZakI2pCAEQIQWJ6lulIGILi97iX3sQvyv4POcfccXB5fgsvbg163Dc46j+Cgd9E+U5+HZEjc",
+	"q+75wXHLGBj0oNM67I2bjycT9H66C02n/zjbg8fHXecUOqJ5+lJ9Kx1Uz3bs7rjrvx0L7+5lDw1J79o6",
+	"vN3bfYE3De/usOEe9U9r3gQRdF0ybtzX16vJ+fyK2w9VevUw67zfDkaV9nm/PW4fW5OH5lV1SN6fJqxr",
+	"tNlR+ao6Y2cjB/qmfbuD7yBpHXK30nzsvPJRo3Vb2zPFLevXrh7Ne2v/eucBX47vmtdDcnbwclOuTe8O",
+	"Lsz+gD/W9nuwTXa7XuVi6jW7HVrqos7dY+XVbV9ctuBZeXR6UvPHVr3townfuRkMyezq/ga1e2/+U2/3",
+	"ov9ALy7PZtP+1fhtZFUeDptT/6l8Jl5KxvlJ9Q365TeXt/z9k1MPTaYXl9dvzpDMX8XL/GnM6B1GR3Nv",
+	"9mRNr2aCkH6zZA06fun07oY9lhtVt3N7s9c2Rnv1iXFydHM07k8cMjkuDUl5fFtvXcNGuX5Se3spT8QI",
+	"1aZnxuUDvbzwzw7u+MlgWi7fHj+25pfIn+8094zb0mPH7u9NaoO7s5ch2UXdJ2uO+xflmVN5PD68PjN8",
+	"Zzbh+60d35lYFXozqvPau/s0vSzvHdObt/t69QWeNe4HO+f2E0JD0twtP9A7e2RUzrzBzsv4ib5w1hFP",
+	"zcvR7dPO4/Soee0x877FXk5Gp5PqqXd91nq7sd/4VYsf2MeVISn3/LfqPewflK1qt3Fp9M3TkvH6QstN",
+	"w2AvBw8+frtnuIH9/f6D13y9KY0H7+cuN7sWaZZen86GBDevfGfs7+35r/Z9aSaqI0GwsK7564v91vdf",
+	"Hm/rT6O6PRFHTfvstvTwsFevvtq9xtmsdd26ah0MiTg8On66v54absc6O+xXzgat5pN7NxnVTu3eTb/S",
+	"eziYw/uKbRCnFb43Tk6n0L17MduN6ZAYrrGDr04vDg76B+1Wq36EOx10susy++hkz7/jV71+v1p+bBhP",
+	"Nnl7bB61XLWG2sez5lF7NukOycGse3x0RU/bLd4+OHhst2ad9onVaR/VW622Nbla9N45f2yV9g4ePcuZ",
+	"D1pPjyf2y/zMHpLSznj3/XJ8Nx2dVMud19qku3dxdHBeJr2HnYPbiutPBzuvN/6gdt9jBzW3duw7wju7",
+	"7pye9YTb6BwOSYUdvz+06E1l7u0/dpu91qHZb7cv5i+tF07vb5t7j7d+e6c0Ii/sBl1Xe9cX7fH8sr23",
+	"e7/fbOCLuyFxG4OdEb86nO21qz3mmK1+vX/o0/lTZYDFMXyqn1317sTOTQdW6pg/Do7bL+907/KxeVc7",
+	"vZg0ykNivd5bzep5aeRWO++DvZtm7b5zOKo405d615m+Wd3XM2RVKu8Pj28uexw8nZ62x9P38Y5zPtj1",
+	"36yTIXl5K52W585TtYdHx2z3uNWaX+zf3rPW02A26Jc7xstNc9Zpk7fJ4NCfv7r3s7vp+cGD3+neNS9Q",
+	"7XFI+vi2Mj49b3Jz79DjR2+N/s6DSfrkarBzwl5uLs8Oa+49c1om6dzY5uNd8+Vp4t3bh3NeK+3vo4sh",
+	"sSdl1iPz8sv5bAL9cQnfNi+M3Ydpf/LSu+6fWo3b/buz+al/fy/eZw/kpX/euL8+Ong9q/Mn6vb7QzIW",
+	"o5uTyk5jPrq+L7Vq04MRfLu+r4q92/fzF+MdTQZPHQx75/u90olx2u5eV66OmrvN6qHZcjpH++aQTKrW",
+	"FX4cXLUgPC2fnrbeT6bXk+vTXs86qz5ePeKT87t5VdRO50djzqDbmA3a9xdj+xJ1572Dm6fTIZky79y5",
+	"HKExv9lv7N2MqwfnXd96f2Ltxt3b4eBs8mRd25W74+mge0Xa8/fJ1Xy3c1t9vfTwfWNf6ij7svvwxM6o",
+	"cVY76w32S/j99Orm2hEv/dZvQ/Lb5fhmb0iUdemcH64zPZ8olklH+bFaq8AHSnqloY+h/SVeHCOTMugx",
+	"Kj3EImVWKez3T2lZf9PfC7WqDmwhM+zfolKUTW7GwilbRiLCQX4uGogIytX4/2RIenrot2aBC4agGxsZ",
+	"yn936/qNwu8AcnQx2AKXle6HxzBlWMyzUyWcO89TxPB4nuXZZDjAWU73UnCXFfw9p4tvtsuhpJ3tDAGR",
+	"3hef8yB23wrs0aJLMhdYbS7Dpx4i3IDeJqAXHiKDdusynT+PuWYe5cJiiL8669dAopAwq5TQg0yo4BsT",
+	"69mlZkaZzQA5yBDApjPl55uYT4KAMyykiIDIUOEL9AUtOFP3i/7ucwQYnAGfOIjreIAhFUCoEIXpwMKl",
+	"PhEexUSHrzMbGzYwIEcAiwWc3l2/CL4o2NCZwTkfEp8jLt/nAZoiomsuFkMQCtCbYDAOvwi+MDj7AlRP",
+	"iVmEPh+SLCAr8Az2z4PtYgZnuXzOmbq5fC6kQObWsQfnDoXm94nxegGO7/9vgjSIt/3I53yOWEb6Qe3O",
+	"0DFQn3X5DAxCT8SAAQmAZliToAPCOSaWJB5mgCH5SuBpUAPEVUXCYHAigw6+bcrhlmsVs3lnJ55cyU7B",
+	"rcz/XCMTnEABOkQg5jEshQ0T/w38cn3S6f0KmsX6Om25ACQDz0KznvuOzMW3DVO6ZFSqqHBmoeS9GYY5",
+	"fqbMKnJuhRYqCIafPd3nGRLO8fPIqzafEbEhMZCZy3+6q40t+zu6STvBXGRiyObf0d3FBLvQ2bangfkn",
+	"mj5zxKaIPTuVz3SaUTbhQhmqP9OzunVPH2/bFDW3bWljD8JtG2PuPtNtG1Puedu29QxcMPnWLOMCEhMy",
+	"c/v22PpM22drRclPxkqMpwWTarMXqM0Asq4Ahhn1v9tnXldpggw7kEwyr0QOOk4Cl0C/a9sebN6ESWJe",
+	"BC1lBICLLVuo/LENpwhAw0CcA0GHhCEJyxDITIItDsmQXK/4GFWmSd9C6lpA5AAORtpayNdHyrleAhq3",
+	"vkrr5vLBQ0HDmEcv6tFTI3rajZ72oqcFiP3wafGQhrpfjp4q0VM1eqrl8jntryvMgkcJLgwW9mLPzdhz",
+	"rE29vFEY+WYxTHMZc81LzKUQ0JlOHCqWF79PIleJ4lHCp04aYxeTZ47fM/CWb8Ps9cIrl47haC5U9Xpk",
+	"cKuV+l69WdutN/O5t4JFCwEGPiZit6584MhlS+1UTiHbaKZjnfMLhLMs9XH78k+dO8nm3BQ62ATHlFoO",
+	"Cg80cZXllVCCQle9iwPa1PV8gcA5NVHkoQu7OCQdaNhAz1Cl96NKdhhl8VlI7/DUlJxgEdyp8XXQyKU3",
+	"/HVIACiAL1J+vv6BXIgdbH58+QpaBKhf0iFkSiVIZcKQxxCXYrMYy5AgQGpSRXBEGQi4kwdfoIMN9N/B",
+	"76JB3S/FYGRpsLGBWrrfJ3HQQwcgVo3tzgtUuv8F6Hn/DT2Pe1QUraBT2CeOkvJuP0uNYP6qb1HjlSKB",
+	"6WLCM2lgUhdi8vUP/X854I2NwDEY+FggoN+CXzyGXcjmvy4P7jh6QMlw7dor7kMR9E1TxFK4KhRkKPRl",
+	"CScAumO9qZjcFVonnJjrHlKSw5MYZK6hhVROn61TYrckG7l8LiUV27Iwl89p5i0TW3rnmszxlz/+fFak",
+	"OH5cNbTaR5Pwn9MlxJAbiJiQiMKIQWwWauVao1LbqAZj4PKbiqtPbm4u11bdZJMOCwdtLrXRzfIhpG/x",
+	"8XpBAi05JlIJvK0j7AX2m05VBYAlCold8c9VNMTPfi2bgfblbeJ0WKikFQvyQGcY9RkynfJTCYvFNn9q",
+	"iz8KGcPMZNAr08dYHBfbqijgRp0r+8gHJaQbk1yDG9nqI5/LdgEGgQsQzDQ0/UWgjkZwJKQRLMdPesgO",
+	"0qEBKl703SEx0RgTZILRPNZO2bWkWqlX9+v7u3vV/d1VPoQ+PPK8ZZ1Mwg/IPI0XcTxB5qVxspZXvJou",
+	"W9i3LOOJ18dJNkQgQynhvvLtpTMKsaOx9RAxpXzkc8pb1I8aa/3MkIW5QEqIvsWPlyygLUlaMOvtqgmT",
+	"ZwNStA1ARGvyJjztGZ3qmEkM1DkdKQGmhQpR8bL6hQkX0HGQdA0tQ0axlmRFpGl1aVu8FTVkbD7lno0U",
+	"0OCpQKcyuJ5xRw6oj7rKuCA55uJVHOTUNjOX5EW7u/U566jtTzllHSzfjII7FVIHsNPXC9xe93RqNw/w",
+	"WC7iPNChiHIxwRgJw5Y+agClCLqupyJB5Zr8r8+c/5Ud5OqHHMyQ4+SHROeKE4f6JDA3KApXpzWL2dcK",
+	"6CMAGWpXF0ggLF0IAIP6dvBLIM1fQbm6W66PqibcRfuN+sis1UfNUbMKm7UGasC9PbM62i2Px/DXvK6t",
+	"GDFIDLvg4AkCDI0RU+UxC3hSDBbVKlIefk2dzlpukX2cYLycjtyim83dZSocIoGYiwniYGajgBQ6IEkc",
+	"OHQhgRZi4BcDEtNBHia/AmwiIrCYxyt8VJIgzBcs1aRQwn2VU5bCNMYGFHLcOFchB7qEMtXGRmRIItmJ",
+	"+C6tYihIcfbH6m1WLoFleQ/3ZJYkPkwepVLLSVJK79yhxJKBFPCog415qsowy4PTiTczG1wAZSFN3cOE",
+	"wHwiV7py7Oxz17HRA7O10XkMZ5KlSoJDHMuUXbkVyX1XxjWbtVeQZA/bf1uMtvoETHilwNKoyKMrvqyp",
+	"q1VbtNmTwJZrNlZ9IjB0CFcEGRkfpohxvE29esC1gDphtwW6+fDGgADHGN1+VE17yPSfUMYebpmuKGPX",
+	"v+IZsWKxWPwzxe3rB6xsPeK/T8l7BjLXSHqA0sHLuG4o9mnT8eGwafYY8VrZzaWif7JSdHOxxKfrQaPD",
+	"xkEsmFSsHVUbylVZpiqmkBZOWtjoRoWoHji0cisM26JWdDmsswhl6JlzJxvp/9TDZLpGG0paVLMsmR2k",
+	"9uRTxsYQeKp4XAj4lUjvcGQwJNSnGKYe5HxGWeZBDym+hcx1sLwMMg+KEI4tO3UTkmA+ypIyyixIgnqd",
+	"RIdquV6uVev5rDNVtrF5Iei4Bjpg7EBLBvqqiMQ29G0dOsDU13qojYF8UC+iqhB0YQhAwVrqBhNKhfyr",
+	"pqR3g5cpGHd4i5LZMUJu1OQJOuXTTE8MGuNgjBlZgpVMMiwf5F2EhpDMt7ucIDO23HRWf/XtX5t6rtox",
+	"2TjiyuuDNvVcFT+ryxi2yXTp3kGqK9urCgm/mmerAvIYy7a+TyKZDdmeVVv2SOemP8GaLXuk0xSKFZ/N",
+	"RTGfkCDhtNJd/l62RkdM0/yN+LkiyaSzR2GqCc54kdd0uqioJYILyqQPnIW1KnpaGREt9JLPEatk3hzE",
+	"7eclk8K5XWAcglar1Tqonb/DdmXbQqUQXpZY3y0CjyS+W0ckYcNvHx/KCI1pVh2i3rQLNrMcqeVjtQog",
+	"dsLLwQYKYhRNslzLg4aNQLVYzgVhf+TSzGazIlSflR8R9OWlXrfdOR90CtViWV3zGNul0MnFQlQjoTGL",
+	"xVJfc5ViOaz5hB7Ofc3ViuWipLYHha2IU4ongnnpj3iA8CEbWEjfLeMhfeyra+a+5o6RSF7MprJY0EVC",
+	"1e/9nqZa4rK5MWWBqRQUOJROgO+B4GZOByV2GvhS9klXUWCiPBBhhwHk1/R5uwVftZHVi+yTByP1pS86",
+	"1FTUqpbLsfyiMmue5wQOcuklOKe93VhJAiqRSxINgrDucQVxwtIUzADknBp4cfkcEOFGSL1c+2EoJze5",
+	"MlAO6zkIFUs1HYAy8OojNtdptwS/PuL5FClyughgxWRjM4yRZlVxkwJeUjeq8NIf2IxLdargQylZRfDo",
+	"BpYluY9dUbRJ6rumhKUggQC2oEAOnSnB0cnlbLn94Tcw/UzhzrrIKUNe4rTJEIIEQ4L7MzRjNE/1K6Xx",
+	"Kc9gaHTnRrBtkmRmsAMVXmYYaO4Das5/HBnSZ9WXKBBcAbE4Wy3UtWoB5ssS8bHEtMqPx3YNwwKK2pBL",
+	"7jCBTK1kyn+dklEXJAV4BEyTOseFjpT4EKG/i9bbpOySMhqXa77O/IaXPWzSQS58A1DVjyldFPTKgyD0",
+	"BRWlKpQ2Usp5oY5UHjEX10BRuKzOxLvwDbvS1dS/9HZ3/AR+LOe3YmFy4EmR1znKBU6rMNLtslGKo1De",
+	"BoUj7ITxe4QNJfHteVXNNNbNMAc0TAeoLR29NxfVGQHXdwT2HAQEdlEQ52fNQSe+YtvC8dlsf/lBVOeQ",
+	"Kg75qTo9faHMWp8lEuJltS6VueMgI8wqegxNMfV5elUvrix2qGWpK9NVnVhylZT+CJ662rSbyEECZW0k",
+	"yvd8YUrycebrTT4u5L9B6SGdQWZy8OpTATVDk6tQAwyokssmfCqjdJaihsZ1gZLKmm5wTUIZNaKBVymH",
+	"weJeop8rElEdxEp7sY2JT0/sYzv3KiJDhksVScZf7Fmtkk/thq52WPTNggt5KIIL4swXCkqVJ6rbNOCM",
+	"f4kpq+VqK+UoYWJlSa4aZiG421NZmrXQM/4bkfsnOW/J6w7XuW6SJQTNItr8hT5b4vLWFS42JlbSY0t6",
+	"IMoJj+mg9dLLV8ZP10j4jEjxdWKHO6L7LHkQ9c8QQyEqQdQWjJEhqgttptfGp8U1DCYDFOj4byW6+Q3+",
+	"mkL6X+6tadL9Zb7aTw9M+TYhTiDsyyYrkqSt1owbq/HIXDVRqZBaCttb96h45FMrIhptXSbiX6nHf66n",
+	"srikdTXj3UWbNOsX5XxZ/oqUATN96m1VAJdMNf7EmWef0sqYfytS26tOakkbEh21K4IBdVGqLWTqTy4E",
+	"h+zygNMhEfqmey5ip/YMyvSEVaQs9XMCTfALIr77K9BzSKT2JCLSp8lOGaawiZKDapBgGppR6M1DDOv7",
+	"8EvR/XRrcknqMrbFTXbLTlXytraflVHKvsBwvXsySiH1F7kmK66vy8B1cT/gTLopcPovSCsl7ij82yWT",
+	"0uKXNkxL4qmEPNj4KYY4rlJGF7rdKQ/2Tv6EKkoXci1NkAVeok6MUcOXa3DFcg7wB3KY6OBeWMEgoMWj",
+	"4rBver7cgF5qE6sUHn9eSwDZ8TJs+Bdp4/QB7rU6OTrEHV3CGG56LGUYV6vHhULceCY8+Asl6iyLQK5H",
+	"GWRzgIipzqECF0GVIwEjqfBdOkUm4JSSYkbY/pft1q0UgT+C6X6Ulu9uXSsSqduAfqaDkromNksWksgH",
+	"f2fQ90y17xflBghCJjIBcpBcWXy1NKTArZIElfAMCPhvKBX5dX8eKpiWLukSDKPpMlmYKq7KQDfo/EMw",
+	"TVymoCU5fuvSKiENC6I/tQEf23aPbugcU7YikvtrmJI4X/g5BFNH2dYELNsfPFxGMEIkRG41QhwFleur",
+	"UflkHiAc/F+dCYiI8P9FLmDpNMHaDY1oOf77FFUon4ghqOOPVTpkUTT/E2m9GCTTJVx8jBsq7SoGVefx",
+	"JqVYTVdmUiU0ceEdC4vjJUvTv4udPPlJkw+HyJSvNIrZtnq5VVQnrPW9LifLPBuiyh/XfC+Wcx/fPv5f",
+	"AAAA//8CTwNQyHkAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -259,7 +259,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UploadStatus'
+                $ref: '#/components/schemas/CloneStatusResponse'
   /compose:
     post:
       summary: compose image
@@ -520,6 +520,16 @@ components:
         reason:
           type: string
         details: {}
+    CloneStatusResponse:
+      required:
+        - compose_id
+      allOf:
+        - type: object
+          properties:
+            compose_id:
+              type: string
+              format: uuid
+        - $ref: '#/components/schemas/UploadStatus'
     UploadStatus:
       required:
         - status

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -1231,7 +1231,7 @@ func (h *Handlers) GetCloneStatus(ctx echo.Context, id uuid.UUID) error {
 		return err
 	}
 
-	var options UploadStatus_Options
+	var options CloneStatusResponse_Options
 	uo, err := cloudStat.Options.AsAWSEC2UploadStatus()
 	if err != nil {
 		logrus.Errorf("Unable to decode clone status: %v", err)
@@ -1247,10 +1247,11 @@ func (h *Handlers) GetCloneStatus(ctx echo.Context, id uuid.UUID) error {
 		return err
 	}
 
-	return ctx.JSON(http.StatusOK, UploadStatus{
-		Status:  UploadStatusStatus(cloudStat.Status),
-		Type:    UploadTypes(cloudStat.Type),
-		Options: options,
+	return ctx.JSON(http.StatusOK, CloneStatusResponse{
+		ComposeId: &cloneEntry.ComposeId,
+		Status:    CloneStatusResponseStatus(cloudStat.Status),
+		Type:      UploadTypes(cloudStat.Type),
+		Options:   options,
 	})
 }
 

--- a/internal/v1/handler_get_compose_status_test.go
+++ b/internal/v1/handler_get_compose_status_test.go
@@ -116,7 +116,7 @@ func TestComposeStatus(t *testing.T) {
 			imageStatus: ImageStatus{
 				Status: ImageStatusStatusSuccess,
 				UploadStatus: &UploadStatus{
-					Status:  UploadStatusStatusSuccess,
+					Status:  Success,
 					Type:    UploadTypesAws,
 					Options: ibAwsUS,
 				},
@@ -137,7 +137,7 @@ func TestComposeStatus(t *testing.T) {
 			imageStatus: ImageStatus{
 				Status: ImageStatusStatusSuccess,
 				UploadStatus: &UploadStatus{
-					Status:  UploadStatusStatusSuccess,
+					Status:  Success,
 					Type:    UploadTypesAwsS3,
 					Options: ibAwsS3US,
 				},
@@ -158,7 +158,7 @@ func TestComposeStatus(t *testing.T) {
 			imageStatus: ImageStatus{
 				Status: ImageStatusStatusSuccess,
 				UploadStatus: &UploadStatus{
-					Status:  UploadStatusStatusSuccess,
+					Status:  Success,
 					Type:    UploadTypesAzure,
 					Options: ibAzureUS,
 				},
@@ -179,7 +179,7 @@ func TestComposeStatus(t *testing.T) {
 			imageStatus: ImageStatus{
 				Status: ImageStatusStatusSuccess,
 				UploadStatus: &UploadStatus{
-					Status:  UploadStatusStatusSuccess,
+					Status:  Success,
 					Type:    UploadTypesGcp,
 					Options: ibGcpUS,
 				},
@@ -200,7 +200,7 @@ func TestComposeStatus(t *testing.T) {
 			imageStatus: ImageStatus{
 				Status: ImageStatusStatusSuccess,
 				UploadStatus: &UploadStatus{
-					Status:  UploadStatusStatusSuccess,
+					Status:  Success,
 					Type:    UploadTypesOciObjectstorage,
 					Options: ibOciUS,
 				},

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -484,14 +484,15 @@ func TestGetCloneStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cloneId, cResp.Id)
 
-	var usResp UploadStatus
+	var usResp CloneStatusResponse
 	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/clones/%s", cloneId), &tutils.AuthString0)
 
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &usResp)
 	require.NoError(t, err)
-	require.Equal(t, UploadStatusStatusSuccess, usResp.Status)
+	require.Equal(t, CloneStatusResponseStatusSuccess, usResp.Status)
 	require.Equal(t, UploadTypesAws, usResp.Type)
+	require.Equal(t, id, *usResp.ComposeId)
 
 	var awsUS AWSUploadStatus
 	jsonUO, err := json.Marshal(usResp.Options)


### PR DESCRIPTION
Clones should include their parent ID, to easily match them.
This follows rest standards.

I've got no idea how to do this properly, but I just felt it would be really nice to have compose_id in the clone detail response :thinking: 