### PR TITLE
API: verify search param is not empty in /blueprints

### DIFF
--- a/internal/common/pointers.go
+++ b/internal/common/pointers.go
@@ -3,3 +3,10 @@ package common
 func ToPtr[T any](x T) *T {
 	return &x
 }
+
+func FromPtr[T any](ref *T) (value T) {
+	if ref != nil {
+		value = *ref
+	}
+	return
+}

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/internal/db"
 
 	"github.com/google/uuid"
@@ -189,7 +190,7 @@ func (h *Handlers) GetBlueprints(ctx echo.Context, params GetBlueprintsParams) e
 	var blueprints []db.BlueprintWithNoBody
 	var count int
 
-	if params.Search != nil {
+	if params.Search != nil && common.FromPtr(params.Search) != "" {
 		blueprints, count, err = h.server.db.FindBlueprints(ctx.Request().Context(), userID.OrgID(), *params.Search, limit, offset)
 		if err != nil {
 			return err


### PR DESCRIPTION
Frontend might submit an empty search in `/blueprints` endpoint, which trigger a redundant search query in DB