### PR TITLE
cmd: pass context into echo logger

### DIFF
--- a/cmd/image-builder/logging.go
+++ b/cmd/image-builder/logging.go
@@ -69,10 +69,11 @@ func requestIdExtractMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		ctxLogger := logrus.StandardLogger().WithContext(ctx).Logger
 		c.SetLogger(&common.EchoLogrusLogger{
 			Logger: ctxLogger,
+			Ctx:    ctx,
 		})
 
 		if !SkipPath(c.Path()) {
-			ctxLogger.Debugf("Started request %s %s", c.Request().Method, c.Request().RequestURI)
+			ctxLogger.WithContext(ctx).Debugf("Started request %s %s", c.Request().Method, c.Request().RequestURI)
 		}
 
 		return next(c)

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -121,11 +121,12 @@ func main() {
 		LogMethod:  true,
 		LogValuesFunc: func(c echo.Context, values middleware.RequestLoggerValues) error {
 			fields := logrus.Fields{
-				"uri":        values.URI,
-				"method":     values.Method,
-				"status":     values.Status,
-				"latency_ms": values.Latency.Milliseconds(),
-				"request_id": c.Request().Context().Value(requestIdCtx),
+				"uri":         values.URI,
+				"method":      values.Method,
+				"status":      values.Status,
+				"latency_ms":  values.Latency.Milliseconds(),
+				"request_id":  c.Request().Context().Value(requestIdCtx),
+				"insights_id": c.Request().Context().Value(insightsRequestIdCtx),
 			}
 			if values.Error != nil {
 				fields["error"] = values.Error

--- a/internal/common/echo_logrus.go
+++ b/internal/common/echo_logrus.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 
@@ -11,10 +12,12 @@ import (
 // EchoLogrusLogger extend logrus.Logger
 type EchoLogrusLogger struct {
 	*logrus.Logger
+	Ctx context.Context
 }
 
 var commonLogger = &EchoLogrusLogger{
 	Logger: logrus.StandardLogger(),
+	Ctx:    context.Background(),
 }
 
 func Logger() *EchoLogrusLogger {
@@ -63,11 +66,11 @@ func (l *EchoLogrusLogger) SetPrefix(p string) {
 }
 
 func (l *EchoLogrusLogger) Print(i ...interface{}) {
-	l.Logger.Print(i...)
+	l.Logger.WithContext(l.Ctx).Print(i...)
 }
 
 func (l *EchoLogrusLogger) Printf(format string, args ...interface{}) {
-	l.Logger.Printf(format, args...)
+	l.Logger.WithContext(l.Ctx).Printf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Printj(j log.JSON) {
@@ -75,15 +78,15 @@ func (l *EchoLogrusLogger) Printj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Println(string(b))
+	l.Logger.WithContext(l.Ctx).Println(string(b))
 }
 
 func (l *EchoLogrusLogger) Debug(i ...interface{}) {
-	l.Logger.Debug(i...)
+	l.Logger.WithContext(l.Ctx).Debug(i...)
 }
 
 func (l *EchoLogrusLogger) Debugf(format string, args ...interface{}) {
-	l.Logger.Debugf(format, args...)
+	l.Logger.WithContext(l.Ctx).Debugf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Debugj(j log.JSON) {
@@ -91,15 +94,15 @@ func (l *EchoLogrusLogger) Debugj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Debugln(string(b))
+	l.Logger.WithContext(l.Ctx).Debugln(string(b))
 }
 
 func (l *EchoLogrusLogger) Info(i ...interface{}) {
-	l.Logger.Info(i...)
+	l.Logger.WithContext(l.Ctx).Info(i...)
 }
 
 func (l *EchoLogrusLogger) Infof(format string, args ...interface{}) {
-	l.Logger.Infof(format, args...)
+	l.Logger.WithContext(l.Ctx).Infof(format, args...)
 }
 
 func (l *EchoLogrusLogger) Infoj(j log.JSON) {
@@ -107,15 +110,15 @@ func (l *EchoLogrusLogger) Infoj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Infoln(string(b))
+	l.Logger.WithContext(l.Ctx).Infoln(string(b))
 }
 
 func (l *EchoLogrusLogger) Warn(i ...interface{}) {
-	l.Logger.Warn(i...)
+	l.Logger.WithContext(l.Ctx).Warn(i...)
 }
 
 func (l *EchoLogrusLogger) Warnf(format string, args ...interface{}) {
-	l.Logger.Warnf(format, args...)
+	l.Logger.WithContext(l.Ctx).Warnf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Warnj(j log.JSON) {
@@ -123,15 +126,15 @@ func (l *EchoLogrusLogger) Warnj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Warnln(string(b))
+	l.Logger.WithContext(l.Ctx).Warnln(string(b))
 }
 
 func (l *EchoLogrusLogger) Error(i ...interface{}) {
-	l.Logger.Error(i...)
+	l.Logger.WithContext(l.Ctx).Error(i...)
 }
 
 func (l *EchoLogrusLogger) Errorf(format string, args ...interface{}) {
-	l.Logger.Errorf(format, args...)
+	l.Logger.WithContext(l.Ctx).Errorf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Errorj(j log.JSON) {
@@ -139,15 +142,15 @@ func (l *EchoLogrusLogger) Errorj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Errorln(string(b))
+	l.Logger.WithContext(l.Ctx).Errorln(string(b))
 }
 
 func (l *EchoLogrusLogger) Fatal(i ...interface{}) {
-	l.Logger.Fatal(i...)
+	l.Logger.WithContext(l.Ctx).Fatal(i...)
 }
 
 func (l *EchoLogrusLogger) Fatalf(format string, args ...interface{}) {
-	l.Logger.Fatalf(format, args...)
+	l.Logger.WithContext(l.Ctx).Fatalf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Fatalj(j log.JSON) {
@@ -155,15 +158,15 @@ func (l *EchoLogrusLogger) Fatalj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Fatalln(string(b))
+	l.Logger.WithContext(l.Ctx).Fatalln(string(b))
 }
 
 func (l *EchoLogrusLogger) Panic(i ...interface{}) {
-	l.Logger.Panic(i...)
+	l.Logger.WithContext(l.Ctx).Panic(i...)
 }
 
 func (l *EchoLogrusLogger) Panicf(format string, args ...interface{}) {
-	l.Logger.Panicf(format, args...)
+	l.Logger.WithContext(l.Ctx).Panicf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Panicj(j log.JSON) {
@@ -171,5 +174,5 @@ func (l *EchoLogrusLogger) Panicj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Panicln(string(b))
+	l.Logger.WithContext(l.Ctx).Panicln(string(b))
 }

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/osbuild/image-builder/internal/distribution"
 	"github.com/osbuild/image-builder/internal/prometheus"
 	"github.com/osbuild/image-builder/internal/provisioning"
-	"github.com/sirupsen/logrus"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/routers"
@@ -229,10 +228,10 @@ func (s *Server) distroRegistry(ctx echo.Context) *distribution.DistroRegistry {
 	entitled := false
 	id, err := s.getIdentity(ctx)
 	if err != nil {
-		logrus.Error("Unable to get entitlement")
+		ctx.Logger().Error("Unable to get entitlement")
 	}
 
-	entitled = id.IsEntitled("rhel")
+	entitled = id.IsEntitled(ctx, "rhel")
 	return s.allDistros.Available(entitled)
 }
 

--- a/internal/v1/server_identity.go
+++ b/internal/v1/server_identity.go
@@ -6,7 +6,6 @@ import (
 	"github.com/labstack/echo/v4"
 	fedora_identity "github.com/osbuild/community-gateway/oidc-authorizer/pkg/identity"
 	rh_identity "github.com/redhatinsights/identity"
-	"github.com/sirupsen/logrus"
 )
 
 type Identity struct {
@@ -67,14 +66,14 @@ func (i *Identity) Type() string {
 	return ""
 }
 
-func (i *Identity) IsEntitled(ask string) bool {
+func (i *Identity) IsEntitled(ctx echo.Context, ask string) bool {
 	if i.rhid != nil {
 		entitled, ok := i.rhid.Entitlements[ask]
 		if !ok {
 			// the user's org does not have an associated EBS account number, these
 			// are associated when a billing relationship exists, which is a decent
 			// proxy for RHEL entitlements
-			logrus.Error("RHEL entitlement not present in identity header")
+			ctx.Logger().Error("RHEL entitlement not present in identity header")
 			return i.AccountNumber() != ""
 		}
 		return entitled.IsEntitled


### PR DESCRIPTION
This pull request fixes an issue with the logging context in the Echo middleware. Previously, the context was not being passed correctly, resulting in incorrect log messages. This PR updates the code to ensure that the context is properly passed to the logger.

Example log output with this patch (see request id and insights id being propagated through the whole lifecycle of the request:

```
time="2024-03-27T09:47:35+01:00" level=warning msg="Sentry/Glitchtip was not initialized" func=main.main file="/Users/lzap/Work/image-builder/cmd/image-builder/main.go:57"
time="2024-03-27T09:47:35+01:00" level=info msg="🚀 Starting image-builder built 2024-03-26T18:07:06Z sha 916b5b server on localhost:8086 ...\n" func=main.main file="/Users/lzap/Work/image-builder/cmd/image-builder/main.go:176"
⇨ http server started on 127.0.0.1:8086
time="2024-03-27T09:47:39+01:00" level=debug msg="Started request GET /api/image-builder/v1/experimental/blueprints" func=main.requestIdExtractMiddleware.func1 file="/Users/lzap/Work/image-builder/cmd/image-builder/logging.go:76" insights_id=O7EucLdrM7nu request_id=E9MuzXP8PipN
time="2024-03-27T09:47:39+01:00" level=debug msg="Executing SQL: \n\t\tSELECT blueprints.id, blueprints.name, blueprints.description, MAX(blueprint_versions.version) as version, MAX(blueprint_versions.created_at) as last_modified_at\n\t\tFROM blueprints INNER JOIN blueprint_versions ON blueprint_versions.blueprint_id = blueprints.id\n\t\tWHERE blueprints.org_id = $1\n\t\tGROUP BY blueprints.id\n\t\tORDER BY last_modified_at DESC\n\t\tLIMIT $2 OFFSET $3; args: [1 100 0]" func="github.com/osbuild/image-builder/internal/db.(*dbTracer).TraceQueryStart" file="/Users/lzap/Work/image-builder/internal/db/db_trace.go:16" insights_id=O7EucLdrM7nu request_id=E9MuzXP8PipN
time="2024-03-27T09:47:39+01:00" level=debug msg="Executing SQL: \n\t\tSELECT COUNT(*)\n\t\tFROM blueprints\n\t\tWHERE blueprints.org_id = $1; args: [1]" func="github.com/osbuild/image-builder/internal/db.(*dbTracer).TraceQueryStart" file="/Users/lzap/Work/image-builder/internal/db/db_trace.go:16" insights_id=O7EucLdrM7nu request_id=E9MuzXP8PipN
time="2024-03-27T09:47:39+01:00" level=debug msg="Getting blueprint list of 0 items" func="github.com/osbuild/image-builder/internal/common.(*EchoLogrusLogger).Debugf" file="/Users/lzap/Work/image-builder/internal/common/echo_logrus.go:89" insights_id=O7EucLdrM7nu request_id=E9MuzXP8PipN
time="2024-03-27T09:47:39+01:00" level=info msg="Processed request GET /api/image-builder/v1/experimental/blueprints" func=main.main.func1 file="/Users/lzap/Work/image-builder/cmd/image-builder/main.go:134" insights_id=O7EucLdrM7nu latency_ms=43 method=GET request_id=E9MuzXP8PipN status=200 uri=/api/image-builder/v1/experimental/blueprints
```