### PR TITLE
v1/api: Image name transposition from Blueprint name (HMS-3801)

### DIFF
--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgerrcode"
@@ -23,12 +24,17 @@ import (
 var (
 	blueprintNameRegex         = regexp.MustCompile(`\S+`)
 	blueprintInvalidNameDetail = "The blueprint name must contain at least two characters."
+	specialChars               = regexp.MustCompile(`[^a-zA-Z0-9 _-]`)
 )
 
 type BlueprintBody struct {
 	Customizations Customizations `json:"customizations"`
 	Distribution   Distributions  `json:"distribution"`
 	ImageRequests  []ImageRequest `json:"image_requests"`
+}
+
+func blueprintToImageName(name string) string {
+	return strings.ToLower(strings.Replace(specialChars.ReplaceAllString(name, "_"), " ", "-", -1))
 }
 
 func BlueprintFromAPI(cbr CreateBlueprintRequest) BlueprintBody {
@@ -196,7 +202,7 @@ func (h *Handlers) ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) err
 			Customizations:   &blueprint.Customizations,
 			Distribution:     blueprint.Distribution,
 			ImageRequests:    []ImageRequest{imageRequest},
-			ImageName:        &blueprintEntry.Name,
+			ImageName:        common.ToPtr(blueprintToImageName(blueprintEntry.Name)),
 			ImageDescription: &blueprintEntry.Description,
 			ClientId:         &clientId,
 		}

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -152,7 +152,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 		ShareWithAccounts: common.ToPtr([]string{"test-account"}),
 	})
 	require.NoError(t, err)
-	name := "Blueprint Human Name"
+	name := "Blueprint Human Name🤣"
 	description := "desc"
 	blueprint := BlueprintBody{
 		Customizations: Customizations{
@@ -194,6 +194,10 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 	require.Len(t, result, 2)
 	require.Equal(t, ids[0], result[0].Id)
 	require.Equal(t, ids[1], result[1].Id)
+
+	compose, err := dbase.GetCompose(ctx, result[0].Id, "000000")
+	require.NoError(t, err)
+	require.Equal(t, "blueprint-human-name_", *compose.ImageName)
 }
 
 func TestHandlers_GetBlueprintComposes(t *testing.T) {


### PR DESCRIPTION
On composing Blueprint, transpose its name to image name,
that's machine friendly, unlike Blueprint name that's human readable.

Refs HMS-3801

Follow-up for #1089