### PR TITLE
api: add blueprint list endpoint

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -423,8 +423,16 @@ func testBlueprints(t *testing.T) {
 	require.Equal(t, updated.Version, bodyNotUpdated.Version)
 	require.Equal(t, "new name", bodyNotUpdated.Name)
 	require.Equal(t, "new desc", bodyNotUpdated.Description)
-
 	require.NotEqual(t, b1, bodyNotUpdated)
+
+	newestBlueprintVersionId := uuid.New()
+	newestBlueprintId := uuid.New()
+	newestBlueprintName := "new name"
+	err = d.InsertBlueprint(newestBlueprintId, newestBlueprintVersionId, ORGID1, ANR1, newestBlueprintName, "desc", body)
+	entries, _, err := d.GetBlueprints(ORGID1, ANR1, 100, 0)
+	require.NoError(t, err)
+	require.Equal(t, entries[0].Name, newestBlueprintName)
+	require.Equal(t, entries[1].Version, updated.Version)
 
 	err = d.DeleteBlueprint(id, ORGID1, ANR1)
 	require.NoError(t, err)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -45,6 +45,14 @@ type BlueprintEntry struct {
 	Description string
 }
 
+type BlueprintWithNoBody struct {
+	Id             uuid.UUID
+	Version        int
+	Name           string
+	Description    string
+	LastModifiedAt time.Time
+}
+
 type DB interface {
 	InsertCompose(jobId uuid.UUID, accountNumber, email, orgId string, imageName *string, request json.RawMessage, clientId *string, blueprintVersionId *uuid.UUID) error
 	GetComposes(orgId string, since time.Duration, limit, offset int, ignoreImageTypes []string) ([]ComposeEntry, int, error)
@@ -60,6 +68,7 @@ type DB interface {
 	InsertBlueprint(id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage) error
 	GetBlueprint(id uuid.UUID, orgID, accountNumber string) (*BlueprintEntry, error)
 	UpdateBlueprint(id uuid.UUID, blueprintId uuid.UUID, orgId string, name string, description string, body json.RawMessage) error
+	GetBlueprints(orgID, accountNumber string, limit, offset int) ([]BlueprintWithNoBody, int, error)
 	DeleteBlueprint(id uuid.UUID, orgID, accountNumber string) error
 }
 

--- a/internal/db/db_blueprints.go
+++ b/internal/db/db_blueprints.go
@@ -49,6 +49,19 @@ const (
         );`
 
 	sqlDeleteBlueprint = `DELETE FROM blueprints WHERE id = $1 AND org_id = $2 AND account_number = $3`
+
+	sqlGetBlueprints = `
+		SELECT blueprints.id, blueprints.name, blueprints.description, MAX(blueprint_versions.version) as version, MAX(blueprint_versions.created_at) as last_modified_at
+		FROM blueprints INNER JOIN blueprint_versions ON blueprint_versions.blueprint_id = blueprints.id
+		WHERE blueprints.org_id = $1 AND blueprints.account_number = $2
+		GROUP BY blueprints.id
+		ORDER BY last_modified_at DESC
+		LIMIT $3 OFFSET $4`
+
+	sqlGetBlueprintsCount = `
+		SELECT COUNT(*)
+		FROM blueprints
+		WHERE blueprints.org_id = $1 AND blueprints.account_number = $2`
 )
 
 func (db *dB) InsertBlueprint(id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage) error {
@@ -144,4 +157,36 @@ func (db *dB) DeleteBlueprint(id uuid.UUID, orgID, accountNumber string) error {
 		return fmt.Errorf("%w, expected 1, returned %d", AffectedRowsMismatchError, tag.RowsAffected())
 	}
 	return err
+}
+
+func (db *dB) GetBlueprints(orgID, accountNumber string, limit, offset int) ([]BlueprintWithNoBody, int, error) {
+	ctx := context.Background()
+	conn, err := db.Pool.Acquire(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, sqlGetBlueprints, orgID, accountNumber, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var blueprints []BlueprintWithNoBody
+	for rows.Next() {
+		var blueprint BlueprintWithNoBody
+		err = rows.Scan(&blueprint.Id, &blueprint.Name, &blueprint.Description, &blueprint.Version, &blueprint.LastModifiedAt)
+		if err != nil {
+			return nil, 0, err
+		}
+		blueprints = append(blueprints, blueprint)
+	}
+	var count int
+	err = conn.QueryRow(ctx, sqlGetBlueprintsCount, orgID, accountNumber).Scan(&count)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return blueprints, count, nil
 }

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -218,6 +218,27 @@ type AzureUploadStatus struct {
 	ImageName string `json:"image_name"`
 }
 
+// BlueprintItem defines model for BlueprintItem.
+type BlueprintItem struct {
+	Description    string             `json:"description"`
+	Id             openapi_types.UUID `json:"id"`
+	LastModifiedAt string             `json:"last_modified_at"`
+	Name           string             `json:"name"`
+	Version        int                `json:"version"`
+}
+
+// BlueprintsResponse defines model for BlueprintsResponse.
+type BlueprintsResponse struct {
+	Data  []BlueprintItem `json:"data"`
+	Links struct {
+		First string `json:"first"`
+		Last  string `json:"last"`
+	} `json:"links"`
+	Meta struct {
+		Count int `json:"count"`
+	} `json:"meta"`
+}
+
 // ClientId defines model for ClientId.
 type ClientId string
 
@@ -647,6 +668,15 @@ type GetComposeClonesParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 
 	// Offset clones page offset, default 0
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
+// GetBlueprintsParams defines parameters for GetBlueprints.
+type GetBlueprintsParams struct {
+	// Limit max amount of blueprints, default 100
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset blueprint page offset, default 0
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
@@ -1180,6 +1210,9 @@ type ServerInterface interface {
 	// create new compose from blueprint
 	// (POST /experimental/blueprint/{id}/compose)
 	ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	// get a collection of blueprints
+	// (GET /experimental/blueprints)
+	GetBlueprints(ctx echo.Context, params GetBlueprintsParams) error
 	// get the openapi json specification
 	// (GET /openapi.json)
 	GetOpenapiJson(ctx echo.Context) error
@@ -1424,6 +1457,31 @@ func (w *ServerInterfaceWrapper) ComposeBlueprint(ctx echo.Context) error {
 	return err
 }
 
+// GetBlueprints converts echo context to params.
+func (w *ServerInterfaceWrapper) GetBlueprints(ctx echo.Context) error {
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetBlueprintsParams
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "limit", ctx.QueryParams(), &params.Limit)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "offset", ctx.QueryParams(), &params.Offset)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter offset: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetBlueprints(ctx, params)
+	return err
+}
+
 // GetOpenapiJson converts echo context to params.
 func (w *ServerInterfaceWrapper) GetOpenapiJson(ctx echo.Context) error {
 	var err error
@@ -1578,6 +1636,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/experimental/blueprint", wrapper.CreateBlueprint)
 	router.PUT(baseURL+"/experimental/blueprint/:id", wrapper.UpdateBlueprint)
 	router.POST(baseURL+"/experimental/blueprint/:id/compose", wrapper.ComposeBlueprint)
+	router.GET(baseURL+"/experimental/blueprints", wrapper.GetBlueprints)
 	router.GET(baseURL+"/openapi.json", wrapper.GetOpenapiJson)
 	router.GET(baseURL+"/oscap/:distribution/profiles", wrapper.GetOscapProfiles)
 	router.GET(baseURL+"/oscap/:distribution/:profile/customizations", wrapper.GetOscapCustomizations)
@@ -1590,138 +1649,140 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9eXPjtpL4V0FpX9UkP+s+bHmqUm9lWbZlS77k+2nWC5EQCYsEaACULOfn774FgKRI",
-	"ijo8mUnytjZ/TCgSaDS6G32hAf+eM6jrUYKI4Lmvv+e4YSMXqsfW/aDTrrYdSpD86THqISYwUh8ZsjAl",
-	"8slE3GDYE+pnrgX0FwA50F9GyASYDIkthMe/lkomNXgRzngRuvCdkqJB3ZIequRAgbgo3XLEjn1sopLP",
-	"MbEKGiIvwCnEDhxhB4t54Z0SxIu2cJ3/MCgxkCd42HBIcvmcmHso9zXHBcPEyn3kc9yGDD3PsLCfoWFQ",
-	"P5hwCn0CIGNwDugYtO4HIGgJuof8czPqtvrL0zEo4dRB4fgF6GCo56BQRm/Q9RyU+/qvXKVaqzd295r7",
-	"5Uo19y2fwwK5Cl0PCoGYRPW//lUu7H/7vVL9+EfWdF341tWdKuVy9F1NLkUNTn1maK6mMUgMvTREAmY+",
-	"5xP86qNgUMF89PGRzzH06mOGTAkykJlvUU86ekGGkKBa94NB7dZzKDSv0auPuLhQLIkPnNl6IKDw+bJ8",
-	"+szJwDmFkGy0AptVuCRHWSFT2zDy89T885i2miCryA1dnEBFviiUjWatvLdf29trNPYbZn2UJacLRbLo",
-	"jPzCDHFRqCx3SHFQjptfK1jMsLFAhvCZmmUG6sywk8O/NXefd+tZyGIXWuhZvlZdIyov+r4adFbN6ppe",
-	"gAx5lGNBWYBGUg8dQI5AvAkYUwaEjYCFp4gAE0vII18oVUtMAGPzLOZiAvAPhsa5r7n/KC30fClQ8qXr",
-	"cID5MoZpQksqJQmQmsMm6icptg6tJZ5lkK/17jO03SLVOBPoomU6n0MXSV0vKWswBIVU7bJ9cUj6Phdg",
-	"hCxMgFxyAAIHSeULKAPEd0eI5QEiZvJjPvgkG/nERIwblKG84pEL58CgREBMACXOPOjCwz48H+vC88BD",
-	"DFOT5yUse+7ZiPDikNzYCAgqoAMcRCxhA8yBg10sURcU7JaBYUMGDQm5mLQruR4m/ltXzi+nLERPQch9",
-	"3S3ncy4m4c9KPmZnfvmvf8HCe6vwJM3NP379/4nfi8fn4bBY+Pb/Yi++/ePX7AWvddezxajvrWdJ2Bao",
-	"tmBmI4bUB8UjwG3qOyYYIeArSUBmesI31DcguQ7AHKsRs3wDjRE2l9HpHobIBKgIGwoww46jxuWa6hJR",
-	"Z6pxE4hAIhTHuT+KYEkfojgkhxQQKoDH6BSbCMCg+TM2JZvjHeSrmY1I0BYTC0AQYZqeqVb9WXNLglw1",
-	"wwSqWxH6fgm35Eh5AB1OZSfuS2g0c9KSTKamCSaG46vPK2dZRw2zOaoaBTiq1gv1eqVW2C8bjcJupVor",
-	"76JmeR9la99wvHUMDhi3xeTBja1WHZkA9OY5EBMObDobEkHBGBMTYDkbBUMpKnBJmYDO15TP6GKDUU7H",
-	"QrmMiBR8XoKyfQkaAk9RwcQMGVI/l8Y+MaGLiIAOX/pasOmsIGhBDl3Qs8hgT0SDdYxJC+Dn2NMw9tC4",
-	"MdotVIzauFA3YbkAd6vVQnlU3i1Xa/vmnrm30aanFESmXVlo/1UeSVLrL1B05wUcKMD1aMQAZKHQdjAi",
-	"ohsI1Bj6jpD2yZP+CCK+q4ym+uXjGICFSKrAKrBdEggl6GKc+/qvDbYxFpR9fFuA4R4lPCNO0xKfUBNI",
-	"OqQF1NwfFSpVs1aA9cZuoV7d3W006vVyuVzO5XNjylwoJ+T72NxMKjMXoaL5EUcIOk4wsSRqanY81Lqb",
-	"R0yzYD2hEtLx8S2JcGzoCHG+mogmFHBr7yUJbJX/InVHhtSOMdPSsOBYCXq4pISxMPKxYyJWmlZKwQz4",
-	"P5Xp/61SHvrlcnWXjsccid/KWTrQgT8CdKW8URz0JIIBs9aOizQ90/LgExGLWTARyEJsCbxutww31UwN",
-	"EhI6r3m4zOzsmCApmkl7cXu7sBgeZIgIEDSPHEm1Ojcuonwu8DifocgM1bZaGHrSgQ7ZKJehvslYwfn4",
-	"rBdQE1gq+ulWfSRguC6SxKNcMISeDeq6WGTa219syO1fQ3JJ0VM0lM0z5udBYwKtrCjpUn8BDuaheZKm",
-	"7rxzd93aNgYKYETTyQqElpW/pkFMe0PTxBIr6FzGiDGGDkf5tHApyxHI1nqOBSZGiorPBXXxO4yCnLU9",
-	"k60/8rl4wLip92GsLV+EvQnax9VIf65CisPY90R0UW2UV8bSywY6gCbDgCSYeB4rDSaQ1qyMXpjOQ2/Q",
-	"EM4cUBI6dkGnIjiBUyk3LmWpTxyoUA1FKxxzYPhMLnpnrpwi7nseZSKMPLYSOTW/aCUmUnUqDFv8+GyG",
-	"LcHlJdp8WyfJ6x2I7/MHNOz1HhqPvm4kWWjMt1d5yWWa7eEFCCyALqHeYYyyDK8ACYgd+Rjp6rTlkkAh",
-	"1+tlI8mixjEEfphTkgL3f27J384tyeLQMjLfZTt+iJuR1Nff7YVsWJLrXQ/188DxkccwEd9pfv+oJV1t",
-	"BsEoRA2YnzOGP8A8b2ECk7Ztk92DgGNiOSg2q59j/j5l8fK5LJcBREKx2WdIiRzRjkaSYesN6ZI7lmlZ",
-	"08L6MyysQiOWxl/i/eIbMCgZY8tnCme1n6BnkdhnKA5JSwAHQS6U4xP46F9GkCOfOV/y4IuLpT2UPrf6",
-	"hQSUyuwLWMwKuD4XQzJCgHvIwGOMzCLojrWgaYgugCz2Oa9GocxETDbwGDKQiYghPa4hUdlX6CIAufL1",
-	"kQngiE5REXRNKZMhZbQQJqkbIJ7aKAvTcIZJigyZNtQpOIMSgYgoSfaXmI2cZqlZ0ttBJQmI8hLlpcQG",
-	"24JvDG+z72PYyJg8W54V06IjSh0EyeKz5MjqNojAkYPM7I9j7KCVStryrAnKkJLjy2MwQfMonc2xRUAY",
-	"d+lMpiJzKEtF0IYEjBCAwPIs1ZUyAMHtdS+5j12Q/x10jrvn4PL4ElzeHvS6bXDWeQQHvYv2mfo8JEPi",
-	"XnXPD45bxsCgB53WYW/cfDyZoPfTXWg6/cfZHjw+7jqn0BHN05fqW+mgerZjd8dd/+1YeHcve2hIetfW",
-	"4e3e7gu8aXh3hw33qH9a8yaIoOuSceO+vl5NzudX3H6o0quHWef9djCqtM/77XH72Jo8NK+qQ/L+NGFd",
-	"o82OylfVGTsbOdA37dsdfAdJ65C7leZj55WPGq3b2p4pblm/dvVo3lv71zsP+HJ817wekrODl5tybXp3",
-	"cGH2B/yxtt+DbbLb9SoXU6/Z7dBSF3XuHiuvbvvisgXPyqPTk5o/tuptH034zs1gSGZX9zeo3Xvzn3q7",
-	"F/0HenF5Npv2r8ZvI6vycNic+k/lM/FSMs5Pqm/QL7+5vOXvn5x6aDK9uLx+c4Zk/ipe5k9jRu8wOpp7",
-	"sydrejUThPSbJWvQ8Uundzfssdyoup3bm722MdqrT4yTo5ujcX/ikMlxaUjK49t66xo2yvWT2ttLeSJG",
-	"qDY9My4f6OWFf3Zwx08G03L59vixNb9E/nynuWfclh47dn9vUhvcnb0MyS7qPllz3L8oz5zK4/Hh9Znh",
-	"O7MJ32/t+M7EqtCbUZ3X3t2n6WV575jevN3Xqy/wrHE/2Dm3nxAakuZu+YHe2SOjcuYNdl7GT/SFs454",
-	"al6Obp92HqdHzWuPmfct9nIyOp1UT73rs9bbjf3Gr1r8wD6uDEm5579V72H/oGxVu41Lo2+elozXF1pu",
-	"GgZ7OXjw8ds9ww3s7/cfvObrTWk8eD93udm1SLP0+nQ2JLh55Ttjf2/Pf7XvSzNRHQmChXXNX1/st77/",
-	"8nhbfxrV7Yk4atpnt6WHh7169dXuNc5mrevWVetgSMTh0fHT/fXUcDvW2WG/cjZoNZ/cu8modmr3bvqV",
-	"3sPBHN5XbIM4rfC9cXI6he7di9luTIfEcI0dfHV6cXDQP2i3WvUj3Omgk12X2Ucne/4dv+r1+9XyY8N4",
-	"ssnbY/Oo5ao11D6eNY/as0l3SA5m3eOjK3rabvH2wcFjuzXrtE+sTvuo3mq1rcnVovfO+WOrtHfw6FnO",
-	"fNB6ejyxX+Zn9pCUdsa775fju+nopFruvNYm3b2Lo4PzMuk97BzcVlx/Oth5vfEHtfseO6i5tWPfEd7Z",
-	"def0rCfcRudwSCrs+P2hRW8qc2//sdvstQ7Nfrt9MX9pvXB6f9vce7z12zulEXlhN+i62ru+aI/nl+29",
-	"3fv9ZgNf3A2J2xjsjPjV4WyvXe0xx2z16/1Dn86fKgMsjuFT/eyqdyd2bjqwUsf8cXDcfnmne5ePzbva",
-	"6cWkUR4S6/XealbPSyO32nkf7N00a/edw1HFmb7Uu870zeq+niGrUnl/eHxz2ePg6fS0PZ6+j3ec88Gu",
-	"/2adDMnLW+m0PHeeqj08Oma7x63W/GL/9p61ngazQb/cMV5umrNOm7xNBof+/NW9n91Nzw8e/E73rnmB",
-	"ao9D0se3lfHpeZObe4ceP3pr9HceTNInV4OdE/Zyc3l2WHPvmdMySefGNh/vmi9PE+/ePpzzWml/H10M",
-	"iT0psx6Zl1/OZxPoj0v4tnlh7D5M+5OX3nX/1Grc7t+dzU/9+3vxPnsgL/3zxv310cHrWZ0/UbffH5Kx",
-	"GN2cVHYa89H1falVmx6M4Nv1fVXs3b6fvxjvaDJ46mDYO9/vlU6M03b3unJ11NxtVg/NltM52jeHZFK1",
-	"rvDj4KoF4Wn59LT1fjK9nlyf9nrWWfXx6hGfnN/Nq6J2Oj8acwbdxmzQvr8Y25eoO+8d3DydDsmUeefO",
-	"5QiN+c1+Y+9mXD047/rW+xNrN+7eDgdnkyfr2q7cHU8H3SvSnr9Prua7ndvq66WH7xv7UkfZl92HJ3ZG",
-	"jbPaWW+wX8Lvp1c314546bd+G5LfLsc3e0OirEvn/HCd6flEsUw6yo/VWgU+UNIrDX0M7S/x4hiZlEGP",
-	"UekhFimzSmG/f0rL+pv+XqhVdWALmWH/FpWibHIzFk7ZMhIRDvJz0UBEUK7G/ydD0tNDvzULXDAE3djI",
-	"UP67W9dvFH4HkKOLwRa4rHQ/PIYpw2KenSrh3HmeIobH8yzPJsMBznK6l4K7rODvOV18s10OJe1sZwiI",
-	"9L74nAex+1ZgjxZdkrnAanMZPvUQ4Qb0NgG98BAZtFuX6fx5zDXzKBcWQ/zVWb8GEoWEWaWEHmRCBd+Y",
-	"WM8uNTPKbAbIQYYANp0pP9/EfBIEnGEhRQREhgpfoC9owZm6X/R3nyPA4Az4xEFcxwMMqQBChShMBxYu",
-	"9YnwKCY6fJ3Z2LCBATkCWCzg9O76RfBFwYbODM75kPgccfk+D9AUEV1zsRiCUIDeBINx+EXwhcHZF6B6",
-	"Sswi9PmQZAFZgWewfx5sFzM4y+VzztTN5XMhBTK3jj04dyg0v0+M1wtwfP9/E6RBvO1HPudzxDLSD2p3",
-	"ho6B+qzLZ2AQeiIGDEgANMOaBB0QzjGxJPEwAwzJVwJPgxogrioSBoMTGXTwbVMOt1yrmM07O/HkSnYK",
-	"bmX+5xqZ4AQK0CECMY9hKWyY+G/gl+uTTu9X0CzW12nLBSAZeBaa9dx3ZC6+bZjSJaNSRYUzCyXvzTDM",
-	"8TNlVpFzK7RQQTD87Ok+z5Bwjp9HXrX5jIgNiYHMXP7TXW1s2d/RTdoJ5iITQzb/ju4uJtiFzrY9Dcw/",
-	"0fSZIzZF7NmpfKbTjLIJF8pQ/ZGe1a17+njbpqi5bUsbexBu2xhz95lu25hyz9u2rWfggsm3ZhkXkJiQ",
-	"mdu3x9Zn2j5bK0p+MlZiPC2YVJu9QG0GkHUFMMyo/90+87pKE2TYgWSSeSVy0HESuAT6Xdv2YPMmTBLz",
-	"ImgpIwBcbNlC5Y9tOEUAGgbiHAg6JAxJWIZAZhJscUiG5HrFx6gyTfoWUtcCIgdwMNLWQr4+Us71EtC4",
-	"9VVaN5cPHgoaxjx6UY+eGtHTbvS0Fz0tQOyHT4uHNNT9cvRUiZ6q0VMtl89pf11hFjxKcGGwsBd7bsae",
-	"Y23q5Y3CyDeLYZrLmGteYi6FgM504lCxvPh9ErlKFI8SPnXSGLuYPHP8noG3fBtmrxdeuXQMR3Ohqtcj",
-	"g1ut1PfqzdpuvZnPvRUsWggw8DERu3XlA0cuW2qncgrZRjMd65xfIJxlqY/bl3/o3Ek256bQwSY4ptRy",
-	"UHigiassr4QSFLrqXRzQpq7nCwTOqYkiD13YxSHpQMMGeoYqvR9VssMoi89CeoenpuQEi+BOja+DRi69",
-	"4a9DAkABfJHy8/V35ELsYPPjy1fQIkD9kg4hUypBKhOGPIa4FJvFWIYEAVKTKoIjykDAnTz4Ah1soP8M",
-	"fhcN6n4pBiNLg40N1NL9PomDHjoAsWpsd16g0v0vQM/7T+h53KOiaAWdwj5xlJR3+1lqBPNXfYsarxQJ",
-	"TBcTnkkDk7oQk6+/6//LAW9sBI7BwMcCAf0W/OIx7EI2/3V5cMfRA0qGa9decR+KoG+aIpbCVaEgQ6Ev",
-	"SzgB0B3rTcXkrtA64cRc95CSHJ7EIHMNLaRy+mydErsl2cjlcymp2JaFuXxOM2+Z2NI712SOv/zx57Mi",
-	"xfHjqqHVPpqE/5wuIYbcQMSERBRGDGKzUCvXGpXaRjUYA5ffVFx9cnNzubbqJpt0WDhoc6mNbpYPIX2L",
-	"j9cLEmjJMZFK4G0dYS+w33SqKgAsUUjsin+uoiF+9mvZDLQvbxOnw0IlrViQBzrDqM+Q6ZSfSlgstvlT",
-	"W/xRyBhmJoNemT7G4rjYVkUBN+pc2Uc+KCHdmOQa3MhWH/lctgswCFyAYKah6S8CdTSCIyGNYDl+0kN2",
-	"kA4NUPGi7w6JicaYIBOM5rF2yq4l1Uq9ul/f392r7u+u8iH04ZHnLetkEn5A5mm8iOMJMi+Nk7W84tV0",
-	"2cK+ZRlPvD5OsiECGUoJ95VvL51RiB2NrYeIKeUjn1Peon7UWOtnhizMBVJC9C1+vGQBbUnSgllvV02Y",
-	"PBuQom0AIlqTN+Fpz+hUx0xioM7pSAkwLVSIipfVL0y4gI6DpGtoGTKKtSQrIk2rS9viraghY/Mp92yk",
-	"gAZPBTqVwfWMO3JAfdRVxgXJMRev4iCntpm5JC/a3a3PWUdtf8op62D5ZhTcqZA6gJ2+XuD2uqdTu3mA",
-	"x3IR54EORZSLCcZIGLb0UQMoRdB1PRUJKtfkv33m/LfsIFc/5GCGHCc/JDpXnDjUJ4G5QVG4Oq1ZzL5W",
-	"QB8ByFC7ukACYelCABjUt4NfAmn+CsrV3XJ9VDXhLtpv1EdmrT5qjppV2Kw1UAPu7ZnV0W55PIa/5nVt",
-	"xYhBYtgFB08QYGiMmCqPWcCTYrCoVpHy8GvqdNZyi+zjBOPldOQW3WzuLlPhEAnEXEwQBzMbBaTQAUni",
-	"wKELCbQQA78YkJgO8jD5FWATEYHFPF7ho5IEYb5gqSaFEu6rnLIUpjE2oJDjxrkKOdAllKk2NiJDEslO",
-	"xHdpFUNBirM/Vm+zcgksy3u4J7Mk8WHyKJVaTpJSeucOJZYMpIBHHWzMU1WGWR6cTryZ2eACKAtp6h4m",
-	"BOYTudKVY2efu46NHpitjc5jOJMsVRIc4lim7MqtSO67Mq7ZrL2CJHvY/ttitNUnYMIrBZZGRR5d8WVN",
-	"Xa3aos2eBLZcs7HqE4GhQ7giyMj4MEWM423q1QOuBdQJuy3QzYc3BgQ4xuj2o2raQ6b/hDL2cMt0RRm7",
-	"/hXPiBWLxeIfKW5fP2Bl6xH/fUreM5C5RtIDlA5exnVDsU+bjg+HTbPHiNfKbi4V/YOVopuLJT5dDxod",
-	"Ng5iwaRi7ajaUK7KMlUxhbRw0sJGNypE9cChlVth2Ba1osthnUUoQ8+cO9lI/189TKZrtKGkRTXLktlB",
-	"ak8+ZWwMgaeKx4WAX4n0DkcGQ0J9imHqQc5nlGUe9JDiW8hcB8vLIPOgCOHYslM3IQnmoywpo8yCJKjX",
-	"SXSoluvlWrWezzpTZRubF4KOa6ADxg60ZKCvikhsQ9/WoQNMfa2H2hjIB/UiqgpBF4YAFKylbjChVMi/",
-	"akp6N3iZgnGHtyiZHSPkRk2eoFM+zfTEoDEOxpiRJVjJJMPyQd5FaAjJfLvLCTJjy01n9Vff/rWp56od",
-	"k40jrrw+aFPPVfGzuoxhm0yX7h2kurK9qpDwq3m2KiCPsWzr+ySS2ZDtWbVlj3Ru+hOs2bJHOk2hWPHZ",
-	"XBTzCQkSTivd5e9la3TENM3fiJ8rkkw6exSmmuCMF3lNp4uKWiK4oEz6wFlYq6KnlRHRQi/5HLFK5s1B",
-	"3H5eMimc2wXGIWi1Wq2D2vk7bFe2LVQK4WWJ9d0i8Ejiu3VEEjb89vGhjNCYZtUh6k27YDPLkVo+VqsA",
-	"Yie8HGygIEbRJMu1PGjYCFSL5VwQ9kcuzWw2K0L1WfkRQV9e6nXbnfNBp1AtltU1j7FdCp1cLEQ1Ehqz",
-	"WCz1NVcplsOaT+jh3NdcrVguSmp7UNiKOKV4IpiXfo8HCB+ygYX03TIe0se+umbua+4YieTFbCqLBV0k",
-	"VP3ev9JUS1w2N6YsMJWCAofSCfA9ENzM6aDETgNfyj7pKgpMlAci7DCA/Jo+b7fgqzayepF98mCkvvRF",
-	"h5qKWtVyOZZfVGbN85zAQS69BOe0txsrSUAlckmiQRDWPa4gTliaghmAnFMDLy6fAyLcCKmXaz8M5eQm",
-	"VwbKYT0HoWKppgNQBl59xOY67Zbg10c8nyJFThcBrJhsbIYx0qwqblLAS+pGFV76HZtxqU4VfCglqwge",
-	"3cCyJPexK4o2SX3XlLAUJBDAFhTIoTMlODq5nC23P/wGpp8p3FkXOWXIS5w2GUKQYEhwf4ZmjOapfqU0",
-	"PuUZDI3u3Ai2TZLMDHagwssMA819QM35jyND+qz6EgWCKyAWZ6uFulYtwHxZIj6WmFb58diuYVhAURty",
-	"yR0mkKmVTPnPUzLqgqQAj4BpUue40JESHyL0d9F6m5RdUkbjcs3Xmd/wsodNOsiFbwCq+jGli4JeeRCE",
-	"vqCiVIXSRko5L9SRyiPm4hooCpfVmXgXvmFXupr6l97ujp/Aj+X8VixMDjwp8jpHucBpFUa6XTZKcRTK",
-	"26BwhJ0wfo+woSS+Pa+qmca6GeaAhukAtaWj9+aiOiPg+o7AnoOAwC4K4vysOejEV2xbOD6b7S8/iOoc",
-	"UsUhP1Wnpy+UWeuzREK8rNalMnccZIRZRY+hKaY+T6/qxZXFDrUsdWW6qhNLrpLS78FTV5t2EzlIoKyN",
-	"RPmeL0xJPs58vcnHhfw3KD2kM8hMDl59KqBmaHIVaoABVXLZhE9llM5S1NC4LlBSWdMNrkkoo0Y08Crl",
-	"MFjcS/RzRSKqg1hpL7Yx8emJfWznXkVkyHCpIsn4kz2rVfKp3dDVDou+WXAhD0VwQZz5QkGp8kR1mwac",
-	"8S8xZbVcbaUcJUysLMlVwywEd3sqS7MWesZ/I3L/JOcted3hOtdNsoSgWUSbP9FnS1zeusLFxsRKemxJ",
-	"D0Q54TEdtF56+cr46RoJnxEpvk7scEd0nyUPov4ZYihEJYjagjEyRHWhzfTa+LS4hsFkgAId/61EN7/B",
-	"X1NI/+Xemibdn+ar/fTAlG8T4gTCvmyyIknaas24sRqPzFUTlQqppbC9dY+KRz61IqLR1mUi/ko9/nM9",
-	"lcUlrasZ7y7apFm/KOfL8lekDJjpU2+rArhkqvEnzjz7lFbG/FuR2l51UkvakOioXREMqItSbSFTf3Ih",
-	"OGSXB5wOidA33XMRO7VnUKYnrCJlqZ8TaIJfEPHdX4GeQyK1JxGRPk12yjCFTZQcVIME09CMQm8eYljf",
-	"h1+K7qdbk0tSl7EtbrJbdqqSt7X9rIxS9gWG692TUQqpP8k1WXF9XQaui/sBZ9JNgdO/IK2UuKPwb5dM",
-	"Sotf2jAtiecaIY+y4J6fIei+Z64X9FvVIC7oa+1PeNs5TID8tPH4fML8rwobfvYKLf/1K1TLiF4b9b9i",
-	"iUok5AoZU5+k45klAd60FLbYSNCrS4V4gZcwZtRdZw10s/8lq+QPWIjPXC69EMClxOZKb01KQnDJ799G",
-	"V2eKyAqNvUamlNwGe/fFEPVV/uSFbnfKg+3vP6Ay0rW4S/NmQaCv9zao4ctltcIjC/AHcpjo7HVYhCag",
-	"xaP63m96vtyAXqoOoRTeYLGWALLjZdjwT3Ko03dwrHWro3s4ont0w33rpU2i1R7uwqfdeK1H8Eem1HFE",
-	"gVyPMsjmABFTXSUAXARVmhuMpM/u0ikyAaeUFDMyr39awcVKEfg9mO5Hafn67bUikbrQ7Wea09RN31my",
-	"kEQ++FOx2mKZi/QuQchEJkAOkiuLr5aGFLhVkqD2rAIC/htKRX7dX/gLpqWrcgXDaLpMFqbqYzPQDTr/",
-	"EEwT9+FoSY5fnLdKSMMzLZ+qoYpVTkWXLI8pW5GM+3OYkjgi/jkEU6eR1+Sctj87voxghEiI3GqEOAoO",
-	"H61G5ZOp3HDwvzqZGxHhf0U6d+lA2No96Wg5/vvUxSmfiCGoA9RVOmRx7ukn0noxSKZLuPgYN1TaVQwO",
-	"DsWblGJluZl58dDEhdfkLE4ILk3/LnZ48CdNPhwiU77SKGbb6uVW0VEPre91RXDm8T5Vwb7me7Gc+/j2",
-	"8T8BAAD//6B3y9iLfwAA",
+	"H4sIAAAAAAAC/+x9e1PjuLL4V1HlnqrZ/ZH3AwJVW+eGECBAeIX3Zi5XsRVbxJaMZCeE/fHdb0nyO3YS",
+	"Zmdm95w6+8esY0utVnerX2qJPwoatR1KEHF5Ye+PAtdMZEP52Lkf9rr1rkUJEj8dRh3EXIzkR4YMTIl4",
+	"0hHXGHZc+bPQAeoLgByoL2OkA0xGxHRdh+9VKjrVeBnOeRna8J2SskbtihqqYkEXcbdyyxE78rCOKh7H",
+	"xCgpiLwEZxBbcIwt7C5K75QgXjZd2/ovjRINOS4PGo5IoVhwFw4q7BW4yzAxCh/FAjchQ89z7JrPUNOo",
+	"5084hT4BkDG4AHQCOvdD4LcE/QP+uRn1O4Pl6WiUcGqhYPwStDBUc5AoozdoOxYq7P1eqNUbzdb2Tnu3",
+	"WqsXvhYL2EW2RNeBrouYQPV/fq+Wdr/+Uat//CNrujZ866tOtWo1/C4nl6IGpx7TFFfTGCSGXhoiAbNY",
+	"8Ah+9ZA/qMs89PFRLDD06mGGdAHSl5mvYU86fkGaK0B17ofDxq1jUahfo1cPcfdCsiQ+cGbroQtdjy/L",
+	"p8esDJxTCIlGOdjk4ZIcJUemNmHk56n585iWT5A8ckMbJ1ARL0pVrd2o7uw2dnZard2W3hxnyWmkSKLO",
+	"yCvNEXdLteUOKQ6KcYsrBYtpJnaR5npMzjIDdaaZyeHf2tvP280sZLENDfQsXsuuIZWjvq8andezuqYX",
+	"IEMO5dilzEcjqYf2IUcg3gRMKAOuiYCBZ4gAHQvIY8+VqpboAMbmWS7EBOAfDE0Ke4X/qkR6vuIr+cp1",
+	"MMBiGcM0oQWVkgRIzWEd9ZMUW4XWEs8yyNd59xjabJEqnAm00TKdz6GNhK4XlNUYgq5Q7aJ9eUQGHnfB",
+	"GBmYALHkAAQWEsoXUAaIZ48RKwJE9OTHov9JNPKIjhjXKENFySMbLoBGiQsxAZRYC78LD/rwYqwLLwIH",
+	"MUx1XhSwzIVjIsLLI3JjIuBSF1rAQsRwTYA5sLCNBeouBdtVoJmQQU1ALiftSuEME++tL+ZXkBbiTEIo",
+	"7G1XiwUbk+BnrRizM7/8z++w9N4pPQlz849f/3/id/T4PBqVS1//X+zF13/8mr3gle56Nhj1nNUsCdoC",
+	"2RbMTcSQ/CB5BLhJPUsHYwQ8KQlIT0/4hnoaJNc+mCM5YpZvoDDC+jI6/YMAGR8V14QumGPLkuNyRXWB",
+	"qDVTuLmIQOJKjnNvHMISPkR5RA4oINQFDqMzrCMA/ebPWBdsjncQr+YmIn5bTAwAQYhpeqZK9WfNLQky",
+	"b4YJVDci9P0SbsmRigBanIpO3BPQaOakBZl0RRNMNMuTn3Nn2UQtvT2uayU4rjdLzWatUdqtaq3Sdq3e",
+	"qG6jdnUXZWvfYLxVDPYZt8HkwY0pVx2ZAvTmWBATDkw6HxGXggkmOsBiNhKGVFTgkjIXWnspn9HGGqOc",
+	"TlzpMiJS8ngFivYVqLl4hko6ZkgT+rky8YgObURcaPGlryWTzksuLYmhS2oWGewJabCKMWkB/Bx7WtoO",
+	"mrTG26Wa1piUmjqsluB2vV6qjqvb1XpjV9/Rd9ba9JSCyLQrkfbP80iSWj9C0V6UsK8AV6MRA5CFwr7l",
+	"IYdh4mZ7FQkZy3DDlCROKLOhW9greB7Ws+TWgtx9tqmOJxjpz6JpBqxgkksfZojxJAKYuMhAbHmyYvSg",
+	"uQ+xmJhEBi5f42Tg14g7lPCMWFGHLtzY+CfpmmH5xarL4PcEM55NHoH3+lhA9fdbZzHcRmoWyWGl078B",
+	"gVW7ZbipZnKQYI5FRTlB5q6FEXH7vvqaQM8SUgMd4f0i4tnSRZO/PBwbJSKCDON9T0kAoQRdTAp7v6/x",
+	"xGIpgI+vEZg8TiupThglJMKfEmrvjku1ut4owWZru9Ssb2+3Ws1mtVqtForrlsGyrIaoqNUfRwhalj+x",
+	"NKNsh/LAxq8fMc3/1YRK6KKPr2neh0OHiH+v5ZIE9q1rJuJYBTq4IlVfaexhS0esMqtV/Bnwf0pH87da",
+	"deRVq/VtOplw5P5WzdNcfx50rbpWHP7uC3eJP3urRTPpndzeRv6JAxkiLvCbh2GLXJ3F9bbEj2/yrMiG",
+	"FolFOmStXAb6JtPaxGYdQU1gKemnWg2QC4N1kSQe5S5D6Fmjto3dTO/uFxNy89eAXEL0JA1F84z5OVCb",
+	"QiMrJr9UX4CFeeAMCcfqvHd33dk04vZhhNPJCruXBNinQUx7Q13HAitoXcaIMYEWR8W0cEnL4cvWao75",
+	"JkaIisddauN3GIbUK3smW38UC/H0xLreB7G2PEqypByoSI0MFjKAPUj4JrFYtt6q5mZult1BH9q5cnhi",
+	"YOJZ0zQYX1qz8sdB8hi9Qc21FoCSIIzwO5XBMZwJubEpS33iQCYGULjCMQeax8SitxbSBeee41DmBnHu",
+	"RiIn5xeuxERiWAb90Y/P5nMTXF6izddVkrzagfg2f0DBXh0P8PDrWpIFxnxzlZdcptnxhI9ABHQJ9R5j",
+	"lGUFFC7ElngMdXXacgmgkGcGHFkK2G8cQ+C7OSUpcP9xS/52bkkWh5aR+Sbb8V3cjKS+/mYvZM2SXO16",
+	"yJ9hPPqN5vfPWtJ8MwjGAWpA/5wx/A7meQMTmLRt6+weBBwTw0KxWf0Y8/cpixclVxKUD4Vivc+QErnM",
+	"zMpqQ7rkjmVa1rSw/ggLK9GIbRot8T76BjRKJtjwmMRZ7l6pWSR2tcoj0nGBhSB3pePj++hfxpAjj1lf",
+	"iuCLjYU9FD63/IVcKJTZFxDNCtged0dkjAB3kCazU2XQnyhBUxBtAFnsc1GOQpmOmGjgMKQhHRFNeFwj",
+	"InP90EYAcunrIx3AMZ2hMujrQiYDyighTFLXRzy1LRskfTWdlBnSTagSvholLiJuRbC/wkxktSvtitp8",
+	"rAhAlFcoryS2cyO+MbzJLqNmIm36bDhGTIuOKbUQJNFnwZH8NojAsYX07I8TbKFcJW04xhRlSMnR5RGY",
+	"okW4ecKxQUAQd6m8uSRzIEtl0IUEjBGAwHAM2ZUyAMHt9VmyaqIk/tvvHfXPweXRJbi83T/rd8Fp7xHs",
+	"n110T+XnERkR+6p/vn/U0YYa3e91Ds4m7cfjKXo/2Ya6NXic78Cjo751Ai23ffJSf6vs10+3zP6k770d",
+	"uc7dyw4akbNr4+B2Z/sF3rScu4OWfTg4aThTRNB1RbuxX1+vpueLK24+1OnVw7z3fjsc17rng+6ke2RM",
+	"H9pX9RF5f5qyvtZlh9Wr+pydji3o6ebtFr6DpHPA7Vr7sffKx63ObWNHd2/ZoHH1qN8bu9dbD/hycte+",
+	"HpHT/ZebamN2t3+hD4b8sbF7Brtku+/ULmZOu9+jlT7q3T3WXu3uxWUHnlbHJ8cNb2I0ux6a8q2b4YjM",
+	"r+5vUPfszXs6274YPNCLy9P5bHA1eRsbtYeD9sx7qp66LxXt/Lj+Br3qm8073u7xiYOms4vL6zdrRBav",
+	"7sviacLoHUaHC2f+ZMyu5i4hg3bFGPa8ysndDXustup27/Zmp6uNd5pT7fjw5nAymFpkelQZkerkttm5",
+	"hq1q87jx9lKdumPUmJ1qlw/08sI73b/jx8NZtXp79NhZXCJvsdXe0W4rjz1zsDNtDO9OX0ZkG/WfjAUe",
+	"XFTnVu3x6OD6VPOs+ZTvdrY8a2rU6M24yRvv9tPssrpzRG/e7pv1F3jauh9unZtPCI1Ie7v6QO/MsVY7",
+	"dYZbL5Mn+sJZz31qX45vn7YeZ4fta4fp9x32cjw+mdZPnOvTztuN+cavOnzfPKqNSPXMe6vfw8F+1aj3",
+	"W5faQD+paK8vtNrWNPay/+Dht3uGW9jbHTw47debymT4fm5zvW+QduX16XREcPvKsybezo73at5X5m59",
+	"7BLsGtf89cV8G3gvj7fNp3HTnLqHbfP0tvLwsNOsv5pnrdN557pz1dkfEffg8Ojp/nqm2T3j9GBQOx12",
+	"2k/23XTcODHPbga1s4f9BbyvmRqxOsF77fhkBu27F73bmo2IZmtb+OrkYn9/sN/tdJqHuNdDx9s2Mw+P",
+	"d7w7fnU2GNSrjy3tySRvj+3Dji3XUPdo3j7szqf9Edmf948Or+hJt8O7+/uP3c681z02et3DZqfTNaZX",
+	"Ue+t88dOZWf/0TGsxbDz9HhsvixOzRGpbE223y8nd7Pxcb3ae21M+zsXh/vnVXL2sLV/W7O92XDr9cYb",
+	"Nu7P2H7Dbhx5luucXvdOTs9cu9U7GJEaO3p/6NCb2sLZfey3zzoH+qDbvVi8dF44vb9t7zzeet2typi8",
+	"sBt0XT+7vuhOFpfdne373XYLX9yNiN0abo351cF8p1s/Y5beGTQHBx5dPNWG2D2CT83Tq7M7d+umB2tN",
+	"zB+HR92Xd7pz+di+a5xcTFvVETFe7412/bwytuu99+HOTbtx3zsY16zZS7Nvzd6M/uspMmq194fHN5s9",
+	"Dp9OTrqT2ftkyzofbntvxvGIvLxVTqoL66l+hsdHbPuo01lc7N7es87TcD4cVHvay0173uuSt+nwwFu8",
+	"2vfzu9n5/oPX69+1L1DjcUQG+LY2OTlvc33nwOGHb63B1oNOBuRquHXMXm4uTw8a9j2zOjrp3Zj64137",
+	"5Wnq3JsHC96o7O6iixExp1V2RhbVl/P5FHqTCr5tX2jbD7PB9OXsenBitG53704XJ979vfs+fyAvg/PW",
+	"/fXh/utpkz9RezAYkYk7vjmubbUW4+v7Sqcx2x/Dt+v7urtz+37+or2j6fCph+HZ+e5Z5Vg76fava1eH",
+	"7e12/UDvWL3DXX1EpnXjCj8OrzoQnlRPTjrvx7Pr6fXJ2ZlxWn+8esTH53eLuts4WRxOOIN2az7s3l9M",
+	"zEvUX5zt3zydjMiMOefW5RhN+M1ua+dmUt8/73vG+xPrtu7eDoan0yfj2qzdHc2G/SvSXbxPrxbbvdv6",
+	"66WD71u7QkeZl/2HJ3ZKtdPG6dlwt4LfT65uri33ZdD5bUR+u5zc7IyItC6984NVpucTpVnpKD9W2ef7",
+	"QEmvNPAxlL/EyxOkUwYdRoWHWKbMqAT9/iks62/qe6lRV4EtZJr5W1j4tM7NiJyyZSRCHMTnsoaIS7kc",
+	"/58MCU8P/dYucZchaMdGhuLf7aZ6I/HbhxxdDDfAJdf9cBimDLuL7FQJ59bzDDE8WWR5NhkOcJbTvRTc",
+	"ZQV/z+lSr81yKGlnO0NAhPfFF9yP3TcCexh1SeYC6+1l+NRBhGvQWQf0wkFk2O1cpvPnMdfModw1GOKv",
+	"1uo1kChbzSpcdSBzZfCNifFsUz2jqGuILKS5wKRz6efrmE/9gDMo2wmBiFDhC/RcWrJm9hf13eMIMDgH",
+	"HrEQV/EAQzKAkCEKU4GFTT3iOhQTFb7OTayZQIMcAexGcM7uBmXwRcKG1hwu+Ih4HHHxvgjQDBFV4RMN",
+	"QShAby6Dcfhl8IXB+RcgewrMQvT5iGQBycHTr9bwt4sZnBeKBWtmF4qFgAKZW8cOXFgU6t8mxqsFOF5t",
+	"sg7SMN72o1jwOGIZ6Qe5O0MnQH5WxVrQDz0RAxokAOpBBYwKCBeYGIJ4mAGGxCsXz/yKMy7rX4bDYxF0",
+	"8E1TDrdcqZj1Ozvx5MpGdSSRqr1GOjiGLugRFzGHYSFsmHhv4Jfr497Zr6Bdbq7SlhEgEXiW2s3CN2Qu",
+	"vq6Z0iWjQkUFMwsk703T9MkzZUaZcyOwUH4w/OyoPs+QcI6fx069/YyICYmG9ELx011NbJjf0E3YCWYj",
+	"HUO2+IbuNibYhtamPTXMP9H0mSM2Q+zZqn2m05yyKXelofozPesb9/Twpk1Re9OWJnYg3LQx5vYz3bQx",
+	"5Y6zaVtHwyWdb8wy7kKiQ6Zv3h4bn2n7bOSU/GSsxHhaMKk2z3y16UNW9eYwo9p888xrnibIsAPJJHMu",
+	"ctCyErj4+l3Zdn/zJkgS8zLoSCMAbGyYrswfm3CGANQ0xDlw6YgwJGBpLtKTYMsjMiLXOR/DOkjhWwhd",
+	"C4gYwMJIWQvx+lA610tA49ZXat1C0X8oKRiL8EUzfGqFT9vh0074FIHYDZ6ihzTU3Wr4VAuf6uFTo1As",
+	"KH9dYuY/CnBBsLATe27HnmNtmtW1wsjXi2Gay5grXmIuhIDOVeJQsrz8bRKZJ4qHCZ86aYxtTJ45fs/A",
+	"W7wNsteRVy4cw/HClWclQoNbrzV3mu3GdrNdLLyVDFryMfAwcbeb0gcOXbbUTuUMsrVmOta5GCGcZamP",
+	"upd/6pRTNudm0MI6OKLUsFBwfI7LLK+A4pdVq10c0KW247kInFMdhR66a5ZHpAc1E6gZyvR+eG4Chll8",
+	"FtA7OKMnJlgGd3J8FTRy4Q3vjQgAJfBFyM/eH8iG2ML6x5c90CFA/hIOIZMqQSgThhyGuBCbaCxNgACp",
+	"SZXBIWXA504RfIEW1tB/+7/LGrW/lP2RhcHGGuqofp/EQQ3tg8gb216UqHD/S9Bx/hs6DneoWzb8TkGf",
+	"OErSu/0sNfz5y75lhVeKBLqNCc+kgU5tiMneH+r/YsAbE4EjMPSwi4B6C35xGLYhW/y6PLhlqQEFw5Vr",
+	"L7kPXb9vmiKGxFWiIEKhL0s4AdCfqE3F5K7QKuHEXPUQkhyc+yELBS2gcvokpxS7JdkoFAspqdiUhYVi",
+	"QTFvmdjCO1dkjr/8/qcBQ8Xx/Wrv5T6agP+cLiGGXENEh8QtjRnEeqlRbbRqjbVqMAauuK6U//jm5nJl",
+	"1U026bBrofWlNqpZMYD0NT7emZ9AS46JZAJv4wg7wn7dGT4fsEAhsSv+uYqG+EnDZTPQvbxNnEUMlLRk",
+	"QRGoDKM6sahSfjJhEW3zp7b4w5AxyEz6vTJ9jOhw4kZFATfyFONH0S8hXZvkGt6IVh/FQrYLMPRdAH+m",
+	"gekvA3kQhyNXGMFq/FyR6CAcGiDjRc8eER1NMEE6GC9i7aRdS6qVZn23ubu9U9/dzvMh1FGl5w3rZBJ+",
+	"QObZz5DjCTIvjZO1vOLVdNnCvmEZT7w+TrAhBBlICfekby+cUYgtha2DiC7ko1iQ3qJ6VFirZ4YMzF0k",
+	"hehr/DBTBG1J0vxZb1ZNmDwbkKKtDyJckzfB2eLwVMdcYCBPhQkJ0A1UCouX5S9MuAstCwnX0NBEFGsI",
+	"VoSaVpW2xVtRTcTmM+6YSAL1n0p0JoLrObfEgOpgtYgLkmNGr+IgZ6aeuSQvuv2NT/WHbX/ImX5/+WYU",
+	"3MmQ2oedvszi9vpMpXaLAE/EIi4CFYpIFxNMkKuZwkf1oZRB33ZkJChdk//1mPW/ooNY/ZCDObKs4oio",
+	"XHHiCKkAZvtF4fJscDn7Egt1BCBD7aoCCYSFCwGgX98OfvGleQ9U69vV5riuw22022qO9UZz3B6367Dd",
+	"aKEW3NnR6+Pt6mQCfy2q2ooxg0QzSxaeIsDQBDFZHhPBE2IQVasIefg1dRZwuUX2cYLJcjpyg24mt5ep",
+	"cIBcxGxMEAdzE/mkUAFJ4nirDQk0EAO/aJDoFnIw+RVgHREXu4t4hY9MEgT5gqWaFEq4J3PKQpgmWIOu",
+	"GDfOVciBKqFMtTERGZFQdkK+C6sYCFKc/bF6m9wlsCzvwZ7MksQHyaNUajlJSuGdW5QYIpACDrWwtkhV",
+	"GWZ5cCrxpmeD86FE0tQ/SAjMJ3KluWNnn/KPje6brbXOYzCTLFXiH+JYpmzuViT3bBHXrNdefpI9aP81",
+	"Gi3/BExwgcXSqMihOV9W1NXKLdrsSWDD1lt5nwgMHMKcIGOj86l5TrTimk+d6JxqgG4xuJ/CxzFGt+9V",
+	"0x4w/QeUsQdbpjll7OpXPCNWLpfLf6a4ffWAtY1H/Ncpec9A5hoJD1A4eBmXW8U+rTusHjTNHiNeK7u+",
+	"VPRPVoquL5b4dD1oeNjYjwWTirUna0O5LMuUxRTCwgkLG97fEdYDB1Yux7BFtaLLYZ1BKEPPnFvZSP+n",
+	"HibTNVpT0iKbZcnsMLUnnzI2motnkscln1+J9A5HGkOu/BTD1IGczynLPOghxLeUuQ6Wl0HmQRHCsWGm",
+	"7t1ymYeypIwyAxK/XifRoV5tVhv1ZjHrTJWprV8IKq6BFphY0BCBviwiMTV1N4wKMNUlMnJjoOjXi8gq",
+	"BFUYApC/lvr+hFIhf96U1G7wMgXjDm9ZMDtGyLWaPEGnYprpiUFjHIwxI0uwkkmG5YO8UWgIyWKzywky",
+	"Y8t1Z/Xz75pb1zNvx2TtiLmXVa3rmRc/y8sYNsl0qd5+qivbqwoIn8+zvIA8xrKN75NIZkM2Z9WGPdK5",
+	"6U+wZsMe6TSFZMVnc1HMI8RPOOW6y9/K1vCIaZq/IT9zkkwqexSkmuCcl3lDpYvKSiK4S5nwgbOwlkVP",
+	"uRFRpJc8jlgt854qbj4vmRTOzRLjEHQ6nc5+4/wddmubFioF8LLE+i4KPJL4bhyRBA2/fnxIIzShWXWI",
+	"atPO38yyhJaP1SqA2AkvC2vIj1EUyQodB2omAvVyteCH/aFLM5/Py1B+ln6E35dXzvrd3vmwV6qXq/JS",
+	"0dguhUoulsIaCYVZLJbaK9TK1aDmEzq4sFdolKtlQW0HuqYkTiWeCOaVP+IBwodoYCB1t4yD1LGvvl7Y",
+	"KxwhN3kNoMxiQRu5sn7v9zTVElcbTijzTaVLgUXpFHgO8O+BtVBip4EvZZ9UFQUm0gNxzSCA3Euft4v4",
+	"qoysWmSfPBipLn1RoaakVr1ajeUXpVlzHMt3kCsv/jntzcZKElCKXJJoEAR1jznECUpTMAOQc6rh6KpD",
+	"4AYbIc1q47uhnNzkykA5qOcg1F2q6QCUgVcPsYVKuyX49RHPpwiRU0UAOZONzTBGmrziJgm8Im9U4ZU/",
+	"sB6X6lTBh1SykuDhDSxLch+7omid1Pd1AUtCAj5slwIxdKYEhyeXs+X2u9/A9COFO+sipwx5idMmQwgS",
+	"DPHvz1CMUTxVr6TGpzyDoeGdG/62SZKZ/g5UcHWmr7n3qb74fmRIn1VfooB/BUR0ttqVl/j5mC9LxMcS",
+	"02rfH9sVDPMpakIuuMNcpCslU/15SkZekOTj4TNN6BwbWkLiA4T+LlpvnbJLymhcrvkq8xtc9rBOB9nw",
+	"DUBZPyZ1kd+rCPzQF9SkqpDaSCrnSB3JPGIhroHCcFmeibfhG7aFq6l+qe3u+An8WM4vZ2Fy4AiRVznK",
+	"CKc8jFS7bJTiKFQ3QeEQW0H8HmJDSXx7XlYzTVQzzAEN0gFyS0ftzYV1RsD2LBc7FgIutpEf52fNQSW+",
+	"YtvC8dlsfvlBWOeQKg75oTo9faHMSp8lFOJltS6UuWUhLcgqOgzNMPV4elVHF2Rb1DDkBf2yTiy5Sip/",
+	"+E99Zdp1ZCEXZW0kivc8MiXFOPPVJh93xb9+6SGdQ6Zz8OpRFyqGJlehAuhTpZBN+FRG6TRFDYVrhJLM",
+	"mq5xTQIZ1cKB85TDMLqX6MeKRFgHkWsvNjHx6Yl9bOZehWTIcKlCyfjJnlWefCo3NN9hUTcLRvJQBhfE",
+	"WkQKSpYnyts04Jx/iSmr5Wor6ShhYmRJrhwmEtzNqSzMWuAZ/43I/YOct+R1h6tcN8ESguYhbX6iz5a4",
+	"vDXHxcbESHpsSQ9EOuExHbRaenlu/HSNXI8RIb5W7HBHeJ8l96P+OWIoQMWP2vwxMkQ10mZqbXxaXINg",
+	"0keBTv5Woltc469JpP9yb02R7qf5aj88MOWbhDi+sC+brFCSNlozdqzGI3PVhKVCcilsbt3D4pFPrYhw",
+	"tFWZiL9Sj/9YTyW6pDWf8XbUJs36qJwvy18RMqCnT73lBXDJVOMPnHn2Ka2M+XdCtZ13UkvYkPCoXRkM",
+	"qY1SbSGTf+DDP2RXBJyOiKv+rgJ3Y6f2NMrUhGWkLPRzAk3wCyKe/StQc0ik9gQiwqfJThmmsAmTg3IQ",
+	"fxqKUejNQQyrv75QCe+nW5FLkpexRTfZLTtVydvaflRGKfsCw9XuyTiF1E9yTXKur8vANbofcC7cFDj7",
+	"C9JKiTsK/3bJpLT4pQ3TkniuEPIwC+54GYLuOfpqQb+VDeKCvtL+BLedwwTITxuPzyfM/6qw4Uev0Opf",
+	"v0KVjKi10fwrlqhAQqyQCfVIOp5ZEuB1S2GDjQS1umSI53sJE0btVdZANfs3WSV/wkJ85nLpSACXEpu5",
+	"3pqQBP+S37+Nrs4UkRyNvUKmVshtfhCelWCNuhUB84P0F48rl0n9RVPgFw3Ie+6hZq4Q7SPkRn8h6HP7",
+	"D3FE/tqYNlIl/xZhbcafbFqZnc+VytXio0TSLycpByjmhTgXqt0J9ysy/sTc0+XhS1MLxFptt1HNEysm",
+	"J0jw8QdimPA6gKAu0oUGD0vOv6r5cg06qdKYSnCpykoCiI6XQcOfFOOlr4VZGemFV8OEVzsHpRRL+5b5",
+	"QVcUZq29acb/K3vyhKyLbIcyyBYAEV3ebgFsBOXOCxiLMNKmM6QDTikpZ2wG/LQaoFwR+MOf7kdl+Ub4",
+	"lSKRumPwR3p4qcvns2Qhibz/t7KVE6VHOw4EIR3pAFlIrCyeLw0pcHmSILdRfQL+C0pFcdWfOPWnpQrF",
+	"XYbRbJksTJZsZ6Drd/4umCauaFKSHL/LMU9Ig2NWnyrrixXzhfd+TyjLMaQ/hymJWws+h2DqgPyKNOjm",
+	"1xksIxgiEiCXjxBH/nm4fFQ+ubsQDP5X+2IhEf4tXLGlM4orHbFwOf7rlGpKn4ghqHImeTokOor3A2kd",
+	"DZLpEkYf44ZKuYr+WbZ4k0qsUjw3tpIHfvwi8OjQ6tL072LnWX/Q5IMhMuUrjWK2rV5uFZ4+UvpeFaln",
+	"njiVhypWfC9XCx9fP/4vAAD///DdCDWMhAAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -477,6 +477,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPErrorList'
+  /experimental/blueprints:
+    get:
+      summary: get a collection of blueprints
+      description: "get a collection of blueprints, returns just the latest version of each blueprint"
+      operationId: getBlueprints
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 100
+          description: max amount of blueprints, default 100
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+          description: blueprint page offset, default 0
+      responses:
+        '200':
+          description: a list of blueprints
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlueprintsResponse'
 
 components:
   schemas:
@@ -724,6 +752,52 @@ components:
         id:
           type: string
           format: uuid
+    BlueprintsResponse:
+      required:
+        - meta
+        - links
+        - data
+      properties:
+        meta:
+          type: object
+          required:
+            - count
+          properties:
+            count:
+              type: integer
+        links:
+          type: object
+          required:
+            - first
+            - last
+          properties:
+            first:
+              type: string
+            last:
+              type: string
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/BlueprintItem'
+    BlueprintItem:
+      required:
+        - id
+        - version
+        - name
+        - description
+        - last_modified_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        version:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+        last_modified_at:
+          type: string         
     Distributions:
       type: string
       description: |


### PR DESCRIPTION
```
GET /experimental/blueprints
````
This PR adds a blueprint list endpoint, which returns an array of blueprints (only the latest version of each blueprint) sorted by its latest version creation date.

Each blueprint item contains its id, name, description, latest version, version date.  body is not included.

A basic pagination with `limit` and `offset`  parameters is implemented.
