### PR TITLE
v1/api: composes filtering by latest blueprint version

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -471,6 +471,12 @@ func testGetBlueprintComposes(t *testing.T) {
 	versionId := uuid.New()
 	err = d.InsertBlueprint(id, versionId, ORGID1, ANR1, "name", "desc", []byte("{}"))
 	require.NoError(t, err)
+
+	// get latest version
+	version, err := d.GetLatestBlueprintVersionNumber(ORGID1, id)
+	require.NoError(t, err)
+	require.Equal(t, 1, version)
+
 	version2Id := uuid.New()
 	err = d.UpdateBlueprint(version2Id, id, ORGID1, "name", "desc2", []byte("{}"))
 	require.NoError(t, err)
@@ -512,6 +518,11 @@ func testGetBlueprintComposes(t *testing.T) {
 	require.Len(t, entries, 1)
 	require.Equal(t, "image4", *entries[0].ImageName)
 	require.Equal(t, 2, entries[0].BlueprintVersion)
+
+	// get latest version
+	version, err = d.GetLatestBlueprintVersionNumber(ORGID1, id)
+	require.NoError(t, err)
+	require.Equal(t, 2, version)
 }
 
 func runTest(t *testing.T, f func(*testing.T)) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -56,6 +56,7 @@ type BlueprintWithNoBody struct {
 type DB interface {
 	InsertCompose(jobId uuid.UUID, accountNumber, email, orgId string, imageName *string, request json.RawMessage, clientId *string, blueprintVersionId *uuid.UUID) error
 	GetComposes(orgId string, since time.Duration, limit, offset int, ignoreImageTypes []string) ([]ComposeEntry, int, error)
+	GetLatestBlueprintVersionNumber(orgId string, blueprintId uuid.UUID) (int, error)
 	GetBlueprintComposes(orgId string, blueprintId uuid.UUID, blueprintVersion *int, since time.Duration, limit, offset int, ignoreImageTypes []string) ([]BlueprintCompose, error)
 	GetCompose(jobId uuid.UUID, orgId string) (*ComposeEntry, error)
 	GetComposeImageType(jobId uuid.UUID, orgId string) (string, error)

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -917,7 +917,8 @@ type GetBlueprintsParams struct {
 
 // GetBlueprintComposesParams defines parameters for GetBlueprintComposes.
 type GetBlueprintComposesParams struct {
-	// BlueprintVersion Filter by a specific version of the Blueprint we want to fetch composes for
+	// BlueprintVersion Filter by a specific version of the Blueprint we want to fetch composes for.
+	// Pass special value -1 to fetch composes for latest version of the Blueprint.
 	BlueprintVersion *int `form:"blueprint_version,omitempty" json:"blueprint_version,omitempty"`
 
 	// Limit max amount of composes, default 100

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -605,7 +605,8 @@ paths:
           schema:
             type: integer
           description: |
-            Filter by a specific version of the Blueprint we want to fetch composes for
+            Filter by a specific version of the Blueprint we want to fetch composes for.
+            Pass special value -1 to fetch composes for latest version of the Blueprint.
         - in: query
           name: limit
           schema:

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -254,6 +254,13 @@ func (h *Handlers) GetBlueprintComposes(ctx echo.Context, blueprintId openapi_ty
 
 	since := time.Hour * 24 * 14
 
+	if params.BlueprintVersion != nil && *params.BlueprintVersion < 0 {
+		*params.BlueprintVersion, err = h.server.db.GetLatestBlueprintVersionNumber(userID.OrgID(), blueprintId)
+		if err != nil {
+			return err
+		}
+	}
+
 	composes, err := h.server.db.GetBlueprintComposes(userID.OrgID(), blueprintId, params.BlueprintVersion, since, limit, offset, ignoreImageTypeStrings)
 	if err != nil {
 		return err

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -168,6 +168,16 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("/api/image-builder/v1.0/composes?blueprint_id=%s&blueprint_version=2&limit=100&offset=1", blueprintId.String()), result.Links.Last)
 	require.Equal(t, 2, len(result.Data))
 	require.Equal(t, 2, result.Meta.Count)
+
+	// get composes for latest version
+	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/composes?blueprint_version=-1", blueprintId.String()), &tutils.AuthString0)
+	require.NoError(t, err)
+
+	require.Equal(t, 200, respStatusCode)
+	err = json.Unmarshal([]byte(body), &result)
+	require.NoError(t, err)
+	require.Equal(t, blueprintId, *result.Data[0].BlueprintId)
+	require.Equal(t, 2, *result.Data[0].BlueprintVersion)
 }
 
 func TestHandlers_GetBlueprint(t *testing.T) {


### PR DESCRIPTION
Add special value parameter -1 for fetching latest blueprint version. Adds extra query for fetching the version, to keep the SQL simple and easy to read.

Refs: HMS-3412