### PR TITLE
handler_compose_image: Accept empty string in SnapshotDate

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -63,7 +63,7 @@ func (h *Handlers) handleCommonCompose(ctx echo.Context, composeRequest ComposeR
 	}
 
 	var repositories []composer.Repository
-	if composeRequest.ImageRequests[0].SnapshotDate != nil {
+	if composeRequest.ImageRequests[0].SnapshotDate != nil && len(*composeRequest.ImageRequests[0].SnapshotDate) > 0 {
 		repositories, err = h.buildRepositorySnapshots(ctx, arch, composeRequest.ImageRequests[0].ImageType, *composeRequest.ImageRequests[0].SnapshotDate)
 		if err != nil {
 			return ComposeResponse{}, err


### PR DESCRIPTION
In my local setup the frontend sends an empty string …instead of nil

Should we fix this here or in the frontend or did I mix something up and it's not needed at all?