### PR TITLE
api: preload swagger spec

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -1740,12 +1740,18 @@ func PathToRawSpec(pathToFile string) map[string]func() ([]byte, error) {
 	return res
 }
 
-// GetSwagger returns the Swagger specification corresponding to the generated code
-// in this file. The external references of Swagger specification are resolved.
-// The logic of resolving external references is tightly connected to "import-mapping" feature.
-// Externally referenced files must be embedded in the corresponding golang packages.
-// Urls can be supported but this task was out of the scope.
-func GetSwagger() (swagger *openapi3.T, err error) {
+var swagger *openapi3.T
+
+func init() {
+	var err error
+	// load OpenAPI spec into memory and error out early
+	swagger, err = getSwagger()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func getSwagger() (swagger *openapi3.T, err error) {
 	var resolvePath = PathToRawSpec("")
 
 	loader := openapi3.NewLoader()
@@ -1770,4 +1776,14 @@ func GetSwagger() (swagger *openapi3.T, err error) {
 		return
 	}
 	return
+}
+
+
+// GetSwagger returns the Swagger specification corresponding to the generated code
+// in this file. The external references of Swagger specification are resolved.
+// The logic of resolving external references is tightly connected to "import-mapping" feature.
+// Externally referenced files must be embedded in the corresponding golang packages.
+// Urls can be supported but this task was out of the scope.
+func GetSwagger() *openapi3.T {
+	return swagger
 }

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -499,10 +499,7 @@ func convertIgnoreImageTypeToSlice(ignoreImageTypes *[]ImageTypes) []string {
 }
 
 func (h *Handlers) GetComposes(ctx echo.Context, params GetComposesParams) error {
-	spec, err := GetSwagger()
-	if err != nil {
-		return err
-	}
+	spec := GetSwagger()
 
 	idHeader, err := getIdentityHeader(ctx)
 	if err != nil {
@@ -1311,10 +1308,7 @@ func (h *Handlers) GetComposeClones(ctx echo.Context, composeId uuid.UUID, param
 		lastOffset = 0
 	}
 
-	spec, err := GetSwagger()
-	if err != nil {
-		return err
-	}
+	spec := GetSwagger()
 
 	return ctx.JSON(http.StatusOK, ClonesResponse{
 		Meta: struct {

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -504,9 +504,8 @@ func TestGetCloneStatus(t *testing.T) {
 }
 
 func TestValidateSpec(t *testing.T) {
-	spec, err := GetSwagger()
-	require.NoError(t, err)
-	err = spec.Validate(context.Background())
+	spec := GetSwagger()
+	err := spec.Validate(context.Background())
 	require.NoError(t, err)
 }
 

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -66,11 +66,7 @@ type Handlers struct {
 }
 
 func Attach(conf *ServerConfig) error {
-	spec, err := GetSwagger()
-	if err != nil {
-		return err
-	}
-
+	spec := GetSwagger()
 	spec.AddServer(&openapi3.Server{URL: fmt.Sprintf("%s/v%s", RoutePrefix(), spec.Info.Version)})
 
 	router, err := legacyrouter.NewRouter(spec)


### PR DESCRIPTION
Function `GetSwagger` is called in many handlers which ultimately loads OpenAPI specification over and over again for no reason in every request. Since the filename is not supposed to be changing during runtime, it can be preloaded during application startup for better performance.