### PR TITLE
tests: add more coverage to composeStatus unit tests

### DIFF
--- a/cmd/image-builder-db-test/main_test.go
+++ b/cmd/image-builder-db-test/main_test.go
@@ -159,7 +159,7 @@ func testGetCompose(t *testing.T) {
 
 	// cross-account compose access not allowed
 	compose, err = d.GetCompose(ctx, composes[0].Id, ORGID2)
-	require.Equal(t, db.ComposeNotFoundError, err)
+	require.Equal(t, db.ComposeEntryNotFoundError, err)
 	require.Nil(t, compose)
 
 }
@@ -281,10 +281,10 @@ func testDeleteCompose(t *testing.T) {
 	_, err = conn.Exec(ctx, insert, composeId, "{}", ANR1, ORGID1)
 
 	err = d.DeleteCompose(ctx, composeId, ORGID2)
-	require.Equal(t, db.ComposeNotFoundError, err)
+	require.Equal(t, db.ComposeEntryNotFoundError, err)
 
 	err = d.DeleteCompose(ctx, uuid.New(), ORGID1)
-	require.Equal(t, db.ComposeNotFoundError, err)
+	require.Equal(t, db.ComposeEntryNotFoundError, err)
 
 	err = d.DeleteCompose(ctx, composeId, ORGID1)
 	require.NoError(t, err)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,8 +11,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// ComposeNotFoundError occurs when no compose request is found for a user.
-var ComposeNotFoundError = errors.New("Compose not found")
+// ComposeEntryNotFoundError occurs when no compose request is found for a user.
+var ComposeEntryNotFoundError = errors.New("Compose entry not found")
 var CloneNotFoundError = errors.New("Clone not found")
 var BlueprintNotFoundError = errors.New("blueprint not found")
 var AffectedRowsMismatchError = errors.New("Unexpected affected rows")
@@ -197,7 +197,7 @@ func (db *dB) GetCompose(ctx context.Context, jobId uuid.UUID, orgId string) (*C
 	err = result.Scan(&compose.Id, &compose.Request, &compose.CreatedAt, &compose.ImageName, &compose.ClientId)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ComposeNotFoundError
+			return nil, ComposeEntryNotFoundError
 		} else {
 			return nil, err
 		}
@@ -219,7 +219,7 @@ func (db *dB) GetComposeImageType(ctx context.Context, jobId uuid.UUID, orgId st
 	err = result.Scan(&imageType)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", ComposeNotFoundError
+			return "", ComposeEntryNotFoundError
 		} else {
 			return "", err
 		}
@@ -306,7 +306,7 @@ func (db *dB) DeleteCompose(ctx context.Context, jobId uuid.UUID, orgId string) 
 
 	tag, err := conn.Exec(ctx, sqlDeleteCompose, orgId, jobId)
 	if tag.RowsAffected() != 1 {
-		return ComposeNotFoundError
+		return ComposeEntryNotFoundError
 	}
 
 	return err

--- a/internal/v1/handler.go
+++ b/internal/v1/handler.go
@@ -426,7 +426,7 @@ func (h *Handlers) DeleteCompose(ctx echo.Context, composeId uuid.UUID) error {
 
 	err = h.server.db.DeleteCompose(ctx.Request().Context(), composeId, userID.OrgID())
 	if err != nil {
-		if errors.Is(err, db.ComposeNotFoundError) {
+		if errors.Is(err, db.ComposeEntryNotFoundError) {
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -503,7 +503,7 @@ func (h *Handlers) getComposeByIdAndOrgId(ctx echo.Context, composeId uuid.UUID)
 
 	composeEntry, err := h.server.db.GetCompose(ctx.Request().Context(), composeId, userID.OrgID())
 	if err != nil {
-		if errors.Is(err, db.ComposeNotFoundError) {
+		if errors.Is(err, db.ComposeEntryNotFoundError) {
 			return nil, echo.NewHTTPError(http.StatusNotFound, err)
 		} else {
 			return nil, err
@@ -596,7 +596,7 @@ func (h *Handlers) CloneCompose(ctx echo.Context, composeId uuid.UUID) error {
 	}
 	imageType, err := h.server.db.GetComposeImageType(ctx.Request().Context(), composeId, userID.OrgID())
 	if err != nil {
-		if errors.Is(err, db.ComposeNotFoundError) {
+		if errors.Is(err, db.ComposeEntryNotFoundError) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Unable to find compose %v", composeId))
 		}
 		ctx.Logger().Errorf("Error querying image type for compose %v: %v", composeId, err)


### PR DESCRIPTION
- this commit add unit test for GetComposeStatus handling 404 NotFound response`composeStatus` doesn't found
- Added TestGetComposeStatusNotFoundResponse to cover the scenario where the compose status API returns a 404 NotFound response, improving the function's test coverage.
- Renamed a test to better reflect the specific case it covers.
increase the coverage of GetComposeStatus  from  *62.2%* to *70.3%*


