### PR TITLE
Formatting

### DIFF
--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -9,11 +9,15 @@ GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 go install golang.org/dl/go$GO_VERSION@latest
 $GO_BINARY download
 
+# Ensure dev tools are installed
+which goimports || $GO_BINARY install golang.org/x/tools/cmd/goimports@latest
+
 # Ensure that all code has been regenerated from its sources
 $GO_BINARY generate ./...
 
 # ... the code is formatted correctly, ...
-$GO_BINARY fmt ./...
+goimports -w internal cmd
+$GO_BINARY fmt ./internal/... ./cmd/...
 
 # ... and that go.mod and go.sum are up to date.
 $GO_BINARY mod tidy


### PR DESCRIPTION
I noticed messy imports, so I propose `goimports` as well as `gofumpt` (a bonus). We find both tools not being intrusive. The patch introduces new script in the ./tools directory and moves formatting from prepare-source.sh.