### PR TITLE
multi: use `slices.Contains`

### DIFF
--- a/cmd/oscap/main.go
+++ b/cmd/oscap/main.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -57,16 +58,6 @@ type Blueprint struct {
 	Packages       []Packages
 	Description    string // get the description from the blueprint.toml
 	Name           string
-}
-
-// TODO: we can get rid of this with golang 1.21
-func contains(needle string, haystack []string) bool {
-	for _, item := range haystack {
-		if needle == item {
-			return true
-		}
-	}
-	return false
 }
 
 func cleanToml(dir string, datastreamDistro string, profile string) {
@@ -197,7 +188,7 @@ func generateJson(dir, datastreamDistro, profileDescription, profile string) {
 		services = &v1.Services{}
 		if s.Enabled != nil {
 			firewalldPkg := "firewalld"
-			if contains(firewalldPkg, *s.Enabled) && !contains(firewalldPkg, packages) {
+			if slices.Contains(*s.Enabled, firewalldPkg) && !slices.Contains(packages, firewalldPkg) {
 				packages = append(packages, firewalldPkg)
 			}
 			services.Enabled = s.Enabled

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -840,16 +841,7 @@ func buildCustomizations(cust *Customizations) (*composer.Customizations, error)
 		if res.Services.Enabled == nil {
 			res.Services.Enabled = &[]string{}
 		}
-		// TODO: switch to `slice.Contains` when moving to go 1.21
-		containsService := func(services []string, service string) bool {
-			for _, s := range services {
-				if s == service {
-					return true
-				}
-			}
-			return false
-		}
-		if !containsService(*res.Services.Enabled, "rhcd") {
+		if !slices.Contains(*res.Services.Enabled, "rhcd") {
 			*res.Services.Enabled = append(*res.Services.Enabled, "rhcd")
 		}
 	}


### PR DESCRIPTION
Since we have upgraded to go v1.21 we can now make use of the `slices.Contains` function which checks to see if a slice contains a particular element. This commit switches all custom implementations of the `slices.Contains` function.