### PR TITLE
composes: Add blueprint version to the composes response (HMS-3587)

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -549,6 +549,7 @@ func testGetBlueprintComposes(t *testing.T) {
 
 	composes, count, err := d.GetComposes(ctx, ORGID1, fortnight, 100, 0, []string{})
 	require.NoError(t, err)
+	require.Equal(t, id, *composes[0].BlueprintId)
 	require.Equal(t, 2, *composes[0].BlueprintVersion)
 
 	count, err = d.CountBlueprintComposesSince(ctx, ORGID1, id, nil, (time.Hour * 24 * 14), nil)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -31,6 +31,7 @@ type ComposeEntry struct {
 
 type ComposeWithBlueprintVersion struct {
 	*ComposeEntry
+	BlueprintId      *uuid.UUID
 	BlueprintVersion *int
 }
 
@@ -88,7 +89,7 @@ const (
 		VALUES ($1, $2, CURRENT_TIMESTAMP, $3, $4, $5, $6, $7, $8)`
 
 	sqlGetComposes = `
-	    SELECT composes.job_id, composes.request, composes.created_at, composes.image_name, composes.client_id, blueprint_versions.version
+	    SELECT composes.job_id, composes.request, composes.created_at, composes.image_name, composes.client_id, blueprint_versions.blueprint_id, blueprint_versions.version
 	    FROM composes LEFT JOIN blueprint_versions ON composes.blueprint_version_id = blueprint_versions.id
 		WHERE org_id = $1
 		AND CURRENT_TIMESTAMP - composes.created_at <= $2
@@ -246,8 +247,9 @@ func (db *dB) GetComposes(ctx context.Context, orgId string, since time.Duration
 		var createdAt time.Time
 		var imageName *string
 		var clientId *string
+		var blueprintId *uuid.UUID
 		var blueprintVersion *int
-		err = result.Scan(&jobId, &request, &createdAt, &imageName, &clientId, &blueprintVersion)
+		err = result.Scan(&jobId, &request, &createdAt, &imageName, &clientId, &blueprintId, &blueprintVersion)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -259,6 +261,7 @@ func (db *dB) GetComposes(ctx context.Context, orgId string, since time.Duration
 				imageName,
 				clientId,
 			},
+			blueprintId,
 			blueprintVersion,
 		})
 	}

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -550,11 +550,13 @@ func (h *Handlers) GetComposes(ctx echo.Context, params GetComposesParams) error
 			return err
 		}
 		data = append(data, ComposesResponseItem{
-			CreatedAt: c.CreatedAt.Format(time.RFC3339),
-			Id:        c.Id,
-			ImageName: c.ImageName,
-			Request:   cmpr,
-			ClientId:  (*ClientId)(c.ClientId),
+			CreatedAt:        c.CreatedAt.Format(time.RFC3339),
+			Id:               c.Id,
+			ImageName:        c.ImageName,
+			BlueprintId:      c.BlueprintId,
+			BlueprintVersion: c.BlueprintVersion,
+			Request:          cmpr,
+			ClientId:         (*ClientId)(c.ClientId),
 		})
 	}
 

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -285,11 +285,16 @@ func TestGetComposes(t *testing.T) {
 	require.Equal(t, 3, result.Meta.Count)
 	require.Equal(t, 3, len(result.Data))
 
-	err = dbase.InsertCompose(ctx, id4, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId, nil)
+	bpId := uuid.New()
+	versionId := uuid.New()
+	err = dbase.InsertBlueprint(ctx, bpId, versionId, "000000", "500000", "bpName", "desc", json.RawMessage("{}"))
 	require.NoError(t, err)
-	err = dbase.InsertCompose(ctx, id5, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), &clientId, nil)
+
+	err = dbase.InsertCompose(ctx, id4, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-installer"}]}`), &clientId, &versionId)
 	require.NoError(t, err)
-	err = dbase.InsertCompose(ctx, id6, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-commit"}]}`), &clientId, nil)
+	err = dbase.InsertCompose(ctx, id5, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "aws"}]}`), &clientId, &versionId)
+	require.NoError(t, err)
+	err = dbase.InsertCompose(ctx, id6, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-commit"}]}`), &clientId, &versionId)
 	require.NoError(t, err)
 
 	respStatusCode, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/composes?ignoreImageTypes=edge-installer&ignoreImageTypes=aws", &tutils.AuthString0)
@@ -300,6 +305,8 @@ func TestGetComposes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(result.Data))
 	require.Equal(t, 1, result.Meta.Count)
+	require.Equal(t, bpId, *result.Data[0].BlueprintId)
+	require.Equal(t, 1, *result.Data[0].BlueprintVersion)
 }
 
 // TestBuildOSTreeOptions checks if the buildOSTreeOptions utility function


### PR DESCRIPTION
In #1046 we've forgotten to add the version to the actual response.
Also we have not exposed blueprint id which might be quite useful.

Fixes https://github.com/osbuild/image-builder-frontend/issues/1982