### PR TITLE
v1: return commit sha via version endpoint

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -181,7 +181,7 @@ func main() {
 		panic(err)
 	}
 
-	logrus.Infof("🚀 Starting image-builder server on %v ...\n", conf.ListenAddress)
+	logrus.Infof("🚀 Starting image-builder built %s sha %s server on %v ...\n", common.BuildTime, common.BuildCommit, conf.ListenAddress)
 	err = echoServer.Start(conf.ListenAddress)
 	if err != nil {
 		panic(err)

--- a/internal/common/runtime.go
+++ b/internal/common/runtime.go
@@ -1,0 +1,36 @@
+package common
+
+import "runtime/debug"
+
+var (
+	// Git SHA commit (first 4 characters)
+	BuildCommit string
+
+	// Build date and time
+	BuildTime string
+
+	// BuildGoVersion carries Go version the binary was built with
+	BuildGoVersion string
+)
+
+func init() {
+	bi, ok := debug.ReadBuildInfo()
+
+	if !ok {
+		BuildTime = "N/A"
+		BuildCommit = "HEAD"
+	}
+
+	BuildGoVersion = bi.GoVersion
+
+	for _, bs := range bi.Settings {
+		switch bs.Key {
+		case "vcs.revision":
+			if len(bs.Value) > 6 {
+				BuildCommit = bs.Value[0:6]
+			}
+		case "vcs.time":
+			BuildTime = bs.Value
+		}
+	}
+}

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -870,7 +870,9 @@ type User struct {
 
 // Version defines model for Version.
 type Version struct {
-	Version string `json:"version"`
+	BuildCommit *string `json:"build_commit,omitempty"`
+	BuildTime   *string `json:"build_time,omitempty"`
+	Version     string  `json:"version"`
 }
 
 // GetComposesParams defines parameters for GetComposes.

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -671,6 +671,10 @@ components:
       properties:
         version:
           type: string
+        build_time:
+          type: string
+        build_commit:
+          type: string
     Readiness:
       type: object
       required:

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/internal/composer"
 	"github.com/osbuild/image-builder/internal/db"
 	"github.com/osbuild/image-builder/internal/provisioning"
@@ -48,7 +49,11 @@ func (h *Handlers) newLinksWithExtraParams(path string, count, limit int, params
 }
 
 func (h *Handlers) GetVersion(ctx echo.Context) error {
-	version := Version{h.server.spec.Info.Version}
+	version := Version{
+		Version:     h.server.spec.Info.Version,
+		BuildCommit: common.ToPtr(common.BuildCommit),
+		BuildTime:   common.ToPtr(common.BuildTime),
+	}
 	return ctx.JSON(http.StatusOK, version)
 }
 


### PR DESCRIPTION
I was not sure recently if my change was pushed to stage or not. Since the version endpoint returns just 1.0 that does not help at all, this patch adds sha commit and build datetime:

```
$HOME/bin/curl-local-ib GET /image-builder/v1/version
{
  "build_commit": "898e84",
  "build_time": "2024-02-28T07:25:03Z",
  "version": "1.0"
}
```

It also prints the same in logs while starting the app.