### PR TITLE
v1: rename to blueprints

### DIFF
--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -414,104 +414,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Customizations'
-  /experimental/blueprint:
-    post:
-      summary: create blueprint
-      description: "create blueprint"
-      operationId: createBlueprint
-      tags:
-        - blueprint
-      requestBody:
-        required: true
-        description: details of blueprint
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateBlueprintRequest"
-      responses:
-        '201':
-          description: blueprint was saved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateBlueprintResponse'
-        '400':
-          description: blueprint is malformed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPErrorList'
-        '403':
-          description: user is not allowed to create blueprints
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPErrorList'
-  /experimental/blueprint/{id}:
-    put:
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: string
-            format: uuid
-          example: '123e4567-e89b-12d3-a456-426655440000'
-          required: true
-          description: UUID of a blueprint
-      summary: update blueprint
-      description: "update blueprint"
-      operationId: updateBlueprint
-      tags:
-        - blueprint
-      requestBody:
-        required: true
-        description: details of blueprint
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateBlueprintRequest"
-      responses:
-        '200':
-          description: blueprint was updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateBlueprintResponse'
-        '404':
-          description: blueprint was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPErrorList'
-  /experimental/blueprint/{id}/compose:
-    post:
-      parameters:
-        - in: path
-          name: id
-          schema:
-            type: string
-            format: uuid
-          example: '123e4567-e89b-12d3-a456-426655440000'
-          required: true
-          description: UUID of a blueprint
-      summary: create new compose from blueprint
-      description: "create new compose from blueprint"
-      operationId: composeBlueprint
-      responses:
-        '201':
-          description: compose was created
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ComposeResponse'
-        '403':
-          description: user is not allowed to compose from blueprints
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPErrorList'
   /experimental/blueprints:
     get:
       summary: get a collection of blueprints
@@ -548,7 +450,104 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlueprintsResponse'
-  /experimental/blueprint/{id}/composes:
+    post:
+      summary: create blueprint
+      description: "create blueprint"
+      operationId: createBlueprint
+      tags:
+        - blueprint
+      requestBody:
+        required: true
+        description: details of blueprint
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBlueprintRequest"
+      responses:
+        '201':
+          description: blueprint was saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateBlueprintResponse'
+        '400':
+          description: blueprint is malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+        '403':
+          description: user is not allowed to create blueprints
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+  /experimental/blueprints/{id}:
+    put:
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: UUID of a blueprint
+      summary: update blueprint
+      description: "update blueprint"
+      operationId: updateBlueprint
+      tags:
+        - blueprint
+      requestBody:
+        required: true
+        description: details of blueprint
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBlueprintRequest"
+      responses:
+        '200':
+          description: blueprint was updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateBlueprintResponse'
+        '404':
+          description: blueprint was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+  /experimental/blueprints/{id}/compose:
+    post:
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: UUID of a blueprint
+      summary: create new compose from blueprint
+      description: "create new compose from blueprint"
+      operationId: composeBlueprint
+      responses:
+        '201':
+          description: compose was created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ComposeResponse'
+        '403':
+          description: user is not allowed to compose from blueprints
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+  /experimental/blueprints/{id}/composes:
     get:
       summary: get composes associated with a blueprint
       description: "get a collection of composes associated to a blueprint, allows for filtering by version"

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -89,7 +89,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 	err = dbase.InsertBlueprint(id, versionId, "000000", "000000", name, description, message)
 	require.NoError(t, err)
 
-	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprint/%s/compose", id.String()), map[string]string{})
+	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/compose", id.String()), map[string]string{})
 	require.Equal(t, http.StatusCreated, respStatusCode)
 
 	var result []ComposeResponse
@@ -140,7 +140,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 	err = dbase.InsertCompose(id4, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "gcp"}]}`), &clientId, &version2Id)
 	require.NoError(t, err)
 
-	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprint/%s/composes", blueprintId.String()), &tutils.AuthString0)
+	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/composes", blueprintId.String()), &tutils.AuthString0)
 	require.NoError(t, err)
 
 	require.Equal(t, 200, respStatusCode)
@@ -154,7 +154,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 	require.Equal(t, 4, result.Meta.Count)
 
 	// get composes for specific version
-	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprint/%s/composes?blueprint_version=2", blueprintId.String()), &tutils.AuthString0)
+	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/composes?blueprint_version=2", blueprintId.String()), &tutils.AuthString0)
 	require.NoError(t, err)
 
 	require.Equal(t, 200, respStatusCode)


### PR DESCRIPTION
Although there is a precedent in using both plural and singular forms (composes/compose), I believe it is worth to be consistent.

The API is still experimental, so this patch is fine.