### PR TITLE
v1/api: add base64-encoded file data

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -79,6 +79,12 @@ const (
 	Rhel9Nightly Distributions = "rhel-9-nightly"
 )
 
+// Defines values for FileDataEncoding.
+const (
+	Base64 FileDataEncoding = "base64"
+	Plain  FileDataEncoding = "plain"
+)
+
 // Defines values for ImageRequestArchitecture.
 const (
 	ImageRequestArchitectureAarch64 ImageRequestArchitecture = "aarch64"
@@ -543,6 +549,9 @@ type File struct {
 	// Data Contents of the file as plain text
 	Data *string `json:"data,omitempty"`
 
+	// DataEncoding When data is base64-encoded to prevent Akamai content filter false positives
+	DataEncoding *FileDataEncoding `json:"data_encoding,omitempty"`
+
 	// EnsureParents Ensure that the parent directories exist
 	EnsureParents *bool `json:"ensure_parents,omitempty"`
 
@@ -558,6 +567,9 @@ type File struct {
 	// User Owner of the file as a uid or a user name
 	User *File_User `json:"user,omitempty"`
 }
+
+// FileDataEncoding When data is base64-encoded to prevent Akamai content filter false positives
+type FileDataEncoding string
 
 // FileGroup0 defines model for .
 type FileGroup0 = string

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1582,6 +1582,11 @@ components:
         data:
           type: string
           description: Contents of the file as plain text
+        data_encoding:
+          type: string
+          enum: ['plain', 'base64']
+          description: When data is base64-encoded to prevent Akamai content filter false positives
+          default: 'plain'
         ensure_parents:
           type: boolean
           description: Ensure that the parent directories exist

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -656,6 +657,14 @@ func buildCustomizations(cust *Customizations) (*composer.Customizations, error)
 						return nil, err
 					}
 				}
+			}
+
+			if f.Data != nil && f.DataEncoding != nil && *f.DataEncoding == "base64" {
+				buf, err := base64.StdEncoding.DecodeString(*f.Data)
+				if err != nil {
+					return nil, err
+				}
+				f.Data = common.ToPtr(string(buf))
 			}
 
 			files = append(files, composer.File{


### PR DESCRIPTION
This is needed to workaround Akamai content filter which goes nuts the moment it sees `/usr/bin/`. All requests containing this in body are refused with 403.

https://issues.redhat.com/browse/HMS-3581