### PR TITLE
make openapi spec endpoint public - alternatesolution (HMS-1220)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dnf-json
 /gen-oscap
 local.env
 __debug*
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ help:
 	@echo "    help:               Print this usage information."
 	@echo "    build:              Build the project from source code"
 	@echo "    run:                Run the project on localhost"
+	@echo "    unit-tests:         Run unit tests (calls dev-prerequisites)"
+	@echo "    dev-prerequisites:  Install necessary development prerequisites on your system"
+	@echo "    push-check:         Replicates the github workflow checks as close as possible"
+	@echo "                        (do this before pushing!)"
 
 .PHONY: build
 build:
@@ -34,3 +38,26 @@ ubi-container:
 .PHONY: generate-openscap-blueprints
 generate-openscap-blueprints:
 	go run ./cmd/oscap/ ./distributions
+
+.PHONY: dev-prerequisites
+dev-prerequisites:
+	go install github.com/jackc/tern@latest
+
+.PHONY: unit-tests
+# re-implementing .github/workflows/tests.yml as close as possible
+unit-tests: dev-prerequisites
+	go test -v -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...
+
+.PHONY: generate
+generate:
+	go generate ./...
+
+.PHONY: push-check
+push-check: generate build unit-tests
+	./tools/prepare-source.sh
+	@if [ 0 -ne $$(git status --porcelain --untracked-files|wc -l) ]; then \
+	    echo "There should be no changed or untracked files"; \
+	    git status --porcelain --untracked-files; \
+	    exit 1; \
+	fi
+	@echo "All looks good - congratulations"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Project building and testing project is based on predefined make targets:
 
  * `make build` to trigger Go builder
 
+### Run Tests
+
+To run the tests locally just call
+
+```sh
+make unit-tests
+```
+
+Before pushing something for a pull request you should run this check to avoid problems with required github actions
+
+```sh
+make push-check
+```
+
 ### Installation
 
 To run the project use `make run` target

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -1712,9 +1712,6 @@ type ServerInterface interface {
 	// get composes associated with a blueprint
 	// (GET /experimental/blueprints/{id}/composes)
 	GetBlueprintComposes(ctx echo.Context, id openapi_types.UUID, params GetBlueprintComposesParams) error
-	// get the openapi json specification
-	// (GET /openapi.json)
-	GetOpenapiJson(ctx echo.Context) error
 	// get the available profiles for a given distribution. This is a temporary endpoint meant to be removed soon.
 	// (GET /oscap/{distribution}/profiles)
 	GetOscapProfiles(ctx echo.Context, distribution Distributions) error
@@ -2066,15 +2063,6 @@ func (w *ServerInterfaceWrapper) GetBlueprintComposes(ctx echo.Context) error {
 	return err
 }
 
-// GetOpenapiJson converts echo context to params.
-func (w *ServerInterfaceWrapper) GetOpenapiJson(ctx echo.Context) error {
-	var err error
-
-	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.GetOpenapiJson(ctx)
-	return err
-}
-
 // GetOscapProfiles converts echo context to params.
 func (w *ServerInterfaceWrapper) GetOscapProfiles(ctx echo.Context) error {
 	var err error
@@ -2224,7 +2212,6 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.PUT(baseURL+"/experimental/blueprints/:id", wrapper.UpdateBlueprint)
 	router.POST(baseURL+"/experimental/blueprints/:id/compose", wrapper.ComposeBlueprint)
 	router.GET(baseURL+"/experimental/blueprints/:id/composes", wrapper.GetBlueprintComposes)
-	router.GET(baseURL+"/openapi.json", wrapper.GetOpenapiJson)
 	router.GET(baseURL+"/oscap/:distribution/profiles", wrapper.GetOscapProfiles)
 	router.GET(baseURL+"/oscap/:distribution/:profile/customizations", wrapper.GetOscapCustomizations)
 	router.GET(baseURL+"/packages", wrapper.GetPackages)

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -40,19 +40,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Readiness'
-  /openapi.json:
-    get:
-      summary: get the openapi json specification
-      operationId: getOpenapiJson
-      tags:
-        - meta
-      responses:
-        '200':
-          description: returns this document
-          content:
-            application/json:
-              schema:
-                type: object
   /distributions:
     get:
       summary: get the distributions available to this user

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -43,9 +45,46 @@ func TestWithoutOsbuildComposerBackend(t *testing.T) {
 	})
 
 	t.Run("GetOpenapiJson", func(t *testing.T) {
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/openapi.json", &tutils.AuthString0)
-		require.Equal(t, http.StatusOK, respStatusCode)
-		// note: not asserting body b/c response is too big
+		// should work with AND without authentication
+		url := "http://localhost:8086/openapi.json"
+
+		testCases := []struct {
+			testCaseName string
+			authString   *string
+		}{
+			{
+				testCaseName: "Test without Authentication",
+				authString:   nil,
+			},
+			{
+				testCaseName: "Test with Authentication",
+				authString:   &tutils.AuthString0,
+			},
+		}
+
+		for _, tc := range testCases {
+			respStatusCode, body := tutils.GetResponseBody(t, url, tc.authString)
+			require.Equal(t, http.StatusOK, respStatusCode, tc.testCaseName)
+
+			var swagger *openapi3.T
+			var specB []byte
+			var err error
+			swagger, err = GetSwagger()
+			require.NoError(t, err)
+
+			specB, err = swagger.MarshalJSON()
+			require.NoError(t, err)
+
+			spec := string(specB) + "\n"
+			// improve readability of the diff - in case of errors
+			spec = strings.ReplaceAll(spec, ",", ",\n")
+			body = strings.ReplaceAll(body, ",", ",\n")
+
+			require.Equal(t, spec, body)
+			require.Equal(t, len(spec), len(body))
+
+		}
+
 	})
 
 	t.Run("StatusCheck", func(t *testing.T) {

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -75,8 +75,6 @@ func Attach(conf *ServerConfig) error {
 		return err
 	}
 
-	spec.AddServer(&openapi3.Server{URL: fmt.Sprintf("%s/v%s", RoutePrefix(), spec.Info.Version)})
-
 	router, err := legacyrouter.NewRouter(spec)
 	if err != nil {
 		return err

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -1,4 +1,4 @@
-//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/cmd/oapi-codegen --config server.cfg.yaml -o api.go api.yaml
+//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/cmd/oapi-codegen --config server.cfg.yaml api.yaml
 package v1
 
 import (
@@ -121,6 +121,8 @@ func Attach(conf *ServerConfig) error {
 
 	RegisterHandlers(s.echo.Group(fmt.Sprintf("%s/v%s", RoutePrefix(), majorVersion), middlewares...), &h)
 	RegisterHandlers(s.echo.Group(fmt.Sprintf("%s/v%s", RoutePrefix(), spec.Info.Version), middlewares...), &h)
+
+	s.echo.GET("/openapi.json", h.GetOpenapiJson)
 
 	/* Used for the livenessProbe */
 	s.echo.GET("/status", func(c echo.Context) error {


### PR DESCRIPTION
This is the alternate solution over #1058 

It is similar but easier to read/maintain I guess.

--
From what I learned today the openapi YAML should rather contain the security entries so also this behavior is documented but this would mean to change all middleware functions caring about authentication validation.