### PR TITLE
internal/v1: fix the documented group prefix for sudo-nopasswd

### DIFF
--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1699,7 +1699,7 @@ components:
           items:
             type: string
             description: |
-              Enable passwordless sudo for users or groups (groups must be prefixed by @)
+              Enable passwordless sudo for users or groups (groups must be prefixed by %)
     Ignition:
       type: object
       additionalProperties: false

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -946,7 +946,7 @@ func TestComposeCustomizations(t *testing.T) {
 					},
 					Installer: &Installer{
 						Unattended:   common.ToPtr(true),
-						SudoNopasswd: &[]string{"admin", "@wheel"},
+						SudoNopasswd: &[]string{"admin", "%wheel"},
 					},
 				},
 				Distribution: "centos-8",
@@ -1021,7 +1021,7 @@ func TestComposeCustomizations(t *testing.T) {
 					},
 					Installer: &composer.Installer{
 						Unattended:   common.ToPtr(true),
-						SudoNopasswd: &[]string{"admin", "@wheel"},
+						SudoNopasswd: &[]string{"admin", "%wheel"},
 					},
 				},
 				ImageRequest: &composer.ImageRequest{


### PR DESCRIPTION
In PR #1096 when the option was added, I wrote in the description that groups must be prefixed with @.  The correct character is actually %.