### PR TITLE
db: optimize blueprint search

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -435,7 +435,10 @@ func testBlueprints(t *testing.T) {
 	require.Equal(t, entries[1].Version, updated.Version)
 
 	err = d.InsertBlueprint(uuid.New(), uuid.New(), ORGID1, ANR1, "unique name", "unique desc", body)
-	entries, count, err := d.FindBlueprints(ORGID1, "unique", 100, 0)
+	entries, count, err := d.FindBlueprints(ORGID1, "", 100, 0)
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+	entries, count, err = d.FindBlueprints(ORGID1, "unique", 100, 0)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 	require.Equal(t, "unique name", entries[0].Name)


### PR DESCRIPTION
This optimizes query in case no search is performed. In that case empty string is passed into the db function and the argument is `%%`. The change will help PostgreSQL optimizer to drop the rest of the where clause in order to quickly return results without any tablescan.

Refs: HMS-3308