### PR TITLE
main: make echo logger context aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dnf-json
 /.idea
 /gen-oscap
 local.env
+__debug*

--- a/cmd/image-builder/logging.go
+++ b/cmd/image-builder/logging.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/random"
+	"github.com/osbuild/image-builder/internal/common"
+	"github.com/sirupsen/logrus"
+)
+
+type ctxKey int
+
+const (
+	requestIdCtx ctxKey = iota
+)
+
+// Use request id from the standard context and add it to the message as a field.
+type ctxHook struct {
+}
+
+func (h *ctxHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
+}
+
+func (h *ctxHook) Fire(e *logrus.Entry) error {
+	if e.Context != nil {
+		e.Data["request_id"] = e.Context.Value(requestIdCtx)
+	}
+
+	return nil
+}
+
+// Extract/generate request id and store it in the standard context
+func requestIdExtractMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		// extract or generate request id
+		rid := c.Request().Header.Get("X-Rh-Edge-Request-Id")
+		if rid != "" {
+			rid = strings.TrimSuffix(rid, "\n")
+		} else {
+			rid = random.String(12)
+		}
+
+		// store it in a standard context
+		ctx := c.Request().Context()
+		ctx = context.WithValue(ctx, requestIdCtx, rid)
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		// and set echo logger to be context logger
+		ctxLogger := logrus.StandardLogger().WithContext(ctx).Logger
+		c.SetLogger(&common.EchoLogrusLogger{
+			Logger: ctxLogger,
+		})
+
+		return next(c)
+	}
+}

--- a/internal/db/db_blueprints.go
+++ b/internal/db/db_blueprints.go
@@ -112,9 +112,7 @@ const (
 )
 
 // GetLatestBlueprintVersionNumber gets the latest version number of a blueprint.
-func (db *dB) GetLatestBlueprintVersionNumber(orgId string, blueprintId uuid.UUID) (int, error) {
-	ctx := context.Background()
-
+func (db *dB) GetLatestBlueprintVersionNumber(ctx context.Context, orgId string, blueprintId uuid.UUID) (int, error) {
 	var latestVersion int
 
 	conn, err := db.Pool.Acquire(ctx)
@@ -136,8 +134,7 @@ func (db *dB) GetLatestBlueprintVersionNumber(orgId string, blueprintId uuid.UUI
 	return latestVersion, nil
 }
 
-func (db *dB) CountBlueprintComposesSince(orgId string, blueprintId uuid.UUID, blueprintVersion *int, since time.Duration, ignoreImageTypes []string) (int, error) {
-	ctx := context.Background()
+func (db *dB) CountBlueprintComposesSince(ctx context.Context, orgId string, blueprintId uuid.UUID, blueprintVersion *int, since time.Duration, ignoreImageTypes []string) (int, error) {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return 0, err
@@ -152,8 +149,7 @@ func (db *dB) CountBlueprintComposesSince(orgId string, blueprintId uuid.UUID, b
 	return count, nil
 }
 
-func (db *dB) GetBlueprintComposes(orgId string, blueprintId uuid.UUID, blueprintVersion *int, since time.Duration, limit, offset int, ignoreImageTypes []string) ([]BlueprintCompose, error) {
-	ctx := context.Background()
+func (db *dB) GetBlueprintComposes(ctx context.Context, orgId string, blueprintId uuid.UUID, blueprintVersion *int, since time.Duration, limit, offset int, ignoreImageTypes []string) ([]BlueprintCompose, error) {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return nil, err
@@ -184,8 +180,7 @@ func (db *dB) GetBlueprintComposes(orgId string, blueprintId uuid.UUID, blueprin
 	return composes, nil
 }
 
-func (db *dB) InsertBlueprint(id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage) error {
-	ctx := context.Background()
+func (db *dB) InsertBlueprint(ctx context.Context, id uuid.UUID, versionId uuid.UUID, orgID, accountNumber, name, description string, body json.RawMessage) error {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return err
@@ -213,8 +208,7 @@ func (db *dB) InsertBlueprint(id uuid.UUID, versionId uuid.UUID, orgID, accountN
 	return err
 }
 
-func (db *dB) GetBlueprint(id uuid.UUID, orgID, accountNumber string) (*BlueprintEntry, error) {
-	ctx := context.Background()
+func (db *dB) GetBlueprint(ctx context.Context, id uuid.UUID, orgID, accountNumber string) (*BlueprintEntry, error) {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return nil, err
@@ -234,8 +228,7 @@ func (db *dB) GetBlueprint(id uuid.UUID, orgID, accountNumber string) (*Blueprin
 	return &result, err
 }
 
-func (db *dB) UpdateBlueprint(id uuid.UUID, blueprintId uuid.UUID, orgId string, name string, description string, body json.RawMessage) error {
-	ctx := context.Background()
+func (db *dB) UpdateBlueprint(ctx context.Context, id uuid.UUID, blueprintId uuid.UUID, orgId string, name string, description string, body json.RawMessage) error {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return err
@@ -264,8 +257,7 @@ func (db *dB) UpdateBlueprint(id uuid.UUID, blueprintId uuid.UUID, orgId string,
 	return err
 }
 
-func (db *dB) DeleteBlueprint(id uuid.UUID, orgID, accountNumber string) error {
-	ctx := context.Background()
+func (db *dB) DeleteBlueprint(ctx context.Context, id uuid.UUID, orgID, accountNumber string) error {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return err
@@ -285,8 +277,7 @@ func (db *dB) DeleteBlueprint(id uuid.UUID, orgID, accountNumber string) error {
 	return nil
 }
 
-func (db *dB) FindBlueprints(orgID, search string, limit, offset int) ([]BlueprintWithNoBody, int, error) {
-	ctx := context.Background()
+func (db *dB) FindBlueprints(ctx context.Context, orgID, search string, limit, offset int) ([]BlueprintWithNoBody, int, error) {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return nil, 0, err
@@ -319,8 +310,7 @@ func (db *dB) FindBlueprints(orgID, search string, limit, offset int) ([]Bluepri
 	return blueprints, count, nil
 }
 
-func (db *dB) GetBlueprints(orgID string, limit, offset int) ([]BlueprintWithNoBody, int, error) {
-	ctx := context.Background()
+func (db *dB) GetBlueprints(ctx context.Context, orgID string, limit, offset int) ([]BlueprintWithNoBody, int, error) {
 	conn, err := db.Pool.Acquire(ctx)
 	if err != nil {
 		return nil, 0, err

--- a/internal/db/db_trace.go
+++ b/internal/db/db_trace.go
@@ -1,0 +1,20 @@
+package db
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/sirupsen/logrus"
+)
+
+// Used for pgx logging with context information
+type dbTracer struct{}
+
+func (dt *dbTracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	logrus.WithContext(ctx).Debugf("Executing SQL with args %v: %s", data.Args, data.SQL)
+	return ctx
+}
+
+func (dt *dbTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryEndData) {
+	// no-op
+}

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestHandlers_ComposeBlueprint(t *testing.T) {
+	ctx := context.Background()
 	ids := []uuid.UUID{uuid.New(), uuid.New()}
 	idx := 0
 	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +46,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 		DistributionsDir: "../../distributions",
 	})
 	defer func() {
-		shutdownErr := srv.Shutdown(context.Background())
+		shutdownErr := srv.Shutdown(ctx)
 		require.NoError(t, shutdownErr)
 	}()
 	defer tokenSrv.Close()
@@ -88,7 +89,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 	var message []byte
 	message, err = json.Marshal(blueprint)
 	require.NoError(t, err)
-	err = dbase.InsertBlueprint(id, versionId, "000000", "000000", name, description, message)
+	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message)
 	require.NoError(t, err)
 
 	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/compose", id.String()), map[string]string{})
@@ -103,6 +104,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 }
 
 func TestHandlers_GetBlueprintComposes(t *testing.T) {
+	ctx := context.Background()
 	blueprintId := uuid.New()
 	versionId := uuid.New()
 	version2Id := uuid.New()
@@ -117,14 +119,14 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 		DistributionsDir: "../../distributions",
 	})
 	defer func() {
-		err := db_srv.Shutdown(context.Background())
+		err := db_srv.Shutdown(ctx)
 		require.NoError(t, err)
 	}()
 	defer tokenSrv.Close()
 
 	var result ComposesResponse
 
-	err = dbase.InsertBlueprint(blueprintId, versionId, "000000", "500000", "blueprint", "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`))
+	err = dbase.InsertBlueprint(ctx, blueprintId, versionId, "000000", "500000", "blueprint", "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`))
 	require.NoError(t, err)
 	id1 := uuid.New()
 	err = dbase.InsertCompose(id1, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId, &versionId)
@@ -133,7 +135,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 	err = dbase.InsertCompose(id2, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), &clientId, &versionId)
 	require.NoError(t, err)
 
-	err = dbase.UpdateBlueprint(version2Id, blueprintId, "000000", "blueprint", "desc2", json.RawMessage(`{"image_requests": [{"image_type": "aws"}, {"image_type": "gcp"}]}`))
+	err = dbase.UpdateBlueprint(ctx, version2Id, blueprintId, "000000", "blueprint", "desc2", json.RawMessage(`{"image_requests": [{"image_type": "aws"}, {"image_type": "gcp"}]}`))
 	require.NoError(t, err)
 	id3 := uuid.New()
 	err = dbase.InsertCompose(id3, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), &clientId, &version2Id)
@@ -181,6 +183,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 }
 
 func TestHandlers_GetBlueprint(t *testing.T) {
+	ctx := context.Background()
 	dbase, err := dbc.NewDB()
 	require.NoError(t, err)
 
@@ -189,7 +192,7 @@ func TestHandlers_GetBlueprint(t *testing.T) {
 		DistributionsDir: "../../distributions",
 	})
 	defer func() {
-		err := db_srv.Shutdown(context.Background())
+		err := db_srv.Shutdown(ctx)
 		require.NoError(t, err)
 	}()
 	defer tokenSrv.Close()
@@ -232,7 +235,7 @@ func TestHandlers_GetBlueprint(t *testing.T) {
 	var message []byte
 	message, err = json.Marshal(blueprint)
 	require.NoError(t, err)
-	err = dbase.InsertBlueprint(id, versionId, "000000", "000000", name, description, message)
+	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message)
 	require.NoError(t, err)
 
 	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s", id.String()), &tutils.AuthString0)
@@ -251,6 +254,7 @@ func TestHandlers_GetBlueprint(t *testing.T) {
 }
 
 func TestHandlers_DeleteBlueprint(t *testing.T) {
+	ctx := context.Background()
 	blueprintId := uuid.New()
 	versionId := uuid.New()
 	version2Id := uuid.New()
@@ -265,12 +269,12 @@ func TestHandlers_DeleteBlueprint(t *testing.T) {
 		DistributionsDir: "../../distributions",
 	})
 	defer func() {
-		err := db_srv.Shutdown(context.Background())
+		err := db_srv.Shutdown(ctx)
 		require.NoError(t, err)
 	}()
 	defer tokenSrv.Close()
 
-	err = dbase.InsertBlueprint(blueprintId, versionId, "000000", "000000", "blueprint", "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`))
+	err = dbase.InsertBlueprint(ctx, blueprintId, versionId, "000000", "000000", "blueprint", "blueprint desc", json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`))
 	require.NoError(t, err)
 	id1 := uuid.New()
 	err = dbase.InsertCompose(id1, "000000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId, &versionId)
@@ -279,7 +283,7 @@ func TestHandlers_DeleteBlueprint(t *testing.T) {
 	err = dbase.InsertCompose(id2, "000000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), &clientId, &versionId)
 	require.NoError(t, err)
 
-	err = dbase.UpdateBlueprint(version2Id, blueprintId, "000000", "blueprint", "desc2", json.RawMessage(`{"image_requests": [{"image_type": "aws"}, {"image_type": "gcp"}]}`))
+	err = dbase.UpdateBlueprint(ctx, version2Id, blueprintId, "000000", "blueprint", "desc2", json.RawMessage(`{"image_requests": [{"image_type": "aws"}, {"image_type": "gcp"}]}`))
 	require.NoError(t, err)
 	id3 := uuid.New()
 	err = dbase.InsertCompose(id3, "000000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), &clientId, &version2Id)
@@ -299,11 +303,11 @@ func TestHandlers_DeleteBlueprint(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Not Found", errorResponse.Errors[0].Detail)
 
-	_, err = dbase.GetBlueprint(blueprintId, "000000", "000000")
+	_, err = dbase.GetBlueprint(ctx, blueprintId, "000000", "000000")
 	require.ErrorIs(t, err, db.BlueprintNotFoundError)
 
 	// Composes should not be assigned to the blueprint anymore
-	bpComposes, err := dbase.GetBlueprintComposes("000000", blueprintId, nil, (time.Hour * 24 * 14), 10, 0, nil)
+	bpComposes, err := dbase.GetBlueprintComposes(ctx, "000000", blueprintId, nil, (time.Hour * 24 * 14), 10, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, bpComposes, 0)
 }


### PR DESCRIPTION
Logging is completely context-less meaning there is no correlation id available in kibana. This is the first step towards having logs fully correlated.

First, a request id is extracted or generated in a new middleware which also stores it in a newly created standard context. This standard context is then passed into logrus logger that has the context associated. Finally, logrus has a new hook that extract the request id from the standard context and creating a text field.

On top of that, pgx driver is configured with a newly created tracer hook which logs SQL queries via debug level with context in mind. As long as the proper standard context is passed into

What it all means: if we pass context down the stack to pgx (and other functions or libraries in the future), we will get fully correlated log records.

Example output for getting list of blueprints (note the request_id being propagated in all three layers of logging):

```
time="2024-02-26T15:56:22+01:00" level=debug msg="Executing SQL with args [13446659 100 0]: \n\t\tSELECT blueprints.id, blueprints.name, blueprints.description, MAX(blueprint_versions.version) as version, MAX(blueprint_versions.created_at) as last_modified_at\n\t\tFROM blueprints INNER JOIN blueprint_versions ON blueprint_versions.blueprint_id = blueprints.id\n\t\tWHERE blueprints.org_id = $1\n\t\tGROUP BY blueprints.id\n\t\tORDER BY last_modified_at DESC\n\t\tLIMIT $2 OFFSET $3" func="github.com/osbuild/image-builder/internal/db.(*dbTracer).TraceQueryStart" file="/home/lzap/work/image-builder/internal/db/db_trace.go:14" request_id=QhOJAOkg2LKH
time="2024-02-26T15:56:22+01:00" level=debug msg="Executing SQL with args [13446659]: \n\t\tSELECT COUNT(*)\n\t\tFROM blueprints\n\t\tWHERE blueprints.org_id = $1" func="github.com/osbuild/image-builder/internal/db.(*dbTracer).TraceQueryStart" file="/home/lzap/work/image-builder/internal/db/db_trace.go:14" request_id=QhOJAOkg2LKH
time="2024-02-26T15:56:22+01:00" level=debug msg="Getting blueprint list of 0 items" func="github.com/osbuild/image-builder/internal/common.(*EchoLogrusLogger).Debugf" file="/home/lzap/work/image-builder/internal/common/echo_logrus.go:86"
time="2024-02-26T15:56:22+01:00" level=info msg="Processed request GET /api/image-builder/v1/experimental/blueprints" func=main.main.func1 file="/home/lzap/work/image-builder/cmd/image-builder/main.go:133" latency_ms=66 method=GET request_id=QhOJAOkg2LKH status=200 uri=/api/image-builder/v1/experimental/blueprints
```