### PR TITLE
Revert "templates/image-builder: parametrise Service object label"

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -162,7 +162,7 @@ objects:
   kind: Service
   metadata:
     labels:
-      service: ${SERVICE_LABEL}
+      service: image-builder
     name: image-builder
     annotations:
       prometheus.io/path: /metrics
@@ -246,7 +246,5 @@ parameters:
     value: ""
   - name: ALLOW_FILE
     value: ""
-  - name: SERVICE_LABEL
-    value: image-builder
   - name: CLOWDAPP_NAME
     value: image-builder


### PR DESCRIPTION
The clowdapp name needs to be unique, not the service label.

This reverts commit a22d5a2e00e3f3e6eb90de3dd181110091558984.