### PR TITLE
.github/workflows/tests: disable codecov until further notice

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Run unit tests
         run: go test -v -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...
 
-      - name: Send coverage to codecov.io
-        run: bash <(curl -s https://codecov.io/bash)
+      # disabled as 'pinging codecov' hangs
+      # see https://github.com/codecov/feedback/issues/354
+      # - name: Send coverage to codecov.io
+      #   run: bash <(curl -s https://codecov.io/bash)
 
   speccheck:
     name: "📋 openapi spec check"


### PR DESCRIPTION
The script hangs while pinging codecov for a url to upload the results to.