### PR TITLE
cmd: skip infra paths logging

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -139,6 +139,18 @@ func main() {
 
 			return nil
 		},
+		Skipper: func(c echo.Context) bool {
+			switch c.Path() {
+			case "/metrics":
+				return true
+			case "/status":
+				return true
+			case "/ready":
+				return true
+			}
+
+			return false
+		},
 	}))
 	if conf.GlitchTipDSN != "" {
 		echoServer.Use(sentryecho.New(sentryecho.Options{}))


### PR DESCRIPTION
Logs are polluted with these nonsense log entries, this should remove it according to docs (untested).

![image](https://github.com/osbuild/image-builder/assets/49752/341df36b-590c-4d4e-821c-bcfcb8835d43)
