### PR TITLE
v1: disable custom repositories' snapshotted repos in repo config

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -282,10 +282,11 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		composerRepo.CheckRepoGpg = repo.MetadataVerification
 		repositories = append(repositories, composerRepo)
 
+		// Don't enable custom repositories, as they require further setup to be useable.
 		customRepo := composer.CustomRepository{
 			Id:      *snap.RepositoryUuid,
 			Baseurl: &[]string{h.server.csReposURL.JoinPath(*snap.Match.RepositoryPath).String()},
-			Enabled: common.ToPtr(true),
+			Enabled: common.ToPtr(false),
 		}
 		if repo.GpgKey != nil && *repo.GpgKey != "" {
 			customRepo.Gpgkey = &[]string{*repo.GpgKey}

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -1097,13 +1097,13 @@ func TestComposeWithSnapshots(t *testing.T) {
 						{
 							Baseurl:  &[]string{"https://content-sources.org/snappy/payload"},
 							CheckGpg: common.ToPtr(true),
-							Enabled:  common.ToPtr(true),
+							Enabled:  common.ToPtr(false),
 							Gpgkey:   &[]string{"some-gpg-key"},
 							Id:       repoPayloadId.String(),
 						},
 						{
 							Baseurl: &[]string{"https://content-sources.org/snappy/payload2"},
-							Enabled: common.ToPtr(true),
+							Enabled: common.ToPtr(false),
 							Id:      repoPayloadId2.String(),
 						},
 					},
@@ -1197,7 +1197,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 						{
 							Baseurl:  &[]string{"https://content-sources.org/snappy/payload"},
 							CheckGpg: common.ToPtr(true),
-							Enabled:  common.ToPtr(true),
+							Enabled:  common.ToPtr(false),
 							Gpgkey:   &[]string{"some-gpg-key"},
 							Id:       repoPayloadId.String(),
 						},


### PR DESCRIPTION
They require extra setup, like subscribing and pointing to mTLS certs.