### PR TITLE
templates/image-builder: parametrise Service object label

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -162,7 +162,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      service: image-builder
+      service: ${SERVICE_LABEL}
     name: image-builder
     annotations:
       prometheus.io/path: /metrics
@@ -246,3 +246,5 @@ parameters:
     value: ""
   - name: ALLOW_FILE
     value: ""
+  - name: SERVICE_LABEL
+    value: image-builder


### PR DESCRIPTION
Other services rely on the label for discovery, since there's now 2 namespaces on the same cluster with the same service (the RHEL and community ones) the two get mixed up randomly.