### PR TITLE
db: add composes org id index

### DIFF
--- a/internal/db/migrations-tern/008_index_composes_org_id.sql
+++ b/internal/db/migrations-tern/008_index_composes_org_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ON composes(org_id);


### PR DESCRIPTION
I noticed most queries filter records by org_id, however, there is no index on the column. With the current strategy of not deleting records from composes table, this might be a problem in the future causing too many table scans. This fixes it.

Warning: We now have three PRs with a migration, make sure we rename the numbers accordingly. Cheers. @croissanne 