### PR TITLE
Fix caller in logs

### DIFF
--- a/cmd/image-builder/logging.go
+++ b/cmd/image-builder/logging.go
@@ -15,6 +15,7 @@ type ctxKey int
 const (
 	requestIdCtx         ctxKey = iota
 	insightsRequestIdCtx ctxKey = iota
+	requestDataCtx       ctxKey = iota
 )
 
 // Use request id from the standard context and add it to the message as a field.
@@ -36,6 +37,10 @@ func (h *ctxHook) Fire(e *logrus.Entry) error {
 	if e.Context != nil {
 		e.Data["request_id"] = e.Context.Value(requestIdCtx)
 		e.Data["insights_id"] = e.Context.Value(insightsRequestIdCtx)
+		rd := e.Context.Value(requestDataCtx).(logrus.Fields)
+		for k, v := range rd {
+			e.Data[k] = v
+		}
 	}
 
 	return nil
@@ -59,27 +64,34 @@ func requestIdExtractMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			iid = random.String(12)
 		}
 
+		// create fields stored with every log statement
+		rd := logrus.Fields{
+			"method": c.Request().Method,
+			"path":   c.Path(),
+		}
+		for _, key := range c.ParamNames() {
+			// protect existing and the most important fields
+			if _, ok := rd[key]; !(ok || key == "msg" || key == "level") {
+				rd[key] = c.Param(key)
+			}
+		}
+
 		// store it in a standard context
 		ctx := c.Request().Context()
 		ctx = context.WithValue(ctx, requestIdCtx, rid)
 		ctx = context.WithValue(ctx, insightsRequestIdCtx, iid)
+		ctx = context.WithValue(ctx, requestDataCtx, rd)
 		c.SetRequest(c.Request().WithContext(ctx))
-
-		f := logrus.Fields{"method": c.Request().Method, "path": c.Path()}
-		for _, key := range c.ParamNames() {
-			f[key] = c.Param(key)
-		}
 
 		// and set echo logger to be context logger
 		ctxLogger := logrus.StandardLogger()
 		c.SetLogger(&common.EchoLogrusLogger{
 			Logger: ctxLogger,
 			Ctx:    ctx,
-			Fields: f,
 		})
 
 		if !SkipPath(c.Path()) {
-			c.Logger().Debugf("Started request")
+			ctxLogger.WithContext(ctx).WithFields(rd).Debugf("Started request")
 		}
 
 		return next(c)

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -154,7 +154,8 @@ func main() {
 			if values.Error != nil {
 				fields["error"] = values.Error
 			}
-			logrus.WithFields(fields).Infof("Processed request %s %s", values.Method, values.URI)
+			logrus.WithContext(c.Request().Context()).
+				WithFields(fields).Infof("Processed request %s %s", values.Method, values.URI)
 
 			return nil
 		},

--- a/internal/common/echo_logrus.go
+++ b/internal/common/echo_logrus.go
@@ -12,14 +12,12 @@ import (
 // EchoLogrusLogger extend logrus.Logger
 type EchoLogrusLogger struct {
 	*logrus.Logger
-	Ctx    context.Context
-	Fields logrus.Fields
+	Ctx context.Context
 }
 
 var commonLogger = &EchoLogrusLogger{
 	Logger: logrus.StandardLogger(),
 	Ctx:    context.Background(),
-	Fields: logrus.Fields{},
 }
 
 func Logger() *EchoLogrusLogger {
@@ -68,11 +66,11 @@ func (l *EchoLogrusLogger) SetPrefix(p string) {
 }
 
 func (l *EchoLogrusLogger) Print(i ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Print(i...)
+	l.Logger.WithContext(l.Ctx).Print(i...)
 }
 
 func (l *EchoLogrusLogger) Printf(format string, args ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Printf(format, args...)
+	l.Logger.WithContext(l.Ctx).Printf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Printj(j log.JSON) {
@@ -80,15 +78,15 @@ func (l *EchoLogrusLogger) Printj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Println(string(b))
+	l.Logger.WithContext(l.Ctx).Println(string(b))
 }
 
 func (l *EchoLogrusLogger) Debug(i ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Debug(i...)
+	l.Logger.WithContext(l.Ctx).Debug(i...)
 }
 
 func (l *EchoLogrusLogger) Debugf(format string, args ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Debugf(format, args...)
+	l.Logger.WithContext(l.Ctx).Debugf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Debugj(j log.JSON) {
@@ -96,15 +94,15 @@ func (l *EchoLogrusLogger) Debugj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Debugln(string(b))
+	l.Logger.WithContext(l.Ctx).Debugln(string(b))
 }
 
 func (l *EchoLogrusLogger) Info(i ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Info(i...)
+	l.Logger.WithContext(l.Ctx).Info(i...)
 }
 
 func (l *EchoLogrusLogger) Infof(format string, args ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Infof(format, args...)
+	l.Logger.WithContext(l.Ctx).Infof(format, args...)
 }
 
 func (l *EchoLogrusLogger) Infoj(j log.JSON) {
@@ -112,15 +110,15 @@ func (l *EchoLogrusLogger) Infoj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Infoln(string(b))
+	l.Logger.WithContext(l.Ctx).Infoln(string(b))
 }
 
 func (l *EchoLogrusLogger) Warn(i ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Warn(i...)
+	l.Logger.WithContext(l.Ctx).Warn(i...)
 }
 
 func (l *EchoLogrusLogger) Warnf(format string, args ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Warnf(format, args...)
+	l.Logger.WithContext(l.Ctx).Warnf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Warnj(j log.JSON) {
@@ -128,15 +126,15 @@ func (l *EchoLogrusLogger) Warnj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Warnln(string(b))
+	l.Logger.WithContext(l.Ctx).Warnln(string(b))
 }
 
 func (l *EchoLogrusLogger) Error(i ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Error(i...)
+	l.Logger.WithContext(l.Ctx).Error(i...)
 }
 
 func (l *EchoLogrusLogger) Errorf(format string, args ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Errorf(format, args...)
+	l.Logger.WithContext(l.Ctx).Errorf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Errorj(j log.JSON) {
@@ -144,15 +142,15 @@ func (l *EchoLogrusLogger) Errorj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Errorln(string(b))
+	l.Logger.WithContext(l.Ctx).Errorln(string(b))
 }
 
 func (l *EchoLogrusLogger) Fatal(i ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Fatal(i...)
+	l.Logger.WithContext(l.Ctx).Fatal(i...)
 }
 
 func (l *EchoLogrusLogger) Fatalf(format string, args ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Fatalf(format, args...)
+	l.Logger.WithContext(l.Ctx).Fatalf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Fatalj(j log.JSON) {
@@ -160,15 +158,15 @@ func (l *EchoLogrusLogger) Fatalj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Fatalln(string(b))
+	l.Logger.WithContext(l.Ctx).Fatalln(string(b))
 }
 
 func (l *EchoLogrusLogger) Panic(i ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Panic(i...)
+	l.Logger.WithContext(l.Ctx).Panic(i...)
 }
 
 func (l *EchoLogrusLogger) Panicf(format string, args ...interface{}) {
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Panicf(format, args...)
+	l.Logger.WithContext(l.Ctx).Panicf(format, args...)
 }
 
 func (l *EchoLogrusLogger) Panicj(j log.JSON) {
@@ -176,5 +174,5 @@ func (l *EchoLogrusLogger) Panicj(j log.JSON) {
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.WithContext(l.Ctx).WithFields(l.Fields).Panicln(string(b))
+	l.Logger.WithContext(l.Ctx).Panicln(string(b))
 }


### PR DESCRIPTION
@lzap based on your #1174 I'd like to add the fix to show the correct caller (for the cases using `echo_logrus.go`)
I'd keep this as draft until yours is merged

Do you think this makes sense?

example log message is (just added some newlines for readabililaty)
before:
```
backend-1            | time="2024-05-07T09:08:36Z" level=error msg="RHEL entitlement not present in identity header"
func="github.com/osbuild/image-builder/internal/common.(*EchoLogrusLogger).Error"
file="/go/src/github.com/osbuild/image-builder/internal/common/echo_logrus.go:153"
distribution=centos-9 insights_id=eIBJqJJqkaz7 method=GET path="/api/image-builder/v1/architectures/:distribution" request_id=FbaXzyS1epxn
```
after:
```
backend-1            | time="2024-05-07T09:12:52Z" level=error msg="RHEL entitlement not present in identity header"
func="github.com/osbuild/image-builder/internal/v1.(*Identity).IsEntitled"
file="/go/src/github.com/osbuild/image-builder/internal/v1/server_identity.go:76"
distribution=centos-9 insights_id=XMckxfNStVNf method=GET path="/api/image-builder/v1/architectures/:distribution" request_id=yIP6lO4O6wmG

```