### PR TITLE
config: fix content-sources deployment name

### DIFF
--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -68,7 +68,7 @@ func LoadConfigFromEnv(conf *ImageBuilderConfig) error {
 			conf.ProvisioningURL = fmt.Sprintf("http://%s:%d/api/provisioning/v1", endpoint.Hostname, endpoint.Port)
 		}
 
-		if endpoint, ok := clowder.DependencyEndpoints["content-sources-backend"]["api"]; ok {
+		if endpoint, ok := clowder.DependencyEndpoints["content-sources-backend"]["service"]; ok {
 			conf.ContentSourcesURL = fmt.Sprintf("http://%s:%d/api/content-sources/v1", endpoint.Hostname, endpoint.Port)
 		}
 


### PR DESCRIPTION
The specific deployment that ib needs to target is called `service`.

---
see https://github.com/content-services/content-sources-backend/blob/de7cd3642ba312628bafe412857d7518c91d003e/deployments/deployment.yaml#L150