### PR TITLE
internal/recommendations: fix package recommendation url

### DIFF
--- a/internal/clients/recommendations/client.go
+++ b/internal/clients/recommendations/client.go
@@ -161,5 +161,5 @@ func (rc *RecommendationsClient) RecommendationsPackages(recommendationsPackages
 	if err != nil {
 		return nil, err
 	}
-	return rc.request("POST", fmt.Sprintf("%s/api/packages/recommendations", rc.URL), contentHeaders, bytes.NewReader(buf))
+	return rc.request("POST", fmt.Sprintf("%s/packages/recommendations", rc.URL), contentHeaders, bytes.NewReader(buf))
 }


### PR DESCRIPTION
The recommendation team is exposing this service and adding proxy configuration with a different URL. Therefore, I'm updating the URL accordingly