### PR TITLE
.github/workflows/tests: remove codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Run unit tests
         run: go test -v -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...
 
-      - name: Send coverage to codecov.io
-        run: bash <(curl -s https://codecov.io/bash)
+      # disabled as 'pinging codecov' hangs
+      # see https://github.com/codecov/feedback/issues/354
+      # - name: Send coverage to codecov.io
+      #   run: bash <(curl -s https://codecov.io/bash)
 
   speccheck:
     name: "📋 openapi spec check"


### PR DESCRIPTION
The script we were using before no longer works, and the results weren't posted for a while now. We should use the v4 action if we want to keep using codecov.