### PR TITLE
common: pass external id into composer

### DIFF
--- a/cmd/image-builder/logging.go
+++ b/cmd/image-builder/logging.go
@@ -1,21 +1,12 @@
 package main
 
 import (
-	"context"
 	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/gommon/random"
 	"github.com/osbuild/image-builder/internal/common"
 	"github.com/sirupsen/logrus"
-)
-
-type ctxKey int
-
-const (
-	requestIdCtx         ctxKey = iota
-	insightsRequestIdCtx ctxKey = iota
-	requestDataCtx       ctxKey = iota
 )
 
 // Use request id from the standard context and add it to the message as a field.
@@ -38,13 +29,12 @@ func (h *ctxHook) Fire(e *logrus.Entry) error {
 		return nil
 	}
 
-	e.Data["request_id"] = e.Context.Value(requestIdCtx)
-	e.Data["insights_id"] = e.Context.Value(insightsRequestIdCtx)
+	e.Data["request_id"] = common.RequestId(e.Context)
+	e.Data["insights_id"] = common.InsightsRequestId(e.Context)
 
-	if rd, ok := e.Context.Value(requestDataCtx).(logrus.Fields); ok {
-		for k, v := range rd {
-			e.Data[k] = v
-		}
+	rd := common.RequestData(e.Context)
+	for k, v := range rd {
+		e.Data[k] = v
 	}
 
 	return nil
@@ -82,9 +72,9 @@ func requestIdExtractMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 		// store it in a standard context
 		ctx := c.Request().Context()
-		ctx = context.WithValue(ctx, requestIdCtx, rid)
-		ctx = context.WithValue(ctx, insightsRequestIdCtx, iid)
-		ctx = context.WithValue(ctx, requestDataCtx, rd)
+		ctx = common.WithRequestId(ctx, rid)
+		ctx = common.WithInsightsRequestId(ctx, iid)
+		ctx = common.WithRequestData(ctx, rd)
 		c.SetRequest(c.Request().WithContext(ctx))
 
 		// and set echo logger to be context logger

--- a/cmd/image-builder/logging_test.go
+++ b/cmd/image-builder/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/osbuild/image-builder/internal/common"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +29,7 @@ func TestFire(t *testing.T) {
 
 		// Data should be added
 		{&logrus.Entry{
-			Context: context.WithValue(context.Background(), requestIdCtx, "Test"),
+			Context: common.WithRequestId(context.Background(), "Test"),
 			Data:    make(logrus.Fields)},
 			map[string]string{},
 			map[string]string{"request_id": "Test"},
@@ -36,8 +37,7 @@ func TestFire(t *testing.T) {
 
 		// valid DataCtx
 		{&logrus.Entry{
-			Context: context.WithValue(context.Background(),
-				requestDataCtx,
+			Context: common.WithRequestData(context.Background(),
 				logrus.Fields{
 					"method": "GET",
 					"path":   "/"}),
@@ -48,15 +48,7 @@ func TestFire(t *testing.T) {
 
 		// invalid DataCtx
 		{&logrus.Entry{
-			Context: context.WithValue(context.Background(), requestDataCtx, nil),
-			Data:    make(logrus.Fields)},
-			map[string]string{},
-			map[string]string{},
-		},
-
-		// invalid DataCtx 2
-		{&logrus.Entry{
-			Context: context.WithValue(context.Background(), requestDataCtx, "Hello"),
+			Context: common.WithRequestData(context.Background(), nil),
 			Data:    make(logrus.Fields)},
 			map[string]string{},
 			map[string]string{},

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -153,8 +153,8 @@ func main() {
 				"method":      values.Method,
 				"status":      values.Status,
 				"latency_ms":  values.Latency.Milliseconds(),
-				"request_id":  c.Request().Context().Value(requestIdCtx),
-				"insights_id": c.Request().Context().Value(insightsRequestIdCtx),
+				"request_id":  common.RequestId(c.Request().Context()),
+				"insights_id": common.InsightsRequestId(c.Request().Context()),
 			}
 			if values.Error != nil {
 				fields["error"] = values.Error

--- a/internal/clients/composer/client.go
+++ b/internal/clients/composer/client.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/internal/oauth2"
 
 	"github.com/google/uuid"
@@ -82,6 +83,7 @@ func (cc *ComposerClient) request(method, url string, headers map[string]string,
 	for k, v := range headers {
 		req.Header.Add(k, v)
 	}
+	req.Header.Add("X-External-Id", common.RequestId(req.Context()))
 
 	token, err := cc.tokener.Token(req.Context())
 	if err != nil {

--- a/internal/common/context.go
+++ b/internal/common/context.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+type ctxKey int
+
+const (
+	requestIdCtx         ctxKey = iota
+	insightsRequestIdCtx ctxKey = iota
+	requestDataCtx       ctxKey = iota
+)
+
+func WithRequestId(ctx context.Context, requestId string) context.Context {
+	return context.WithValue(ctx, requestIdCtx, requestId)
+}
+
+func RequestId(ctx context.Context) string {
+	rid := ctx.Value(requestIdCtx)
+	if rid == nil {
+		return ""
+	}
+	return rid.(string)
+}
+
+func WithInsightsRequestId(ctx context.Context, insightsRequestId string) context.Context {
+	return context.WithValue(ctx, insightsRequestIdCtx, insightsRequestId)
+}
+
+func InsightsRequestId(ctx context.Context) string {
+	iid := ctx.Value(insightsRequestIdCtx)
+	if iid == nil {
+		return ""
+	}
+	return iid.(string)
+}
+
+func WithRequestData(ctx context.Context, data logrus.Fields) context.Context {
+	return context.WithValue(ctx, requestDataCtx, data)
+}
+
+func RequestData(ctx context.Context) logrus.Fields {
+	rd := ctx.Value(requestDataCtx)
+	if rd == nil {
+		return logrus.Fields{}
+	}
+	return rd.(logrus.Fields)
+}


### PR DESCRIPTION
This pull request updates the code to pass the external id into the composer. It also includes changes to the common package to handle request ids and insights request ids.

Requires this feature to be present in composer:

https://github.com/osbuild/osbuild-composer/pull/4047

Will work without any problems with old composer versions.