### PR TITLE
clients: move go:generate comment into separate file

### DIFF
--- a/internal/clients/composer/client.go
+++ b/internal/clients/composer/client.go
@@ -1,5 +1,3 @@
-//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yaml openapi.v2.yml
-
 package composer
 
 import (

--- a/internal/clients/composer/package.go
+++ b/internal/clients/composer/package.go
@@ -1,0 +1,4 @@
+//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yaml openapi.v2.yml
+
+// Generated OpenAPI clients for the Composer service.
+package composer

--- a/internal/clients/content_sources/client.go
+++ b/internal/clients/content_sources/client.go
@@ -1,5 +1,3 @@
-//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yaml content-sources.v1.json
-
 package content_sources
 
 import (

--- a/internal/clients/content_sources/package.go
+++ b/internal/clients/content_sources/package.go
@@ -1,0 +1,4 @@
+//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yaml content-sources.v1.json
+
+// Generated OpenAPI clients for the Content Sources service.
+package content_sources

--- a/internal/clients/provisioning/client.go
+++ b/internal/clients/provisioning/client.go
@@ -1,5 +1,3 @@
-//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yml provisioning.v1.yml
-
 package provisioning
 
 import (

--- a/internal/clients/provisioning/package.go
+++ b/internal/clients/provisioning/package.go
@@ -1,0 +1,4 @@
+//go:generate go run -mod=mod github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yml provisioning.v1.yml
+
+// Generated OpenAPI clients for the Provisioning service.
+package provisioning


### PR DESCRIPTION
This pull request moves the go:generate comment from the client.go file to a separate package.go file for each client. This improves code organization and makes it easier to manage the go:generate commands for each client.

Reason: I skipped review of `client.go` the other day because I thought the file is generated while it is actually not.

I already asked to do the same in https://github.com/osbuild/image-builder/pull/1128 which introduces a 4th client into the codebase.
