### PR TITLE
.github: setup go in spec-update workflow

### DIFF
--- a/.github/workflows/spec-update.yml
+++ b/.github/workflows/spec-update.yml
@@ -11,6 +11,12 @@ jobs:
     name: "spec update"
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v4.1.0
+        with:
+          go-version: 1.19
+        id: go
+
       - name: Clone repository
         uses: actions/checkout@v3.0.2
 


### PR DESCRIPTION
Since this workflow calls prepare-source, it should setup go before running.