### PR TITLE
v1: switch snapshot_date format to extended ISO 8601

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -694,7 +694,7 @@ type ImageRequest struct {
 	// distribution. The snapshot that was made closest to, but before the specified date will
 	// be used. If no snapshots made before the specified date can be found, the snapshot
 	// closest to, but after the specified date will be used. If no snapshots can be found at
-	// all, the request will fail.
+	// all, the request will fail. The format must be YYYY-MM-DD (ISO 8601 extended).
 	SnapshotDate  *string       `json:"snapshot_date,omitempty"`
 	UploadRequest UploadRequest `json:"upload_request"`
 }

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1064,7 +1064,7 @@ components:
             distribution. The snapshot that was made closest to, but before the specified date will
             be used. If no snapshots made before the specified date can be found, the snapshot
             closest to, but after the specified date will be used. If no snapshots can be found at
-            all, the request will fail.
+            all, the request will fail. The format must be YYYY-MM-DD (ISO 8601 extended).
     ImageTypes:
       type: string
       enum:

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -191,9 +191,9 @@ func buildRepositories(arch *distribution.Architecture, imageType ImageTypes) []
 }
 
 func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, arch *distribution.Architecture, imageType ImageTypes, snapshotDate string) ([]composer.Repository, error) {
-	date, err := time.Parse(time.RFC3339, snapshotDate)
+	date, err := time.Parse(time.DateOnly, snapshotDate)
 	if err != nil {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Snapshot date %s is not in RFC3339 format", snapshotDate))
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Snapshot date %s is not in DateOnly (yyyy-mm-dd) format", snapshotDate))
 	}
 
 	repoURLs := []string{}

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -842,7 +842,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 			var body content_sources.ApiListSnapshotByDateRequest
 			err := json.NewDecoder(r.Body).Decode(&body)
 			require.NoError(t, err)
-			require.Equal(t, "1999-01-01", *body.Date)
+			require.Equal(t, "1999-01-30", *body.Date)
 			require.ElementsMatch(t, []string{
 				repoBaseId.String(),
 				repoAppstrId.String(),
@@ -853,7 +853,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 					{
 						IsAfter: common.ToPtr(false),
 						Match: &content_sources.ApiSnapshotResponse{
-							CreatedAt:      common.ToPtr("1998-01-01"),
+							CreatedAt:      common.ToPtr("1998-01-30"),
 							RepositoryPath: common.ToPtr("/snappy/baseos"),
 						},
 						RepositoryUuid: common.ToPtr(repoBaseId.String()),
@@ -861,7 +861,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 					{
 						IsAfter: common.ToPtr(false),
 						Match: &content_sources.ApiSnapshotResponse{
-							CreatedAt:      common.ToPtr("1998-01-01"),
+							CreatedAt:      common.ToPtr("1998-01-30"),
 							RepositoryPath: common.ToPtr("/snappy/appstream"),
 						},
 						RepositoryUuid: common.ToPtr(repoAppstrId.String()),
@@ -892,7 +892,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 			{
 				Architecture: "x86_64",
 				ImageType:    ImageTypesGuestImage,
-				SnapshotDate: common.ToPtr("1999-01-01T00:00:00.000Z"),
+				SnapshotDate: common.ToPtr("1999-01-30"),
 				UploadRequest: UploadRequest{
 					Type:    UploadTypesAwsS3,
 					Options: uo,


### PR DESCRIPTION
---

Request from @andrewgdewar, it makes sense, the time part was ignored anyway.