### PR TITLE
v1/api: Read extra header to distinguish UI requests (HMS-4254)

### DIFF
--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -199,6 +199,9 @@ func (h *Handlers) ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) err
 	}
 	composeResponses := make([]ComposeResponse, 0, len(blueprint.ImageRequests))
 	clientId := ClientId("api")
+	if ctx.Request().Header.Get("X-ImageBuilder-ui") != "" {
+		clientId = "ui"
+	}
 	for _, imageRequest := range blueprint.ImageRequests {
 		if requestBody.ImageTypes != nil && !slices.Contains(*requestBody.ImageTypes, imageRequest.ImageType) {
 			continue


### PR DESCRIPTION
Read a special header that only our UI sends to distinguish UI and API requests.