### PR TITLE
v1: explicitly add rhcd for openscap + subscription

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -840,7 +840,18 @@ func buildCustomizations(cust *Customizations) (*composer.Customizations, error)
 		if res.Services.Enabled == nil {
 			res.Services.Enabled = &[]string{}
 		}
-		*res.Services.Enabled = append(*res.Services.Enabled, "rhcd")
+		// TODO: switch to `slice.Contains` when moving to go 1.21
+		containsService := func(services []string, service string) bool {
+			for _, s := range services {
+				if s == service {
+					return true
+				}
+			}
+			return false
+		}
+		if !containsService(*res.Services.Enabled, "rhcd") {
+			*res.Services.Enabled = append(*res.Services.Enabled, "rhcd")
+		}
 	}
 
 	if cust.Firewall != nil {

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -830,6 +830,19 @@ func buildCustomizations(cust *Customizations) (*composer.Customizations, error)
 		}
 	}
 
+	// we need to explicitly add 'rhcd' to the enabled services
+	// if openscap and subscription customizations are set, otherwise
+	// the insights-client doesn't register properly
+	if cust.Subscription != nil && cust.Subscription.Insights && cust.Openscap != nil {
+		if res.Services == nil {
+			res.Services = &composer.Services{}
+		}
+		if res.Services.Enabled == nil {
+			res.Services.Enabled = &[]string{}
+		}
+		*res.Services.Enabled = append(*res.Services.Enabled, "rhcd")
+	}
+
 	if cust.Firewall != nil {
 		res.Firewall = &composer.FirewallCustomization{
 			Ports: cust.Firewall.Ports,

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -1996,6 +1996,139 @@ func TestComposeCustomizations(t *testing.T) {
 				},
 			},
 		},
+		// subscriptions, openscap with services customizations
+		{
+			imageBuilderRequest: ComposeRequest{
+				Customizations: &Customizations{
+					Subscription: &Subscription{
+						Insights: true,
+					},
+					Openscap: &OpenSCAP{
+						ProfileId: "test",
+					},
+					Services: &Services{
+						Enabled: &[]string{"test_service"},
+						Masked:  &[]string{"test_service2"},
+					},
+				},
+				Distribution: "rhel-8",
+				ImageRequests: []ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    ImageTypesGuestImage,
+						UploadRequest: UploadRequest{
+							Type:    UploadTypesAwsS3,
+							Options: uo,
+						},
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
+				Distribution: "rhel-89",
+				Customizations: &composer.Customizations{
+					Subscription: &composer.Subscription{
+						ActivationKey: "",
+						BaseUrl:       "",
+						Insights:      true,
+						Rhc:           common.ToPtr(false),
+						Organization:  "0",
+						ServerUrl:     "",
+					},
+					Openscap: &composer.OpenSCAP{
+						ProfileId: "test",
+					},
+					Services: &composer.Services{
+						Enabled: &[]string{"test_service", "rhcd"},
+						Masked:  &[]string{"test_service2"},
+					},
+				},
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					Repositories: []composer.Repository{
+						{
+							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os"),
+							Rhsm:     common.ToPtr(true),
+							Gpgkey:   common.ToPtr(rhelGpg),
+							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"),
+							Rhsm:     common.ToPtr(true),
+							Gpgkey:   common.ToPtr(rhelGpg),
+							CheckGpg: common.ToPtr(true),
+						},
+					},
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+				},
+			},
+		},
+		// subscriptions, openscap with no services customizations
+		{
+			imageBuilderRequest: ComposeRequest{
+				Customizations: &Customizations{
+					Subscription: &Subscription{
+						Insights: true,
+					},
+					Openscap: &OpenSCAP{
+						ProfileId: "test",
+					},
+				},
+				Distribution: "rhel-8",
+				ImageRequests: []ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    ImageTypesGuestImage,
+						UploadRequest: UploadRequest{
+							Type:    UploadTypesAwsS3,
+							Options: uo,
+						},
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
+				Distribution: "rhel-89",
+				Customizations: &composer.Customizations{
+					Subscription: &composer.Subscription{
+						ActivationKey: "",
+						BaseUrl:       "",
+						Insights:      true,
+						Rhc:           common.ToPtr(false),
+						Organization:  "0",
+						ServerUrl:     "",
+					},
+					Openscap: &composer.OpenSCAP{
+						ProfileId: "test",
+					},
+					Services: &composer.Services{
+						Enabled: &[]string{"rhcd"},
+					},
+				},
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					Repositories: []composer.Repository{
+						{
+							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os"),
+							Rhsm:     common.ToPtr(true),
+							Gpgkey:   common.ToPtr(rhelGpg),
+							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Baseurl:  common.ToPtr("https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os"),
+							Rhsm:     common.ToPtr(true),
+							Gpgkey:   common.ToPtr(rhelGpg),
+							CheckGpg: common.ToPtr(true),
+						},
+					},
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+				},
+			},
+		},
 	}
 
 	for idx, payload := range payloads {


### PR DESCRIPTION
If both openscap and subscription customizations are set, we should explicitly add `rhcd` to the list of enabled services. For some reason the service gets disabled during the openscap remediation and is then not running when the system has started.