### PR TITLE
cmd/image-builder-db-test: improve tern error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ gen-oscap:
 
 .PHONY: image-builder-migrate-db-tern
 image-builder-migrate-db-tern:
-	go test -c -tags=integration -o image-builder-db-test ./cmd/image-builder-db-test/
+	go build -o image-builder-migrate-db-tern ./cmd/image-builder-migrate-db-tern/
 
 .PHONY: image-builder-db-test
 image-builder-db-test:

--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -62,13 +63,18 @@ func migrateTern(t *testing.T) {
 	// run tern migration on top of existing db
 	c := conf(t)
 
-	cmd := exec.Command("tern", "migrate",
-		"-m", c.TernMigrationsDir,
+	a := []string{
+		"migrate",
+		"--migrations", c.TernMigrationsDir,
+		"--database", c.PGDatabase,
 		"--host", c.PGHost, "--port", c.PGPort,
 		"--user", c.PGUser, "--password", c.PGPassword,
-		"--sslmode", c.PGSSLMode)
+		"--sslmode", c.PGSSLMode,
+	}
+	cmd := exec.Command("tern", a...)
+
 	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "tern command failed with non-zero code, combined output: %s", string(output))
+	require.NoErrorf(t, err, "tern command failed with non-zero code, cmd: tern %s, combined output: %s", strings.Join(a, " "), string(output))
 }
 
 func connect(t *testing.T) *pgx.Conn {

--- a/test/README.md
+++ b/test/README.md
@@ -40,12 +40,24 @@ can be found under schutzbot.
 ## Unit tests
 
 Run the following from **the root directory** of the repository:
+
 ```
 go clean -testcache
-go test -v ./...
+go test ./...
 ```
 
-## Integration test
+Some tests do require database and start a postgres container using podman or docker.
+
+
+## Unit integration tests
+
+You can run tests which are executed on CI under name "DB tests" locally, just keep in mind this drops public schema completely.
+
+```
+TERN_MIGRATIONS_DIR=../../internal/db/migrations-tern/ go test -tags integration ./...
+```
+
+## End-to-end tntegration tests
 
 It's recommended to run these inside of a vm as the scripts make extensive
 changes to the host. Running integration test requires specific environment


### PR DESCRIPTION
Improve error handling when tern command fails. It was a pain to debug this.

I also noticed I made an incorrect edit during my other change when I broke the build make target into multiple command, this fixes it:

https://github.com/osbuild/image-builder/commit/acbb3e6355698f6652a4e9ae8ce234dd8ea6a06e