### PR TITLE
distributions: switch to http urls for rhel-10-nightly

### DIFF
--- a/distributions/rhel-10-nightly/rhel-10-nightly.json
+++ b/distributions/rhel-10-nightly/rhel-10-nightly.json
@@ -12,11 +12,11 @@
     "image_types": ["aws", "azure", "guest-image", "openstack", "vsphere", "vsphere-ova"],
     "repositories": [{
       "id": "baseos",
-      "baseurl": "https://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/BaseOS/x86_64/os/",
+      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/BaseOS/x86_64/os/",
       "rhsm": false
     }, {
       "id": "appstream",
-      "baseurl": "https://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/AppStream/x86_64/os/",
+      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/AppStream/x86_64/os/",
       "rhsm": false
     }]
   },
@@ -24,11 +24,11 @@
     "image_types": [ "aws", "azure", "guest-image", "openstack"],
     "repositories": [{
       "id": "baseos",
-      "baseurl": "https://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/BaseOS/aarch64/os/",
+      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/BaseOS/aarch64/os/",
       "rhsm": false
     }, {
       "id": "appstream",
-      "baseurl": "https://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/AppStream/aarch64/os/",
+      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/AppStream/aarch64/os/",
       "rhsm": false
     }]
   }


### PR DESCRIPTION
Depsolving fails on ssl verification.