### PR TITLE
pr_check: Increase timeout to 90m

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -8,7 +8,7 @@ export COMPONENT_NAME="image-builder"              # name of app-sre "resourceTe
 export IMAGE="quay.io/cloudservices/image-builder" # image location on quay
 
 export IQE_PLUGINS="image-builder"         # name of the IQE plugin for this app.
-export IQE_CJI_TIMEOUT="60m"               # This is the time to wait for smoke test to complete or fail
+export IQE_CJI_TIMEOUT="90m"               # This is the time to wait for smoke test to complete or fail
 export IQE_MARKER_EXPRESSION="be_pr_check" # run only tests marked by be_pr_check
 export IQE_ENV="ephemeral"                 # run only api test
 export IQE_IMAGE_TAG="image-builder"


### PR DESCRIPTION
The actual image build can take up to 60 minutes and there is not enough time for the rest of the tests and cleanup then.