### PR TITLE
v1: add /experimental/blueprints/{id}/imageTypes endpoint to image builder (HMS-4066)

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -1766,6 +1766,9 @@ type ServerInterface interface {
 	// get composes associated with a blueprint
 	// (GET /experimental/blueprints/{id}/composes)
 	GetBlueprintComposes(ctx echo.Context, id openapi_types.UUID, params GetBlueprintComposesParams) error
+	// Get image types from a blueprint
+	// (GET /experimental/blueprints/{id}/image_types)
+	GetImageTypesFromBlueprint(ctx echo.Context, id openapi_types.UUID) error
 	// List recommended packages.
 	// (POST /experimental/recommendations)
 	RecommendPackage(ctx echo.Context) error
@@ -2127,6 +2130,22 @@ func (w *ServerInterfaceWrapper) GetBlueprintComposes(ctx echo.Context) error {
 	return err
 }
 
+// GetImageTypesFromBlueprint converts echo context to params.
+func (w *ServerInterfaceWrapper) GetImageTypesFromBlueprint(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetImageTypesFromBlueprint(ctx, id)
+	return err
+}
+
 // RecommendPackage converts echo context to params.
 func (w *ServerInterfaceWrapper) RecommendPackage(ctx echo.Context) error {
 	var err error
@@ -2285,6 +2304,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.PUT(baseURL+"/experimental/blueprints/:id", wrapper.UpdateBlueprint)
 	router.POST(baseURL+"/experimental/blueprints/:id/compose", wrapper.ComposeBlueprint)
 	router.GET(baseURL+"/experimental/blueprints/:id/composes", wrapper.GetBlueprintComposes)
+	router.GET(baseURL+"/experimental/blueprints/:id/image_types", wrapper.GetImageTypesFromBlueprint)
 	router.POST(baseURL+"/experimental/recommendations", wrapper.RecommendPackage)
 	router.GET(baseURL+"/oscap/:distribution/profiles", wrapper.GetOscapProfiles)
 	router.GET(baseURL+"/oscap/:distribution/:profile/customizations", wrapper.GetOscapCustomizations)

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -591,6 +591,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPErrorList'
+  /experimental/blueprints/{id}/image_types:
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        example: '123e4567-e89b-12d3-a456-426655440000'
+        required: true
+        description: UUID of a blueprint
+    get:
+      summary: Get image types from a blueprint
+      description: "get image types from a blueprint"
+      operationId: getImageTypesFromBlueprint
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ImageTypes'
   /experimental/blueprints/{id}/composes:
     get:
       summary: get composes associated with a blueprint

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -132,6 +132,31 @@ func (h *Handlers) GetBlueprint(ctx echo.Context, id openapi_types.UUID) error {
 	return ctx.JSON(http.StatusOK, blueprintResponse)
 }
 
+func (h *Handlers) GetImageTypesFromBlueprint(ctx echo.Context, id openapi_types.UUID) error {
+	userID, err := h.server.getIdentity(ctx)
+	if err != nil {
+		return err
+	}
+
+	ctx.Logger().Infof("Fetching blueprint %s", id)
+	blueprintEntry, err := h.server.db.GetBlueprint(ctx.Request().Context(), id, userID.OrgID())
+	if err != nil {
+		return err
+	}
+
+	blueprint, err := BlueprintFromEntry(blueprintEntry)
+	if err != nil {
+		return err
+	}
+
+	var imageTypes []ImageTypes
+	for _, req := range blueprint.ImageRequests {
+		imageTypes = append(imageTypes, req.ImageType)
+	}
+
+	return ctx.JSON(http.StatusOK, imageTypes)
+}
+
 func (h *Handlers) UpdateBlueprint(ctx echo.Context, blueprintId uuid.UUID) error {
 	userID, err := h.server.getIdentity(ctx)
 	if err != nil {


### PR DESCRIPTION
This commit introduces a new endpoint that retrieves a list of image types for a specific blueprint image. It also adds a handler function to implement this endpoint. Additionally, unit tests are included to verify the functionality of this new endpoint.