### PR TITLE
(HMS-4562) Allow Blueprints update without changing User password

### DIFF
--- a/internal/clients/composer/client.go
+++ b/internal/clients/composer/client.go
@@ -146,7 +146,3 @@ func (cc *ComposerClient) CloneCompose(id uuid.UUID, clone CloneComposeBody) (*h
 func (cc *ComposerClient) CloneStatus(id uuid.UUID) (*http.Response, error) {
 	return cc.request("GET", fmt.Sprintf("%s/clones/%s", cc.composerURL, id), nil, nil)
 }
-
-func (cu *User) IsRedacted() bool {
-	return cu.Password == nil || *cu.Password == "<REDACTED>"
-}

--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -945,11 +945,15 @@ type UploadStatusStatus string
 // UploadTypes defines model for UploadTypes.
 type UploadTypes string
 
-// User defines model for User.
+// User At least one of password, ssh_key must be set, validator takes care of it.
+// On update empty string can be used to remove password or ssh_key,
+// but at least one of them still must be present.
 type User struct {
 	Name string `json:"name"`
 
 	// Password Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
+	// The password is never returned in the response.
+	// Empty string can be used to remove the password during update but only with ssh_key set.
 	Password *string `json:"password,omitempty"`
 	SshKey   *string `json:"ssh_key,omitempty"`
 }

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1883,7 +1883,10 @@ components:
       type: object
       required:
         - name
-        # One of (password, ssh_key) must be set, validator takes care of it
+      description: |
+        At least one of password, ssh_key must be set, validator takes care of it.
+        On update empty string can be used to remove password or ssh_key,
+        but at least one of them still must be present.
       properties:
         name:
           type: string
@@ -1897,6 +1900,8 @@ components:
           example: "$6$G91SvTj7uVp3xhqj$zVa8nqnJTlewniDII5dmvsBJnj3kloL3CXWdPDu9.e677VoRQd5zB6GKwkDvfGLoRR7NTl5nXLnJywk6IPIvS."
           description: |
             Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
+            The password is never returned in the response.
+            Empty string can be used to remove the password during update but only with ssh_key set.
     Filesystem:
       type: object
       required:

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -268,8 +268,9 @@ func (h *Handlers) GetComposeStatus(ctx echo.Context, composeId uuid.UUID) error
 		return err
 	}
 	if composeRequest.Customizations != nil && composeRequest.Customizations.Users != nil {
-		for _, u := range *composeRequest.Customizations.Users {
-			u.RedactPassword()
+		users := *composeRequest.Customizations.Users
+		for i := range users {
+			users[i].RedactPassword()
 		}
 	}
 

--- a/internal/v1/handler_get_compose_status_test.go
+++ b/internal/v1/handler_get_compose_status_test.go
@@ -237,6 +237,7 @@ func TestComposeStatus(t *testing.T) {
 		require.Equal(t, payload.imageStatus, result.ImageStatus)
 		require.Equal(t, cr.Distribution, result.Request.Distribution)
 		require.Equal(t, cr.Distribution, result.Request.Distribution)
-		require.True(t, (*result.Request.Customizations.Users)[0].IsRedacted())
+		user := (*result.Request.Customizations.Users)[0]
+		require.Nil(t, user.Password)
 	}
 }

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2553,7 +2553,7 @@ func TestComposeCustomizations(t *testing.T) {
 
 			// Check that the password returned is redacted
 			for _, u := range *composerRequest.Customizations.Users {
-				require.True(t, u.IsRedacted())
+				require.True(t, u.Password == nil)
 			}
 		}
 		composerRequest = composer.ComposeRequest{}


### PR DESCRIPTION
HMS-4562

See the issue for detailed acceptance criteria, in short the PR:

- [x] Blueprint can be updated without specifying the password, and password is not changed.
- [x] `<REDACTED>` value is not used at all, instead users password property is omitted from response
- [x] either password or ssh_key must be set for every user (or both)
- [x] empty string can be used to remove password or ssh_key (while still having either ssh_key or password set) == user can be changed from 'password user' to 'ssh_key user' and back