### PR TITLE
v1: pass echo context through handlers

### DIFF
--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/sirupsen/logrus"
 )
 
 type BlueprintBody struct {
@@ -64,7 +63,7 @@ func (h *Handlers) CreateBlueprint(ctx echo.Context) error {
 	ctx.Logger().Infof("Inserting blueprint: %s (%s), for orgID: %s and account: %s", blueprintRequest.Name, id, userID.OrgID(), userID.AccountNumber())
 	err = h.server.db.InsertBlueprint(ctx.Request().Context(), id, versionId, userID.OrgID(), userID.AccountNumber(), blueprintRequest.Name, blueprintRequest.Description, body)
 	if err != nil {
-		logrus.Error("Error inserting id into db", err)
+		ctx.Logger().Errorf("Error inserting id into db: %s", err.Error())
 		return err
 	}
 	ctx.Logger().Infof("Inserted blueprint %s", id)


### PR DESCRIPTION
This is a followup for my logging improvement patch. This ensures the echo context is passed around. Generally speaking, instead of:

```
logrus.Info(...)
```

write:

```
ctx.Logger().Info(...)
```

That is all that needs to be done. In the next patch, I will update the db functions to accept context.