### PR TITLE
v1/api: move blueprints endpoints out of experimental (HMS-4200)

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -923,27 +923,6 @@ type Version struct {
 	Version     string  `json:"version"`
 }
 
-// GetComposesParams defines parameters for GetComposes.
-type GetComposesParams struct {
-	// Limit max amount of composes, default 100
-	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
-
-	// Offset composes page offset, default 0
-	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
-
-	// IgnoreImageTypes Filter the composes on image type. The filter is optional and can be specified multiple times.
-	IgnoreImageTypes *[]ImageTypes `form:"ignoreImageTypes,omitempty" json:"ignoreImageTypes,omitempty"`
-}
-
-// GetComposeClonesParams defines parameters for GetComposeClones.
-type GetComposeClonesParams struct {
-	// Limit max amount of clones, default 100
-	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
-
-	// Offset clones page offset, default 0
-	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
-}
-
 // GetBlueprintsParams defines parameters for GetBlueprints.
 type GetBlueprintsParams struct {
 	// Name fetch blueprint with specific name
@@ -980,6 +959,63 @@ type GetBlueprintComposesParams struct {
 	IgnoreImageTypes *[]ImageTypes `form:"ignoreImageTypes,omitempty" json:"ignoreImageTypes,omitempty"`
 }
 
+// GetComposesParams defines parameters for GetComposes.
+type GetComposesParams struct {
+	// Limit max amount of composes, default 100
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset composes page offset, default 0
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// IgnoreImageTypes Filter the composes on image type. The filter is optional and can be specified multiple times.
+	IgnoreImageTypes *[]ImageTypes `form:"ignoreImageTypes,omitempty" json:"ignoreImageTypes,omitempty"`
+}
+
+// GetComposeClonesParams defines parameters for GetComposeClones.
+type GetComposeClonesParams struct {
+	// Limit max amount of clones, default 100
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset clones page offset, default 0
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
+// GetBlueprintsExperimentalParams defines parameters for GetBlueprintsExperimental.
+type GetBlueprintsExperimentalParams struct {
+	// Name fetch blueprint with specific name
+	Name *string `form:"name,omitempty" json:"name,omitempty"`
+
+	// Search search for blueprints by name or description
+	Search *string `form:"search,omitempty" json:"search,omitempty"`
+
+	// Limit max amount of blueprints, default 100
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset blueprint page offset, default 0
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
+// ComposeBlueprintExperimentalJSONBody defines parameters for ComposeBlueprintExperimental.
+type ComposeBlueprintExperimentalJSONBody struct {
+	ImageTypes *[]ImageTypes `json:"image_types,omitempty"`
+}
+
+// GetBlueprintComposesExperimentalParams defines parameters for GetBlueprintComposesExperimental.
+type GetBlueprintComposesExperimentalParams struct {
+	// BlueprintVersion Filter by a specific version of the Blueprint we want to fetch composes for.
+	// Pass special value -1 to fetch composes for latest version of the Blueprint.
+	BlueprintVersion *int `form:"blueprint_version,omitempty" json:"blueprint_version,omitempty"`
+
+	// Limit max amount of composes, default 100
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset composes page offset, default 0
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// IgnoreImageTypes Filter the composes on image type. The filter is optional and can be specified multiple times.
+	IgnoreImageTypes *[]ImageTypes `form:"ignoreImageTypes,omitempty" json:"ignoreImageTypes,omitempty"`
+}
+
 // GetPackagesParams defines parameters for GetPackages.
 type GetPackagesParams struct {
 	// Distribution distribution to look up packages for
@@ -1001,12 +1037,6 @@ type GetPackagesParams struct {
 // GetPackagesParamsArchitecture defines parameters for GetPackages.
 type GetPackagesParamsArchitecture string
 
-// ComposeImageJSONRequestBody defines body for ComposeImage for application/json ContentType.
-type ComposeImageJSONRequestBody = ComposeRequest
-
-// CloneComposeJSONRequestBody defines body for CloneCompose for application/json ContentType.
-type CloneComposeJSONRequestBody = CloneRequest
-
 // CreateBlueprintJSONRequestBody defines body for CreateBlueprint for application/json ContentType.
 type CreateBlueprintJSONRequestBody = CreateBlueprintRequest
 
@@ -1015,6 +1045,21 @@ type UpdateBlueprintJSONRequestBody = CreateBlueprintRequest
 
 // ComposeBlueprintJSONRequestBody defines body for ComposeBlueprint for application/json ContentType.
 type ComposeBlueprintJSONRequestBody ComposeBlueprintJSONBody
+
+// ComposeImageJSONRequestBody defines body for ComposeImage for application/json ContentType.
+type ComposeImageJSONRequestBody = ComposeRequest
+
+// CloneComposeJSONRequestBody defines body for CloneCompose for application/json ContentType.
+type CloneComposeJSONRequestBody = CloneRequest
+
+// CreateBlueprintExperimentalJSONRequestBody defines body for CreateBlueprintExperimental for application/json ContentType.
+type CreateBlueprintExperimentalJSONRequestBody = CreateBlueprintRequest
+
+// UpdateBlueprintExperimentalJSONRequestBody defines body for UpdateBlueprintExperimental for application/json ContentType.
+type UpdateBlueprintExperimentalJSONRequestBody = CreateBlueprintRequest
+
+// ComposeBlueprintExperimentalJSONRequestBody defines body for ComposeBlueprintExperimental for application/json ContentType.
+type ComposeBlueprintExperimentalJSONRequestBody ComposeBlueprintExperimentalJSONBody
 
 // RecommendPackageJSONRequestBody defines body for RecommendPackage for application/json ContentType.
 type RecommendPackageJSONRequestBody = RecommendPackageRequest
@@ -1728,6 +1773,27 @@ type ServerInterface interface {
 	// get the architectures and their image types available for a given distribution
 	// (GET /architectures/{distribution})
 	GetArchitectures(ctx echo.Context, distribution Distributions) error
+	// get a collection of blueprints
+	// (GET /blueprints)
+	GetBlueprints(ctx echo.Context, params GetBlueprintsParams) error
+	// create blueprint
+	// (POST /blueprints)
+	CreateBlueprint(ctx echo.Context) error
+	// delete a blueprint
+	// (DELETE /blueprints/{id})
+	DeleteBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	// get detail of a blueprint
+	// (GET /blueprints/{id})
+	GetBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	// update blueprint
+	// (PUT /blueprints/{id})
+	UpdateBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	// create new compose from blueprint
+	// (POST /blueprints/{id}/compose)
+	ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	// get composes associated with a blueprint
+	// (GET /blueprints/{id}/composes)
+	GetBlueprintComposes(ctx echo.Context, id openapi_types.UUID, params GetBlueprintComposesParams) error
 	// get status of a compose clone
 	// (GET /clones/{id})
 	GetCloneStatus(ctx echo.Context, id openapi_types.UUID) error
@@ -1757,25 +1823,25 @@ type ServerInterface interface {
 	GetDistributions(ctx echo.Context) error
 	// get a collection of blueprints
 	// (GET /experimental/blueprints)
-	GetBlueprints(ctx echo.Context, params GetBlueprintsParams) error
+	GetBlueprintsExperimental(ctx echo.Context, params GetBlueprintsExperimentalParams) error
 	// create blueprint
 	// (POST /experimental/blueprints)
-	CreateBlueprint(ctx echo.Context) error
+	CreateBlueprintExperimental(ctx echo.Context) error
 	// delete a blueprint
 	// (DELETE /experimental/blueprints/{id})
-	DeleteBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	DeleteBlueprintExperimental(ctx echo.Context, id openapi_types.UUID) error
 	// get detail of a blueprint
 	// (GET /experimental/blueprints/{id})
-	GetBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	GetBlueprintExperimental(ctx echo.Context, id openapi_types.UUID) error
 	// update blueprint
 	// (PUT /experimental/blueprints/{id})
-	UpdateBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	UpdateBlueprintExperimental(ctx echo.Context, id openapi_types.UUID) error
 	// create new compose from blueprint
 	// (POST /experimental/blueprints/{id}/compose)
-	ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) error
+	ComposeBlueprintExperimental(ctx echo.Context, id openapi_types.UUID) error
 	// get composes associated with a blueprint
 	// (GET /experimental/blueprints/{id}/composes)
-	GetBlueprintComposes(ctx echo.Context, id openapi_types.UUID, params GetBlueprintComposesParams) error
+	GetBlueprintComposesExperimental(ctx echo.Context, id openapi_types.UUID, params GetBlueprintComposesExperimentalParams) error
 	// List recommended packages.
 	// (POST /experimental/recommendations)
 	RecommendPackage(ctx echo.Context) error
@@ -1814,6 +1880,164 @@ func (w *ServerInterfaceWrapper) GetArchitectures(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.GetArchitectures(ctx, distribution)
+	return err
+}
+
+// GetBlueprints converts echo context to params.
+func (w *ServerInterfaceWrapper) GetBlueprints(ctx echo.Context) error {
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetBlueprintsParams
+	// ------------- Optional query parameter "name" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "name", ctx.QueryParams(), &params.Name)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter name: %s", err))
+	}
+
+	// ------------- Optional query parameter "search" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "search", ctx.QueryParams(), &params.Search)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter search: %s", err))
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "limit", ctx.QueryParams(), &params.Limit)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "offset", ctx.QueryParams(), &params.Offset)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter offset: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetBlueprints(ctx, params)
+	return err
+}
+
+// CreateBlueprint converts echo context to params.
+func (w *ServerInterfaceWrapper) CreateBlueprint(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.CreateBlueprint(ctx)
+	return err
+}
+
+// DeleteBlueprint converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteBlueprint(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.DeleteBlueprint(ctx, id)
+	return err
+}
+
+// GetBlueprint converts echo context to params.
+func (w *ServerInterfaceWrapper) GetBlueprint(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetBlueprint(ctx, id)
+	return err
+}
+
+// UpdateBlueprint converts echo context to params.
+func (w *ServerInterfaceWrapper) UpdateBlueprint(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.UpdateBlueprint(ctx, id)
+	return err
+}
+
+// ComposeBlueprint converts echo context to params.
+func (w *ServerInterfaceWrapper) ComposeBlueprint(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ComposeBlueprint(ctx, id)
+	return err
+}
+
+// GetBlueprintComposes converts echo context to params.
+func (w *ServerInterfaceWrapper) GetBlueprintComposes(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetBlueprintComposesParams
+	// ------------- Optional query parameter "blueprint_version" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "blueprint_version", ctx.QueryParams(), &params.BlueprintVersion)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter blueprint_version: %s", err))
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "limit", ctx.QueryParams(), &params.Limit)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "offset", ctx.QueryParams(), &params.Offset)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter offset: %s", err))
+	}
+
+	// ------------- Optional query parameter "ignoreImageTypes" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "ignoreImageTypes", ctx.QueryParams(), &params.IgnoreImageTypes)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ignoreImageTypes: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetBlueprintComposes(ctx, id, params)
 	return err
 }
 
@@ -1979,12 +2203,12 @@ func (w *ServerInterfaceWrapper) GetDistributions(ctx echo.Context) error {
 	return err
 }
 
-// GetBlueprints converts echo context to params.
-func (w *ServerInterfaceWrapper) GetBlueprints(ctx echo.Context) error {
+// GetBlueprintsExperimental converts echo context to params.
+func (w *ServerInterfaceWrapper) GetBlueprintsExperimental(ctx echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
-	var params GetBlueprintsParams
+	var params GetBlueprintsExperimentalParams
 	// ------------- Optional query parameter "name" -------------
 
 	err = runtime.BindQueryParameter("form", true, false, "name", ctx.QueryParams(), &params.Name)
@@ -2014,37 +2238,21 @@ func (w *ServerInterfaceWrapper) GetBlueprints(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetBlueprints(ctx, params)
+	err = w.Handler.GetBlueprintsExperimental(ctx, params)
 	return err
 }
 
-// CreateBlueprint converts echo context to params.
-func (w *ServerInterfaceWrapper) CreateBlueprint(ctx echo.Context) error {
+// CreateBlueprintExperimental converts echo context to params.
+func (w *ServerInterfaceWrapper) CreateBlueprintExperimental(ctx echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.CreateBlueprint(ctx)
+	err = w.Handler.CreateBlueprintExperimental(ctx)
 	return err
 }
 
-// DeleteBlueprint converts echo context to params.
-func (w *ServerInterfaceWrapper) DeleteBlueprint(ctx echo.Context) error {
-	var err error
-	// ------------- Path parameter "id" -------------
-	var id openapi_types.UUID
-
-	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
-	}
-
-	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.DeleteBlueprint(ctx, id)
-	return err
-}
-
-// GetBlueprint converts echo context to params.
-func (w *ServerInterfaceWrapper) GetBlueprint(ctx echo.Context) error {
+// DeleteBlueprintExperimental converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteBlueprintExperimental(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id openapi_types.UUID
@@ -2055,12 +2263,12 @@ func (w *ServerInterfaceWrapper) GetBlueprint(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetBlueprint(ctx, id)
+	err = w.Handler.DeleteBlueprintExperimental(ctx, id)
 	return err
 }
 
-// UpdateBlueprint converts echo context to params.
-func (w *ServerInterfaceWrapper) UpdateBlueprint(ctx echo.Context) error {
+// GetBlueprintExperimental converts echo context to params.
+func (w *ServerInterfaceWrapper) GetBlueprintExperimental(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id openapi_types.UUID
@@ -2071,12 +2279,12 @@ func (w *ServerInterfaceWrapper) UpdateBlueprint(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.UpdateBlueprint(ctx, id)
+	err = w.Handler.GetBlueprintExperimental(ctx, id)
 	return err
 }
 
-// ComposeBlueprint converts echo context to params.
-func (w *ServerInterfaceWrapper) ComposeBlueprint(ctx echo.Context) error {
+// UpdateBlueprintExperimental converts echo context to params.
+func (w *ServerInterfaceWrapper) UpdateBlueprintExperimental(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id openapi_types.UUID
@@ -2087,12 +2295,28 @@ func (w *ServerInterfaceWrapper) ComposeBlueprint(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.ComposeBlueprint(ctx, id)
+	err = w.Handler.UpdateBlueprintExperimental(ctx, id)
 	return err
 }
 
-// GetBlueprintComposes converts echo context to params.
-func (w *ServerInterfaceWrapper) GetBlueprintComposes(ctx echo.Context) error {
+// ComposeBlueprintExperimental converts echo context to params.
+func (w *ServerInterfaceWrapper) ComposeBlueprintExperimental(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ComposeBlueprintExperimental(ctx, id)
+	return err
+}
+
+// GetBlueprintComposesExperimental converts echo context to params.
+func (w *ServerInterfaceWrapper) GetBlueprintComposesExperimental(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id openapi_types.UUID
@@ -2103,7 +2327,7 @@ func (w *ServerInterfaceWrapper) GetBlueprintComposes(ctx echo.Context) error {
 	}
 
 	// Parameter object where we will unmarshal all parameters from the context
-	var params GetBlueprintComposesParams
+	var params GetBlueprintComposesExperimentalParams
 	// ------------- Optional query parameter "blueprint_version" -------------
 
 	err = runtime.BindQueryParameter("form", true, false, "blueprint_version", ctx.QueryParams(), &params.BlueprintVersion)
@@ -2133,7 +2357,7 @@ func (w *ServerInterfaceWrapper) GetBlueprintComposes(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetBlueprintComposes(ctx, id, params)
+	err = w.Handler.GetBlueprintComposesExperimental(ctx, id, params)
 	return err
 }
 
@@ -2279,6 +2503,13 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	}
 
 	router.GET(baseURL+"/architectures/:distribution", wrapper.GetArchitectures)
+	router.GET(baseURL+"/blueprints", wrapper.GetBlueprints)
+	router.POST(baseURL+"/blueprints", wrapper.CreateBlueprint)
+	router.DELETE(baseURL+"/blueprints/:id", wrapper.DeleteBlueprint)
+	router.GET(baseURL+"/blueprints/:id", wrapper.GetBlueprint)
+	router.PUT(baseURL+"/blueprints/:id", wrapper.UpdateBlueprint)
+	router.POST(baseURL+"/blueprints/:id/compose", wrapper.ComposeBlueprint)
+	router.GET(baseURL+"/blueprints/:id/composes", wrapper.GetBlueprintComposes)
 	router.GET(baseURL+"/clones/:id", wrapper.GetCloneStatus)
 	router.POST(baseURL+"/compose", wrapper.ComposeImage)
 	router.GET(baseURL+"/composes", wrapper.GetComposes)
@@ -2288,13 +2519,13 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/composes/:composeId/clones", wrapper.GetComposeClones)
 	router.GET(baseURL+"/composes/:composeId/metadata", wrapper.GetComposeMetadata)
 	router.GET(baseURL+"/distributions", wrapper.GetDistributions)
-	router.GET(baseURL+"/experimental/blueprints", wrapper.GetBlueprints)
-	router.POST(baseURL+"/experimental/blueprints", wrapper.CreateBlueprint)
-	router.DELETE(baseURL+"/experimental/blueprints/:id", wrapper.DeleteBlueprint)
-	router.GET(baseURL+"/experimental/blueprints/:id", wrapper.GetBlueprint)
-	router.PUT(baseURL+"/experimental/blueprints/:id", wrapper.UpdateBlueprint)
-	router.POST(baseURL+"/experimental/blueprints/:id/compose", wrapper.ComposeBlueprint)
-	router.GET(baseURL+"/experimental/blueprints/:id/composes", wrapper.GetBlueprintComposes)
+	router.GET(baseURL+"/experimental/blueprints", wrapper.GetBlueprintsExperimental)
+	router.POST(baseURL+"/experimental/blueprints", wrapper.CreateBlueprintExperimental)
+	router.DELETE(baseURL+"/experimental/blueprints/:id", wrapper.DeleteBlueprintExperimental)
+	router.GET(baseURL+"/experimental/blueprints/:id", wrapper.GetBlueprintExperimental)
+	router.PUT(baseURL+"/experimental/blueprints/:id", wrapper.UpdateBlueprintExperimental)
+	router.POST(baseURL+"/experimental/blueprints/:id/compose", wrapper.ComposeBlueprintExperimental)
+	router.GET(baseURL+"/experimental/blueprints/:id/composes", wrapper.GetBlueprintComposesExperimental)
 	router.POST(baseURL+"/experimental/recommendations", wrapper.RecommendPackage)
 	router.GET(baseURL+"/oscap/:distribution/profiles", wrapper.GetOscapProfiles)
 	router.GET(baseURL+"/oscap/:distribution/:profile/customizations", wrapper.GetOscapCustomizations)

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -97,6 +97,256 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPErrorList'
+  /blueprints:
+    get:
+      summary: get a collection of blueprints
+      description: "get a collection of blueprints, returns just the latest version of each blueprint"
+      operationId: getBlueprints
+      tags:
+        - blueprint
+      parameters:
+        - in: query
+          name: name
+          required: false
+          schema:
+            type: string
+          description: fetch blueprint with specific name
+        - in: query
+          name: search
+          required: false
+          schema:
+            type: string
+          description: search for blueprints by name or description
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 100
+          description: max amount of blueprints, default 100
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+          description: blueprint page offset, default 0
+      responses:
+        '200':
+          description: a list of blueprints
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlueprintsResponse'
+    post:
+      summary: create blueprint
+      description: "create blueprint"
+      operationId: createBlueprint
+      tags:
+        - blueprint
+      requestBody:
+        required: true
+        description: details of blueprint
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBlueprintRequest"
+      responses:
+        '201':
+          description: blueprint was saved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateBlueprintResponse'
+        '422':
+          description: blueprint is malformed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+        '403':
+          description: user is not allowed to create blueprints
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+  /blueprints/{id}:
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          format: uuid
+        example: '123e4567-e89b-12d3-a456-426655440000'
+        required: true
+        description: UUID of a blueprint
+    put:
+      summary: update blueprint
+      description: "update blueprint"
+      operationId: updateBlueprint
+      tags:
+        - blueprint
+      requestBody:
+        required: true
+        description: details of blueprint
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBlueprintRequest"
+      responses:
+        '200':
+          description: blueprint was updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateBlueprintResponse'
+        '404':
+          description: blueprint was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+    get:
+      summary: get detail of a blueprint
+      description: "get a blueprint detail"
+      operationId: getBlueprint
+      tags:
+        - blueprint
+      responses:
+        '200':
+          description: detail of a blueprint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlueprintResponse'
+        '404':
+          description: blueprint was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+    delete:
+      summary: delete a blueprint
+      description: |
+        Deletes all versions of Blueprint, the compose will still count towards quota.
+      operationId: deleteBlueprint
+      tags:
+        - blueprint
+      responses:
+        '204':
+          description: Successfully deleted
+        '404':
+          description: Blueprint to delete was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+  /blueprints/{id}/compose:
+    post:
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: UUID of a blueprint
+      summary: create new compose from blueprint
+      description: "create new compose from blueprint, optionally specifying the target image types to build"
+      operationId: composeBlueprint
+      tags:
+        - blueprint
+      requestBody:
+          required: false
+          description: "list of target image types that the user wants to build for this compose"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  image_types:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ImageTypes"
+                    example: ["azure", "aws"]
+      responses:
+        '201':
+          description: compose was created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ComposeResponse'
+        '403':
+          description: user is not allowed to compose from blueprints
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+  /blueprints/{id}/composes:
+    get:
+      summary: get composes associated with a blueprint
+      description: "get a collection of composes associated to a blueprint, allows for filtering by version"
+      operationId: getBlueprintComposes
+      tags:
+        - blueprint
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+          example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: UUID of a blueprint
+        - in: query
+          name: blueprint_version
+          schema:
+            type: integer
+          description: |
+            Filter by a specific version of the Blueprint we want to fetch composes for.
+            Pass special value -1 to fetch composes for latest version of the Blueprint.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 100
+          description: max amount of composes, default 100
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+          description: composes page offset, default 0
+        - in: query
+          name: ignoreImageTypes
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ImageTypes'
+              example: ['rhel-edge-installer', 'rhel-edge-commit', ...]
+          description: |
+            Filter the composes on image type. The filter is optional and can be specified multiple times.
+      responses:
+        '200':
+          description: a list of composes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposesResponse'
+        '404':
+          description: blueprint was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
   /composes:
     get:
       summary: get a collection of previous compose requests for the logged in user
@@ -419,7 +669,7 @@ paths:
     get:
       summary: get a collection of blueprints
       description: "get a collection of blueprints, returns just the latest version of each blueprint"
-      operationId: getBlueprints
+      operationId: getBlueprintsExperimental
       tags:
         - blueprint
       parameters:
@@ -460,7 +710,7 @@ paths:
     post:
       summary: create blueprint
       description: "create blueprint"
-      operationId: createBlueprint
+      operationId: createBlueprintExperimental
       tags:
         - blueprint
       requestBody:
@@ -502,7 +752,7 @@ paths:
     put:
       summary: update blueprint
       description: "update blueprint"
-      operationId: updateBlueprint
+      operationId: updateBlueprintExperimental
       tags:
         - blueprint
       requestBody:
@@ -528,7 +778,7 @@ paths:
     get:
       summary: get detail of a blueprint
       description: "get a blueprint detail"
-      operationId: getBlueprint
+      operationId: getBlueprintExperimental
       tags:
         - blueprint
       responses:
@@ -548,7 +798,7 @@ paths:
       summary: delete a blueprint
       description: |
         Deletes all versions of Blueprint, the compose will still count towards quota.
-      operationId: deleteBlueprint
+      operationId: deleteBlueprintExperimental
       tags:
         - blueprint
       responses:
@@ -573,7 +823,7 @@ paths:
           description: UUID of a blueprint
       summary: create new compose from blueprint
       description: "create new compose from blueprint, optionally specifying the target image types to build"
-      operationId: composeBlueprint
+      operationId: composeBlueprintExperimental
       tags:
         - blueprint
       requestBody:
@@ -608,7 +858,7 @@ paths:
     get:
       summary: get composes associated with a blueprint
       description: "get a collection of composes associated to a blueprint, allows for filtering by version"
-      operationId: getBlueprintComposes
+      operationId: getBlueprintComposesExperimental
       tags:
         - blueprint
       parameters:

--- a/internal/v1/handler_blueprints_experimental.go
+++ b/internal/v1/handler_blueprints_experimental.go
@@ -1,0 +1,35 @@
+package v1
+
+import (
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+func (h *Handlers) CreateBlueprintExperimental(ctx echo.Context) error {
+	return h.CreateBlueprint(ctx)
+}
+
+func (h *Handlers) GetBlueprintExperimental(ctx echo.Context, id uuid.UUID) error {
+	return h.GetBlueprint(ctx, id)
+}
+
+func (h *Handlers) UpdateBlueprintExperimental(ctx echo.Context, id uuid.UUID) error {
+	return h.UpdateBlueprint(ctx, id)
+}
+
+func (h *Handlers) ComposeBlueprintExperimental(ctx echo.Context, id uuid.UUID) error {
+	return h.ComposeBlueprint(ctx, id)
+}
+
+func (h *Handlers) GetBlueprintsExperimental(ctx echo.Context, params GetBlueprintsExperimentalParams) error {
+	return h.GetBlueprints(ctx, GetBlueprintsParams(params))
+}
+
+func (h *Handlers) GetBlueprintComposesExperimental(ctx echo.Context, blueprintId openapi_types.UUID, params GetBlueprintComposesExperimentalParams) error {
+	return h.GetBlueprintComposes(ctx, blueprintId, GetBlueprintComposesParams(params))
+}
+
+func (h *Handlers) DeleteBlueprintExperimental(ctx echo.Context, id uuid.UUID) error {
+	return h.DeleteBlueprint(ctx, id)
+}

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -48,11 +48,11 @@ func TestHandlers_CreateBlueprint(t *testing.T) {
 			},
 		},
 	}
-	statusCode, _ := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/experimental/blueprints", body)
+	statusCode, _ := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/blueprints", body)
 	require.Equal(t, http.StatusCreated, statusCode)
 
 	// Test unique name constraint
-	statusCode, resp := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/experimental/blueprints", body)
+	statusCode, resp := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/blueprints", body)
 	require.Equal(t, http.StatusUnprocessableEntity, statusCode)
 	err = json.Unmarshal([]byte(resp), &jsonResp)
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestHandlers_CreateBlueprint(t *testing.T) {
 
 	// Test non empty name constraint
 	body["name"] = ""
-	statusCode, resp = tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/experimental/blueprints", body)
+	statusCode, resp = tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/blueprints", body)
 	require.Equal(t, http.StatusUnprocessableEntity, statusCode)
 	err = json.Unmarshal([]byte(resp), &jsonResp)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestHandlers_UpdateBlueprint(t *testing.T) {
 			},
 		},
 	}
-	statusCode, resp := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/experimental/blueprints", body)
+	statusCode, resp := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/blueprints", body)
 	require.Equal(t, http.StatusCreated, statusCode)
 	var result ComposeResponse
 	err = json.Unmarshal([]byte(resp), &result)
@@ -104,7 +104,7 @@ func TestHandlers_UpdateBlueprint(t *testing.T) {
 
 	// Test non empty name constraint
 	body["name"] = ""
-	statusCode, resp = tutils.PutResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s", result.Id), body)
+	statusCode, resp = tutils.PutResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s", result.Id), body)
 	t.Log(resp)
 	require.Equal(t, http.StatusUnprocessableEntity, statusCode)
 	err = json.Unmarshal([]byte(resp), &jsonResp)
@@ -204,7 +204,7 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/compose", id.String()), tc.payload)
+			respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s/compose", id.String()), tc.payload)
 			require.Equal(t, http.StatusCreated, respStatusCode)
 
 			var result []ComposeResponse
@@ -259,7 +259,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 	err = dbase.InsertCompose(ctx, id4, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "gcp"}]}`), &clientId, &version2Id)
 	require.NoError(t, err)
 
-	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/composes", blueprintId.String()), &tutils.AuthString0)
+	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s/composes", blueprintId.String()), &tutils.AuthString0)
 	require.NoError(t, err)
 
 	require.Equal(t, 200, respStatusCode)
@@ -273,7 +273,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 	require.Equal(t, 4, result.Meta.Count)
 
 	// get composes for specific version
-	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/composes?blueprint_version=2", blueprintId.String()), &tutils.AuthString0)
+	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s/composes?blueprint_version=2", blueprintId.String()), &tutils.AuthString0)
 	require.NoError(t, err)
 
 	require.Equal(t, 200, respStatusCode)
@@ -287,7 +287,7 @@ func TestHandlers_GetBlueprintComposes(t *testing.T) {
 	require.Equal(t, 2, result.Meta.Count)
 
 	// get composes for latest version
-	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s/composes?blueprint_version=-1", blueprintId.String()), &tutils.AuthString0)
+	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s/composes?blueprint_version=-1", blueprintId.String()), &tutils.AuthString0)
 	require.NoError(t, err)
 
 	require.Equal(t, 200, respStatusCode)
@@ -353,7 +353,7 @@ func TestHandlers_GetBlueprint(t *testing.T) {
 	err = dbase.InsertBlueprint(ctx, id, versionId, "000000", "000000", name, description, message)
 	require.NoError(t, err)
 
-	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s", id.String()), &tutils.AuthString0)
+	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s", id.String()), &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, respStatusCode)
 
 	var result BlueprintResponse
@@ -393,14 +393,14 @@ func TestHandlers_GetBlueprints(t *testing.T) {
 	require.NoError(t, err)
 
 	var result BlueprintsResponse
-	respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/experimental/blueprints?name=blueprint", &tutils.AuthString0)
+	respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/blueprints?name=blueprint", &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &result)
 	require.NoError(t, err)
 	require.Len(t, result.Data, 1)
 	require.Equal(t, blueprintId, result.Data[0].Id)
 
-	respStatusCode, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/experimental/blueprints?name=Blueprint", &tutils.AuthString0)
+	respStatusCode, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/blueprints?name=Blueprint", &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &result)
 	require.NoError(t, err)
@@ -446,12 +446,12 @@ func TestHandlers_DeleteBlueprint(t *testing.T) {
 	err = dbase.InsertCompose(ctx, id4, "000000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "gcp"}]}`), &clientId, &version2Id)
 	require.NoError(t, err)
 
-	respStatusCode, body := tutils.DeleteResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s", blueprintId.String()))
+	respStatusCode, body := tutils.DeleteResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s", blueprintId.String()))
 	require.Equal(t, 204, respStatusCode)
 	require.Equal(t, "", body)
 
 	var errorResponse HTTPErrorList
-	notFoundCode, body := tutils.DeleteResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/experimental/blueprints/%s", blueprintId.String()))
+	notFoundCode, body := tutils.DeleteResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/blueprints/%s", blueprintId.String()))
 	require.Equal(t, 404, notFoundCode)
 	err = json.Unmarshal([]byte(body), &errorResponse)
 	require.NoError(t, err)


### PR DESCRIPTION
Add non-experimental version of Blueprints endpoints.

Add wrappers for experimental endpoints, so we can serve both.
Wrappers will be removed once ready in #1204

Good opportunity for an API re-review :)