### PR TITLE
Fix HTTP error logging in server

### DIFF
--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -67,6 +67,10 @@ func LoadConfigFromEnv(conf *ImageBuilderConfig) error {
 		if endpoint, ok := clowder.DependencyEndpoints["provisioning-backend"]["api"]; ok {
 			conf.ProvisioningURL = fmt.Sprintf("http://%s:%d/api/provisioning/v1", endpoint.Hostname, endpoint.Port)
 		}
+
+		if strings.Contains(*clowder.LoadedConfig.Metadata.EnvName, "ephemeral") {
+			conf.LogLevel = "DEBUG"
+		}
 	}
 
 	return nil

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -201,6 +201,8 @@ func (s *Server) HTTPErrorHandler(err error, c echo.Context) {
 		if strings.HasSuffix(c.Path(), "/compose") {
 			prometheus.ComposeErrors.Inc()
 		}
+	} else if err != nil {
+		c.Logger().Warnf("HTTP error: %s", err)
 	}
 
 	errors = append(errors, HTTPError{


### PR DESCRIPTION
This pull request fixes the HTTP error logging in the server by adding proper error messages to the logger. Previously, the error messages were not being logged correctly, leading to difficulties in debugging and troubleshooting. With this fix, the server will now log the appropriate error messages when encountering HTTP errors.