### PR TITLE
internal/v1: Skip crypt() tests on macOS

### DIFF
--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +21,10 @@ import (
 )
 
 func TestHandlers_CreateBlueprint(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("crypt() not supported on darwin")
+	}
+
 	var jsonResp HTTPErrorList
 	ctx := context.Background()
 	dbase, err := dbc.NewDB()
@@ -91,6 +96,10 @@ func TestHandlers_CreateBlueprint(t *testing.T) {
 }
 
 func TestHandlers_UpdateBlueprint(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("crypt() not supported on darwin")
+	}
+
 	var jsonResp HTTPErrorList
 	ctx := context.Background()
 	dbase, err := dbc.NewDB()
@@ -765,6 +774,10 @@ func TestHandlers_DeleteBlueprint(t *testing.T) {
 }
 
 func TestBlueprintBody_CryptPasswords(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("crypt() not supported on darwin")
+	}
+
 	// Create a sample blueprint body with users
 	passwordToHash := "password123"
 	blueprint := &BlueprintBody{


### PR DESCRIPTION
this commit add checks in several tests to skip them when running on macOS (darwin) 
using `runtime.GOOS == "darwin"` 
this prevents the tests from failing on macOS since the `crypt()` function is not supported on this platform.