### PR TITLE
Revert "image-builder: log Info messages to sentry as well"

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -58,7 +58,7 @@ func main() {
 		logrus.Warn("Sentry/Glitchtip was not initialized")
 	} else {
 		sentryhook := sentrylogrus.NewFromClient([]logrus.Level{logrus.PanicLevel,
-			logrus.FatalLevel, logrus.ErrorLevel, logrus.InfoLevel},
+			logrus.FatalLevel, logrus.ErrorLevel},
 			sentry.CurrentHub().Client())
 		logrus.AddHook(sentryhook)
 	}


### PR DESCRIPTION
This reverts commit 07167854b11a19dc9ce550545e4d70a33283c8a5.

glitchtip issues are showing, no need for InfoLevel messages anymore