### PR TITLE
api: add compose blueprint endpoint

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -100,9 +100,9 @@ func testInsertCompose(t *testing.T) {
 	migrateTern(t)
 
 	// test
-	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId)
+	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId, nil)
 	require.NoError(t, err)
-	err = d.InsertCompose(uuid.New(), "", "", ORGID1, &imageName, []byte("{}"), &clientId)
+	err = d.InsertCompose(uuid.New(), "", "", ORGID1, &imageName, []byte("{}"), &clientId, nil)
 	require.NoError(t, err)
 }
 
@@ -113,13 +113,13 @@ func testGetCompose(t *testing.T) {
 	imageName := "MyImageName"
 	clientId := "ui"
 
-	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId)
+	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId, nil)
 	require.NoError(t, err)
-	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId)
+	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId, nil)
 	require.NoError(t, err)
-	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId)
+	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId, nil)
 	require.NoError(t, err)
-	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId)
+	err = d.InsertCompose(uuid.New(), ANR1, EMAIL1, ORGID1, &imageName, []byte("{}"), &clientId, nil)
 	require.NoError(t, err)
 
 	// test
@@ -311,7 +311,7 @@ func testClones(t *testing.T) {
       }
     }
   ]
-}`), nil))
+}`), nil, nil))
 
 	require.NoError(t, d.InsertClone(composeId, cloneId, []byte(`
 {

--- a/internal/db/db_blueprints.go
+++ b/internal/db/db_blueprints.go
@@ -19,7 +19,7 @@ const (
 		VALUES($1, $2, $3, $4)`
 
 	sqlGetBlueprint = `
-		SELECT blueprints.name, blueprints.description, blueprint_versions.version, blueprint_versions.body
+		SELECT blueprints.id, blueprint_versions.id, blueprints.name, blueprints.description, blueprint_versions.version, blueprint_versions.body
 		FROM blueprints INNER JOIN blueprint_versions ON blueprint_versions.blueprint_id = blueprints.id
 		WHERE blueprints.id = $1 AND blueprints.org_id = $2 AND blueprints.account_number = $3    
 		ORDER BY blueprint_versions.created_at DESC LIMIT 1`
@@ -66,7 +66,7 @@ func (db *dB) GetBlueprint(id uuid.UUID, orgID, accountNumber string) (*Blueprin
 
 	var result BlueprintEntry
 	row := conn.QueryRow(ctx, sqlGetBlueprint, id, orgID, accountNumber)
-	err = row.Scan(&result.Name, &result.Description, &result.Version, &result.Body)
+	err = row.Scan(&result.Id, &result.VersionId, &result.Name, &result.Description, &result.Version, &result.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -414,6 +414,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPErrorList'
+  /experimental/blueprint/{id}/compose:
+    post:
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: UUID of a blueprint
+      summary: create new compose from blueprint
+      description: "create new compose from blueprint"
+      operationId: composeBlueprint
+      responses:
+        '201':
+          description: compose was created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ComposeResponse'
+        '403':
+          description: user is not allowed to compose from blueprints
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
 
 components:
   schemas:

--- a/internal/v1/handler_get_compose_status_test.go
+++ b/internal/v1/handler_get_compose_status_test.go
@@ -39,7 +39,7 @@ func TestComposeStatus(t *testing.T) {
 	}
 	crRaw, err := json.Marshal(cr)
 	require.NoError(t, err)
-	err = dbase.InsertCompose(composeId, "000000", "user000000@test.test", "000000", cr.ImageName, crRaw, (*string)(cr.ClientId))
+	err = dbase.InsertCompose(composeId, "000000", "user000000@test.test", "000000", cr.ImageName, crRaw, (*string)(cr.ClientId), nil)
 	require.NoError(t, err)
 	srv, tokenSrv := startServerWithCustomDB(t, apiSrv.URL, "", dbase, "../../distributions", "")
 	defer func() {

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -397,7 +397,7 @@ func TestComposeStatusError(t *testing.T) {
 	require.NoError(t, err)
 	imageName := "MyImageName"
 	clientId := "ui"
-	err = dbase.InsertCompose(id, "600000", "user@test.test", "000001", &imageName, json.RawMessage("{}"), &clientId)
+	err = dbase.InsertCompose(id, "600000", "user@test.test", "000001", &imageName, json.RawMessage("{}"), &clientId, nil)
 	require.NoError(t, err)
 
 	srv, tokenSrv := startServerWithCustomDB(t, apiSrv.URL, "", dbase, "../../distributions", "")

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -127,7 +127,7 @@ func TestGetComposeMetadata(t *testing.T) {
 	require.NoError(t, err)
 	imageName := "MyImageName"
 	clientId := "ui"
-	err = dbase.InsertCompose(id, "500000", "user500000@test.test", "000000", &imageName, json.RawMessage("{}"), &clientId)
+	err = dbase.InsertCompose(id, "500000", "user500000@test.test", "000000", &imageName, json.RawMessage("{}"), &clientId, nil)
 	require.NoError(t, err)
 
 	srv, tokenSrv := startServerWithCustomDB(t, apiSrv.URL, "", dbase, "../../distributions", "")
@@ -204,11 +204,11 @@ func TestGetComposes(t *testing.T) {
 
 	imageName := "MyImageName"
 	clientId := "ui"
-	err = dbase.InsertCompose(id, "500000", "user500000@test.test", "000000", &imageName, json.RawMessage("{}"), &clientId)
+	err = dbase.InsertCompose(id, "500000", "user500000@test.test", "000000", &imageName, json.RawMessage("{}"), &clientId, nil)
 	require.NoError(t, err)
-	err = dbase.InsertCompose(id2, "500000", "user500000@test.test", "000000", &imageName, json.RawMessage("{}"), &clientId)
+	err = dbase.InsertCompose(id2, "500000", "user500000@test.test", "000000", &imageName, json.RawMessage("{}"), &clientId, nil)
 	require.NoError(t, err)
-	err = dbase.InsertCompose(id3, "500000", "user500000@test.test", "000000", &imageName, json.RawMessage("{}"), &clientId)
+	err = dbase.InsertCompose(id3, "500000", "user500000@test.test", "000000", &imageName, json.RawMessage("{}"), &clientId, nil)
 	require.NoError(t, err)
 
 	composeEntry, err := dbase.GetCompose(id, "000000")
@@ -223,11 +223,11 @@ func TestGetComposes(t *testing.T) {
 	require.Equal(t, 3, result.Meta.Count)
 	require.Equal(t, 3, len(result.Data))
 
-	err = dbase.InsertCompose(id4, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId)
+	err = dbase.InsertCompose(id4, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId, nil)
 	require.NoError(t, err)
-	err = dbase.InsertCompose(id5, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), &clientId)
+	err = dbase.InsertCompose(id5, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), &clientId, nil)
 	require.NoError(t, err)
-	err = dbase.InsertCompose(id6, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-commit"}]}`), &clientId)
+	err = dbase.InsertCompose(id6, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-commit"}]}`), &clientId, nil)
 	require.NoError(t, err)
 
 	respStatusCode, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/composes?ignoreImageTypes=edge-installer&ignoreImageTypes=aws", &tutils.AuthString0)
@@ -375,7 +375,7 @@ func TestGetClones(t *testing.T) {
       "image_type": "aws"
     }
   ]
-}`), nil)
+}`), nil, nil)
 	require.NoError(t, err)
 	srv, tokenSrv := startServerWithCustomDB(t, apiSrv.URL, provSrv.URL, dbase, "../../distributions", "")
 	defer func() {
@@ -464,7 +464,7 @@ func TestGetCloneStatus(t *testing.T) {
       "image_type": "aws"
     }
   ]
-}`), nil)
+}`), nil, nil)
 	require.NoError(t, err)
 	srv, tokenSrv := startServerWithCustomDB(t, apiSrv.URL, "", dbase, "../../distributions", "")
 	defer func() {


### PR DESCRIPTION

This adds a new endpoint for composing a blueprint.
path:`/experimental/blueprint/{id}/compose`
Added a FK for reference a blueprint in compose table

Versioning association if needed will be added as a follow-up
The compose's name needs to be generated, for now I used just blueprint's name (unify the blueprint's name with a sequence number?)


