### PR TITLE
db: drop account number check from blueprints

### DIFF
--- a/internal/db/migrations-tern/010_drop_blueprints_account_number_check.sql
+++ b/internal/db/migrations-tern/010_drop_blueprints_account_number_check.sql
@@ -1,0 +1,1 @@
+ALTER TABLE blueprints DROP CONSTRAINT blueprints_account_number_check;


### PR DESCRIPTION
Account number will be dropped soon, we do not want to enforce it.

This is blocking stage testing currently, as there is no account number in stage.