### PR TITLE
cmd/image-builder: add deployment channel as field to the logs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,11 +59,8 @@ jobs:
           version: v1.56.2
           skip-cache: true
 
-      - name: install tern
-        run: go install github.com/jackc/tern@latest
-
       - name: Run unit tests
-        run: go test -v -race -covermode=atomic -coverprofile=coverage.txt -coverpkg=./... ./...
+        run: make unit-tests
 
       # disabled as 'pinging codecov' hangs
       # see https://github.com/codecov/feedback/issues/354

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/gommon/log"
+	slogger "github.com/osbuild/osbuild-composer/pkg/splunk_logger"
 	"github.com/sirupsen/logrus"
 )
 
@@ -71,6 +72,10 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+	}
+
+	if conf.DeploymentChannel != "" {
+		logrus.AddHook(&slogger.EnvironmentHook{Channel: conf.DeploymentChannel})
 	}
 
 	if conf.SplunkHost != "" {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/osbuild/community-gateway/oidc-authorizer v0.0.0-20240117171535-401ddadefd40
 	github.com/osbuild/images v0.73.0
-	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240311100454-57ebfb401131
+	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/prometheus/client_golang v1.19.1
 	github.com/redhatinsights/app-common-go v1.6.8
 	github.com/redhatinsights/identity v0.0.0-20220719174832-36a7b1cbeff1

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/osbuild/community-gateway/oidc-authorizer v0.0.0-20240117171535-401dd
 github.com/osbuild/community-gateway/oidc-authorizer v0.0.0-20240117171535-401ddadefd40/go.mod h1:CecYUdLQNeKEkEC0DOejBTaVxs8Xbr30tRtgOIpbuKo=
 github.com/osbuild/images v0.73.0 h1:2mKFohG1mGh92KFr/rtkmOYTe1Oi6YT0Qdgdz5I20hE=
 github.com/osbuild/images v0.73.0/go.mod h1:5xDxWmKDseAPwsnHS16AsHDM2ytCDJcsPK2uaKfvGvc=
-github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240311100454-57ebfb401131 h1:T0XABvVgYzQ4MUfJG+WF+2+/lDHXv8ZMRf9Sqeq+N24=
-github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240311100454-57ebfb401131/go.mod h1:z+WA+dX6qMwc7fqY5jCzESDIlg4WR2sBQezxsoXv9Ik=
+github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
+github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ type ImageBuilderConfig struct {
 	RecommendCA           string `env:"RECOMMENDATIONS_CA_PATH"`
 	GlitchTipDSN          string `env:"GLITCHTIP_DSN"`
 	FedoraAuth            bool   `env:"FEDORA_AUTH"`
+	DeploymentChannel     string `env:"CHANNEL"`
 }
 
 func (ibc *ImageBuilderConfig) IsDebug() bool {

--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -191,7 +191,10 @@ func startServer(t *testing.T, tscc *testServerClientsConf, conf *ServerConfig) 
 	require.NoError(t, err)
 	// execute in parallel b/c .Run() will block execution
 	go func() {
-		_ = echoServer.Start("localhost:8086")
+		err = echoServer.Start("localhost:8086")
+		if err.Error() != "http: Server closed" {
+			require.NoError(t, err)
+		}
 	}()
 
 	// wait until server is ready

--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -130,6 +130,8 @@ objects:
                 key: proxy
                 name: recommendations-secrets
                 optional: true
+          - name: CHANNEL
+            value: ${CHANNEL}
         volumeMounts:
           - name: config-volume
             mountPath: /app/config

--- a/vendor/github.com/osbuild/osbuild-composer/pkg/splunk_logger/environment_hook.go
+++ b/vendor/github.com/osbuild/osbuild-composer/pkg/splunk_logger/environment_hook.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type EnvironmentHook struct {
+	Channel string
+}
+
+func (h *EnvironmentHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
+}
+
+func (h *EnvironmentHook) Fire(e *logrus.Entry) error {
+	e.Data["channel"] = h.Channel
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -170,8 +170,8 @@ github.com/osbuild/community-gateway/oidc-authorizer/pkg/identity
 # github.com/osbuild/images v0.73.0
 ## explicit; go 1.21
 github.com/osbuild/images/pkg/crypt
-# github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240311100454-57ebfb401131
-## explicit; go 1.19
+# github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
+## explicit; go 1.21
 github.com/osbuild/osbuild-composer/pkg/splunk_logger
 # github.com/perimeterx/marshmallow v1.1.5
 ## explicit; go 1.17


### PR DESCRIPTION
add deployment channel as field to the logs similar to 
https://github.com/osbuild/osbuild-composer/pull/4285
and based on
https://github.com/osbuild/osbuild-composer/pull/4301