### PR TITLE
db: add function to GetBlueprintComposes

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -47,6 +47,7 @@ type BlueprintEntry struct {
 type DB interface {
 	InsertCompose(jobId uuid.UUID, accountNumber, email, orgId string, imageName *string, request json.RawMessage, clientId *string, blueprintVersionId *uuid.UUID) error
 	GetComposes(orgId string, since time.Duration, limit, offset int, ignoreImageTypes []string) ([]ComposeEntry, int, error)
+	GetBlueprintComposes(orgId string, blueprintId uuid.UUID, since time.Duration, limit, offset int, ignoreImageTypes []string) ([]ComposeEntryWithVersion, int, error)
 	GetCompose(jobId uuid.UUID, orgId string) (*ComposeEntry, error)
 	GetComposeImageType(jobId uuid.UUID, orgId string) (string, error)
 	CountComposesSince(orgId string, duration time.Duration) (int, error)

--- a/internal/db/db_blueprints.go
+++ b/internal/db/db_blueprints.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
 )
+
+type ComposeEntryWithVersion struct {
+	ComposeEntry
+	BlueprintId      uuid.UUID
+	BlueprintVersion int
+}
 
 const (
 	sqlInsertBlueprint = `
@@ -18,6 +25,23 @@ const (
 		INSERT INTO blueprint_versions(id, blueprint_id, version, body)
 		VALUES($1, $2, $3, $4)`
 
+	sqlGetBlueprintComposes = `
+		SELECT blueprint_versions.version, composes.job_id, composes.request, composes.created_at, composes.image_name, composes.client_id
+		FROM composes INNER JOIN blueprint_versions ON composes.blueprint_version_id = blueprint_versions.id
+		WHERE composes.org_id = $1
+		  	AND blueprint_versions.blueprint_id = $2
+			AND CURRENT_TIMESTAMP - composes.created_at <= $3
+			AND ($4::text[] is NULL OR composes.request->'image_requests'->0->>'image_type' <> ALL($4))
+			AND composes.deleted = FALSE
+		ORDER BY composes.created_at DESC
+		LIMIT $5 OFFSET $6`
+
+	sqlCountActiveBlueprintComposesSince = `
+		SELECT COUNT(*)
+		FROM composes INNER JOIN blueprint_versions ON composes.blueprint_version_id = blueprint_versions.id
+		WHERE org_id=$1 AND blueprint_versions.blueprint_id = $2 AND CURRENT_TIMESTAMP - composes.created_at <= $3 AND composes.deleted = FALSE
+		AND ($4::text[] is NULL OR composes.request->'image_requests'->0->>'image_type' <> ALL($4))`
+
 	sqlGetBlueprint = `
 		SELECT blueprints.id, blueprint_versions.id, blueprints.name, blueprints.description, blueprint_versions.version, blueprint_versions.body
 		FROM blueprints INNER JOIN blueprint_versions ON blueprint_versions.blueprint_id = blueprints.id
@@ -26,6 +50,57 @@ const (
 
 	sqlDeleteBlueprint = `DELETE FROM blueprints WHERE id = $1 AND org_id = $2 AND account_number = $3`
 )
+
+func (db *dB) GetBlueprintComposes(orgId string, blueprintId uuid.UUID, since time.Duration, limit, offset int, ignoreImageTypes []string) ([]ComposeEntryWithVersion, int, error) {
+	ctx := context.Background()
+	conn, err := db.Pool.Acquire(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer conn.Release()
+	result, err := conn.Query(ctx, sqlGetBlueprintComposes, orgId, blueprintId, since, ignoreImageTypes, limit, offset)
+	defer result.Close()
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var composes []ComposeEntryWithVersion
+	for result.Next() {
+		var version int
+		var jobId uuid.UUID
+		var request json.RawMessage
+		var createdAt time.Time
+		var imageName *string
+		var clientId *string
+		err = result.Scan(&version, &jobId, &request, &createdAt, &imageName, &clientId)
+		if err != nil {
+			return nil, 0, err
+		}
+		composes = append(composes, ComposeEntryWithVersion{
+			ComposeEntry{
+				jobId,
+				request,
+				createdAt,
+				imageName,
+				clientId,
+			},
+			blueprintId,
+			version,
+		})
+	}
+	if err = result.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	var count int
+	err = conn.QueryRow(ctx, sqlCountActiveBlueprintComposesSince, orgId, blueprintId, since, ignoreImageTypes).Scan(&count)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return composes, count, nil
+}
 
 func (db *dB) InsertBlueprint(id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage) error {
 	ctx := context.Background()


### PR DESCRIPTION
Refactors common funcionality to get generic composes and composes filtered by Blueprint.
It uses two functions, as the sql queries are quite different.

Refs HMS-3068

Currently depends on https://github.com/osbuild/image-builder/pull/921