### PR TITLE
v1: add targets to the composeBlueprint endPoint (HMS-4066)

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -958,6 +958,11 @@ type GetBlueprintsParams struct {
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
+// ComposeBlueprintJSONBody defines parameters for ComposeBlueprint.
+type ComposeBlueprintJSONBody struct {
+	ImageTypes *[]ImageTypes `json:"image_types,omitempty"`
+}
+
 // GetBlueprintComposesParams defines parameters for GetBlueprintComposes.
 type GetBlueprintComposesParams struct {
 	// BlueprintVersion Filter by a specific version of the Blueprint we want to fetch composes for.
@@ -1006,6 +1011,9 @@ type CreateBlueprintJSONRequestBody = CreateBlueprintRequest
 
 // UpdateBlueprintJSONRequestBody defines body for UpdateBlueprint for application/json ContentType.
 type UpdateBlueprintJSONRequestBody = CreateBlueprintRequest
+
+// ComposeBlueprintJSONRequestBody defines body for ComposeBlueprint for application/json ContentType.
+type ComposeBlueprintJSONRequestBody ComposeBlueprintJSONBody
 
 // RecommendPackageJSONRequestBody defines body for RecommendPackage for application/json ContentType.
 type RecommendPackageJSONRequestBody = RecommendPackageRequest

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -572,10 +572,23 @@ paths:
           required: true
           description: UUID of a blueprint
       summary: create new compose from blueprint
-      description: "create new compose from blueprint"
+      description: "create new compose from blueprint, optionally specifying the target image types to build"
       operationId: composeBlueprint
       tags:
         - blueprint
+      requestBody:
+          required: false
+          description: "list of target image types that the user wants to build for this compose"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  image_types:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ImageTypes"
+                    example: ["azure", "aws"]
       responses:
         '201':
           description: compose was created

--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -16,6 +16,8 @@ import (
 	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/internal/db"
 
+	"slices"
+
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
@@ -176,6 +178,12 @@ func (h *Handlers) UpdateBlueprint(ctx echo.Context, blueprintId uuid.UUID) erro
 }
 
 func (h *Handlers) ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) error {
+	var requestBody ComposeBlueprintJSONBody
+	err := ctx.Bind(&requestBody)
+	if err != nil {
+		return err
+	}
+
 	userID, err := h.server.getIdentity(ctx)
 	if err != nil {
 		return err
@@ -192,6 +200,9 @@ func (h *Handlers) ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) err
 	composeResponses := make([]ComposeResponse, 0, len(blueprint.ImageRequests))
 	clientId := ClientId("api")
 	for _, imageRequest := range blueprint.ImageRequests {
+		if requestBody.ImageTypes != nil && !slices.Contains(*requestBody.ImageTypes, imageRequest.ImageType) {
+			continue
+		}
 		composeRequest := ComposeRequest{
 			Customizations:   &blueprint.Customizations,
 			Distribution:     blueprint.Distribution,

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,7 +112,7 @@ func TestHandlers_UpdateBlueprint(t *testing.T) {
 	require.Equal(t, "Invalid blueprint name", jsonResp.Errors[0].Title)
 }
 
-func TestHandlers_ComposeBlueprint(t *testing.T) {
+func TestHandlers_ComposeBlueprint_without_Targets(t *testing.T) {
 	ctx := context.Background()
 	ids := []uuid.UUID{uuid.New(), uuid.New()}
 	idx := 0
@@ -185,7 +186,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message)
 	require.NoError(t, err)
 
-	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/compose", id.String()), map[string]string{})
+	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/compose", id.String()), strings.NewReader(""))
 	require.Equal(t, http.StatusCreated, respStatusCode)
 
 	var result []ComposeResponse
@@ -194,6 +195,179 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 	require.Len(t, result, 2)
 	require.Equal(t, ids[0], result[0].Id)
 	require.Equal(t, ids[1], result[1].Id)
+}
+
+func TestHandlers_ComposeBlueprint_with_Targets(t *testing.T) {
+	ctx := context.Background()
+	ids := []uuid.UUID{uuid.New(), uuid.New()}
+	idx := 0
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if "Bearer" == r.Header.Get("Authorization") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		result := composer.ComposeId{
+			Id: ids[idx],
+		}
+		idx += 1
+		encodeErr := json.NewEncoder(w).Encode(result)
+		require.NoError(t, encodeErr)
+	}))
+	defer apiSrv.Close()
+
+	dbase, err := dbc.NewDB()
+	require.NoError(t, err)
+	srv, tokenSrv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, &ServerConfig{
+		DBase:            dbase,
+		DistributionsDir: "../../distributions",
+	})
+	defer func() {
+		shutdownErr := srv.Shutdown(ctx)
+		require.NoError(t, shutdownErr)
+	}()
+	defer tokenSrv.Close()
+
+	id := uuid.New()
+	versionId := uuid.New()
+
+	uploadOptions := UploadRequest_Options{}
+	err = uploadOptions.FromAWSUploadRequestOptions(AWSUploadRequestOptions{
+		ShareWithAccounts: common.ToPtr([]string{"test-account"}),
+	})
+	require.NoError(t, err)
+	name := "Blueprint Human Name"
+	description := "desc"
+	blueprint := BlueprintBody{
+		Customizations: Customizations{
+			Packages: common.ToPtr([]string{"nginx"}),
+		},
+		Distribution: "centos-8",
+		ImageRequests: []ImageRequest{
+			{
+				Architecture: ImageRequestArchitectureX8664,
+				ImageType:    ImageTypesAws,
+				UploadRequest: UploadRequest{
+					Type:    UploadTypesAws,
+					Options: uploadOptions,
+				},
+			},
+			{
+				Architecture: ImageRequestArchitectureAarch64,
+				ImageType:    ImageTypesGuestImage,
+				UploadRequest: UploadRequest{
+					Type:    UploadTypesAwsS3,
+					Options: uploadOptions,
+				},
+			},
+		},
+	}
+	payload := ComposeBlueprintJSONBody{
+		ImageTypes: &[]ImageTypes{"aws", "guest-image", "gcp"},
+	}
+	var message []byte
+	message, err = json.Marshal(blueprint)
+	require.NoError(t, err)
+	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message)
+	require.NoError(t, err)
+
+	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/compose", id.String()), payload)
+	require.Equal(t, http.StatusCreated, respStatusCode)
+
+	var result []ComposeResponse
+	err = json.Unmarshal([]byte(body), &result)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	require.Equal(t, ids[0], result[0].Id)
+	require.Equal(t, ids[1], result[1].Id)
+}
+
+func TestHandlers_ComposeBlueprint_with_One_Target(t *testing.T) {
+	ctx := context.Background()
+	ids := []uuid.UUID{uuid.New(), uuid.New()}
+	idx := 0
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if "Bearer" == r.Header.Get("Authorization") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		require.Equal(t, "Bearer accesstoken", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		result := composer.ComposeId{
+			Id: ids[idx],
+		}
+		idx += 1
+		encodeErr := json.NewEncoder(w).Encode(result)
+		require.NoError(t, encodeErr)
+	}))
+	defer apiSrv.Close()
+
+	dbase, err := dbc.NewDB()
+	require.NoError(t, err)
+	srv, tokenSrv := startServer(t, &testServerClientsConf{ComposerURL: apiSrv.URL}, &ServerConfig{
+		DBase:            dbase,
+		DistributionsDir: "../../distributions",
+	})
+	defer func() {
+		shutdownErr := srv.Shutdown(ctx)
+		require.NoError(t, shutdownErr)
+	}()
+	defer tokenSrv.Close()
+
+	id := uuid.New()
+	versionId := uuid.New()
+
+	uploadOptions := UploadRequest_Options{}
+	err = uploadOptions.FromAWSUploadRequestOptions(AWSUploadRequestOptions{
+		ShareWithAccounts: common.ToPtr([]string{"test-account"}),
+	})
+	require.NoError(t, err)
+	name := "Blueprint Human Name"
+	description := "desc"
+	blueprint := BlueprintBody{
+		Customizations: Customizations{
+			Packages: common.ToPtr([]string{"nginx"}),
+		},
+		Distribution: "centos-8",
+		ImageRequests: []ImageRequest{
+			{
+				Architecture: ImageRequestArchitectureX8664,
+				ImageType:    ImageTypesAws,
+				UploadRequest: UploadRequest{
+					Type:    UploadTypesAws,
+					Options: uploadOptions,
+				},
+			},
+			{
+				Architecture: ImageRequestArchitectureAarch64,
+				ImageType:    ImageTypesGuestImage,
+				UploadRequest: UploadRequest{
+					Type:    UploadTypesAwsS3,
+					Options: uploadOptions,
+				},
+			},
+		},
+	}
+	payload := ComposeBlueprintJSONBody{
+		ImageTypes: &[]ImageTypes{"aws"},
+	}
+	var message []byte
+	message, err = json.Marshal(blueprint)
+	require.NoError(t, err)
+	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message)
+	require.NoError(t, err)
+
+	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/compose", id.String()), payload)
+	require.Equal(t, http.StatusCreated, respStatusCode)
+
+	var result []ComposeResponse
+	err = json.Unmarshal([]byte(body), &result)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, ids[0], result[0].Id)
 }
 
 func TestHandlers_GetBlueprintComposes(t *testing.T) {

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -181,6 +181,9 @@ type binder struct{}
 
 func (b binder) Bind(i interface{}, ctx echo.Context) error {
 	request := ctx.Request()
+	if request.ContentLength == 0 {
+		return nil
+	}
 
 	contentType := request.Header["Content-Type"]
 	if len(contentType) != 1 || contentType[0] != "application/json" {


### PR DESCRIPTION
this commit add optional target to composeBlueprint endPoint that bring the ability
to build image with specific image types, also add support at the handler function
add unit tests that check this changes