### PR TITLE
Drop modular repos from Fedora 39 and 40 configurations

### DIFF
--- a/distributions/fedora-40/fedora-40.json
+++ b/distributions/fedora-40/fedora-40.json
@@ -27,16 +27,6 @@
         "id": "updates",
         "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f40&arch=x86_64",
         "rhsm": false
-      },
-      {
-        "id": "fedora-modular",
-        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-40&arch=x86_64",
-        "rhsm": false
-      },
-      {
-        "id": "updates-modular",
-        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f40&arch=x86_64",
-        "rhsm": false
       }
     ]
   },
@@ -54,16 +44,6 @@
       {
         "id": "updates",
         "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f40&arch=aarch64",
-        "rhsm": false
-      },
-      {
-        "id": "fedora-modular",
-        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-40&arch=aarch64",
-        "rhsm": false
-      },
-      {
-        "id": "updates-modular",
-        "metalink": "https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f40&arch=aarch64",
         "rhsm": false
       }
     ]


### PR DESCRIPTION
Fedora has no modular content since Fedora 39. The metalinks for F39 just point to the Everything repositories, and the metalinks for F40 just don't exist at all (so if anything expects these URLs to actually work, it'll break).