### PR TITLE
chore: reduce go depbot to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"
     groups:
       go-deps:


### PR DESCRIPTION
Hey,

if you look at the [recently closed "deps" PRs](https://github.com/osbuild/image-builder/pulls?page=3&q=is%3Apr+is%3Aclosed++deps), all of them were closed this year (2 months period). With that, I propose to reduce frequency from daily to weekly to reduce notifications load on the team. Urgent security issues go through Red Hat Security Response Team anyway, we should not depend on dependanbot for this reason. Weekly notification is still a good reminder to not stop updating deps and get stuck.