### PR TITLE
tests: tweaks to the way routes are tested

### DIFF
--- a/internal/v1/handler_get_compose_status_test.go
+++ b/internal/v1/handler_get_compose_status_test.go
@@ -228,7 +228,7 @@ func TestComposeStatus(t *testing.T) {
 	for idx, payload := range payloads {
 		fmt.Printf("TT payload %d\n", idx)
 		composerStatus = payload.composerStatus
-		respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s", composeId), &tutils.AuthString0)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s", composeId), &tutils.AuthString0)
 		require.Equal(t, http.StatusOK, respStatusCode)
 
 		var result ComposeStatus

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -42,7 +42,7 @@ func TestValidateComposeRequest(t *testing.T) {
 			Distribution:   "centos-9",
 			ImageRequests:  []ImageRequest{},
 		}
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, `Error at \"/image_requests\": minimum number of items is 1`)
 	})
@@ -74,7 +74,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				},
 			},
 		}
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, `Error at \"/image_requests\": maximum number of items is 1`)
 	})
@@ -97,7 +97,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				},
 			},
 		}
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "Expected at least one source or account to share the image with")
 	})
@@ -153,7 +153,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				Distribution:   "centos-9",
 				ImageRequests:  []ImageRequest{tc.request},
 			}
-			respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+			respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
 			require.Contains(t, body, "Request must contain either (1) a source id, and no tenant or subscription ids or (2) tenant and subscription ids, and no source id.")
 		})
@@ -171,7 +171,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				},
 			},
 		}
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Regexp(t, "image_requests/0/upload_request/options|image_requests/0/upload_request/type", body)
 		require.Regexp(t, "Value is not nullable|value is not one of the allowed values|doesn't match any schema from", body)
@@ -199,7 +199,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				},
 			},
 		}
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "Error at \\\"/image_requests/0/architecture\\\"")
 	})
@@ -224,7 +224,7 @@ func TestValidateComposeRequest(t *testing.T) {
 				},
 			},
 		}
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "Error at \\\"/image_requests/0/upload_request/type\\\"")
 	})
@@ -277,7 +277,7 @@ func TestValidateComposeRequest(t *testing.T) {
 		for _, it := range []ImageTypes{ImageTypesAmi, ImageTypesAws} {
 			payload.ImageRequests[0].ImageType = it
 			payload.ImageRequests[0].UploadRequest = awsUr
-			respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+			respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
 			require.Contains(t, body, fmt.Sprintf("Total AWS image size cannot exceed %d bytes", FSMaxSize))
 		}
@@ -285,7 +285,7 @@ func TestValidateComposeRequest(t *testing.T) {
 		for _, it := range []ImageTypes{ImageTypesAzure, ImageTypesVhd} {
 			payload.ImageRequests[0].ImageType = it
 			payload.ImageRequests[0].UploadRequest = azureUr
-			respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+			respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
 			require.Contains(t, body, fmt.Sprintf("Total Azure image size cannot exceed %d bytes", FSMaxSize))
 		}
@@ -419,7 +419,7 @@ func TestComposeStatusError(t *testing.T) {
 	}()
 	defer tokenSrv.Close()
 
-	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s",
+	respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s",
 		id), &tutils.AuthString1)
 	require.Equal(t, http.StatusOK, respStatusCode)
 
@@ -478,7 +478,7 @@ func TestComposeImageErrorsWhenStatusCodeIsNotStatusCreated(t *testing.T) {
 			},
 		},
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 	require.Equal(t, http.StatusInternalServerError, respStatusCode)
 	require.Contains(t, body, "Failed posting compose request to osbuild-composer")
 }
@@ -532,7 +532,7 @@ func TestComposeImageErrorResolvingOSTree(t *testing.T) {
 			},
 		},
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 	require.Equal(t, http.StatusBadRequest, respStatusCode)
 	require.Contains(t, body, "Error resolving OSTree repo")
 }
@@ -577,7 +577,7 @@ func TestComposeImageErrorsWhenCannotParseResponse(t *testing.T) {
 			},
 		},
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 	require.Equal(t, http.StatusInternalServerError, respStatusCode)
 	require.Contains(t, body, "Internal Server Error")
 }
@@ -610,7 +610,7 @@ func TestComposeImageErrorsWhenDistributionNotExists(t *testing.T) {
 			},
 		},
 	}
-	respStatusCode, _ := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+	respStatusCode, _ := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 	require.Equal(t, http.StatusBadRequest, respStatusCode)
 }
 
@@ -657,7 +657,7 @@ func TestComposeImageReturnsIdWhenNoErrors(t *testing.T) {
 			},
 		},
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 	require.Equal(t, http.StatusCreated, respStatusCode)
 
 	var result ComposeResponse
@@ -725,7 +725,7 @@ func TestComposeImageAllowList(t *testing.T) {
 
 		payload := createPayload("centos-9")
 
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusCreated, respStatusCode)
 
 		var result ComposeResponse
@@ -750,7 +750,7 @@ func TestComposeImageAllowList(t *testing.T) {
 
 		payload := createPayload("rhel-8")
 
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusForbidden, respStatusCode)
 
 		var result ComposeResponse
@@ -775,7 +775,7 @@ func TestComposeImageAllowList(t *testing.T) {
 
 		payload := createPayload("rhel-8")
 
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload)
 		require.Equal(t, http.StatusForbidden, respStatusCode)
 
 		var result ComposeResponse
@@ -1209,7 +1209,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 
 	for idx, payload := range payloads {
 		fmt.Printf("TT payload %d\n", idx)
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload.imageBuilderRequest)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload.imageBuilderRequest)
 		require.Equal(t, http.StatusCreated, respStatusCode)
 		var result ComposeResponse
 		err := json.Unmarshal([]byte(body), &result)
@@ -2433,7 +2433,7 @@ func TestComposeCustomizations(t *testing.T) {
 
 	for idx, payload := range payloads {
 		fmt.Printf("TT payload %d\n", idx)
-		respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/compose", payload.imageBuilderRequest)
+		respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/compose", payload.imageBuilderRequest)
 		require.Equal(t, http.StatusCreated, respStatusCode)
 
 		var result ComposeResponse

--- a/internal/v1/handler_recommend_package_test.go
+++ b/internal/v1/handler_recommend_package_test.go
@@ -45,7 +45,7 @@ func TestRecommendPackage_Success_with_StatusForbidden(t *testing.T) {
 			return recommendedPackages
 		}(),
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL, payload)
+	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL+"/", payload)
 	require.Equal(t, http.StatusCreated, respStatusCode)
 	var result RecommendationsResponse
 	expectedResult := RecommendationsResponse{
@@ -90,7 +90,7 @@ func TestRecommendPackage_Success_with_StatusUnauthorized(t *testing.T) {
 		}(),
 	}
 
-	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL, payload)
+	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL+"/", payload)
 	require.Equal(t, http.StatusCreated, respStatusCode)
 	var result RecommendationsResponse
 	expectedResult := RecommendationsResponse{
@@ -133,7 +133,7 @@ func TestRecommendPackage_Success_with_no_packages(t *testing.T) {
 			return recommendedPackages
 		}(),
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL, payload)
+	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL+"/", payload)
 	require.Equal(t, http.StatusCreated, respStatusCode)
 	var result RecommendationsResponse
 	expectedResult := RecommendationsResponse{
@@ -178,7 +178,7 @@ func TestRecommendPackage_Success_with_packages(t *testing.T) {
 			return recommendedPackages
 		}(),
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL, payload)
+	respStatusCode, body := tutils.PostResponseBody(t, apiSrv.URL+"/", payload)
 	require.Equal(t, http.StatusCreated, respStatusCode)
 	var result RecommendationsResponse
 	expectedResult := RecommendationsResponse{
@@ -234,7 +234,7 @@ func TestRecommendPackage_with_authenticationServer(t *testing.T) {
 			return recommendedPackages
 		}(),
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, "http://localhost:8086/api/image-builder/v1/experimental/recommendations", payload)
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+"/api/image-builder/v1/experimental/recommendations", payload)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	var result RecommendationsResponse
 	expectedResult := RecommendationsResponse{

--- a/internal/v1/handler_test.go
+++ b/internal/v1/handler_test.go
@@ -35,7 +35,7 @@ func TestWithoutOsbuildComposerBackend(t *testing.T) {
 	defer tokenSrv.Close()
 
 	t.Run("GetVersion", func(t *testing.T) {
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &tutils.AuthString0)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &tutils.AuthString0)
 		require.Equal(t, http.StatusOK, respStatusCode)
 
 		var result Version
@@ -52,29 +52,29 @@ func TestWithoutOsbuildComposerBackend(t *testing.T) {
 			authString   *string
 		}{
 			{
-				url:          "http://localhost:8086/api/image-builder/v1/openapi.json",
+				url:          "/api/image-builder/v1/openapi.json",
 				testCaseName: "Test without Authentication",
 				authString:   nil,
 			},
 			{
-				url:          "http://localhost:8086/api/image-builder/v1/openapi.json",
+				url:          "/api/image-builder/v1/openapi.json",
 				testCaseName: "Test with Authentication",
 				authString:   &tutils.AuthString0,
 			},
 			{
-				url:          "http://localhost:8086/api/image-builder/v1.0/openapi.json",
+				url:          "/api/image-builder/v1.0/openapi.json",
 				testCaseName: "Test without Authentication (v1.0 URL)",
 				authString:   nil,
 			},
 			{
-				url:          "http://localhost:8086/openapi.json",
+				url:          "/openapi.json",
 				testCaseName: "Test without Authentication (basic URL)",
 				authString:   nil,
 			},
 		}
 
 		for _, tc := range testCases {
-			respStatusCode, body := tutils.GetResponseBody(t, tc.url, tc.authString)
+			respStatusCode, body := tutils.GetResponseBody(t, srv.URL+tc.url, tc.authString)
 			require.Equal(t, http.StatusOK, respStatusCode, tc.testCaseName)
 
 			var swagger *openapi3.T
@@ -99,7 +99,7 @@ func TestWithoutOsbuildComposerBackend(t *testing.T) {
 	})
 
 	t.Run("StatusCheck", func(t *testing.T) {
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/status", nil)
+		respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/status", nil)
 		require.Equal(t, http.StatusOK, respStatusCode)
 	})
 }
@@ -126,7 +126,7 @@ func TestGetComposeEntryNotFoundResponse(t *testing.T) {
 	}()
 	defer tokenSrv.Close()
 
-	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s",
+	respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s",
 		id), &tutils.AuthString0)
 	require.Equal(t, http.StatusNotFound, respStatusCode)
 	require.Contains(t, body, "Compose entry not found")
@@ -193,7 +193,7 @@ func TestGetComposeStatusNotFoundResponse(t *testing.T) {
 		fmt.Printf("TT payload %d\n", idx)
 		composerStatus = payload.composerStatus
 
-		respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s",
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s",
 			composeId), &tutils.AuthString0)
 		require.Equal(t, http.StatusNotFound, respStatusCode)
 		var result ComposeStatus
@@ -265,8 +265,8 @@ func TestGetComposeMetadata(t *testing.T) {
 	var result composer.ComposeMetadata
 
 	// Get API response and compare
-	respStatusCode, body := tutils.GetResponseBody(t,
-		fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s/metadata", id), &tutils.AuthString0)
+	respStatusCode, body := tutils.GetResponseBody(t, srv.URL+
+		fmt.Sprintf("/api/image-builder/v1/composes/%s/metadata", id), &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &result)
 	require.NoError(t, err)
@@ -294,7 +294,7 @@ func TestGetComposeMetadata404(t *testing.T) {
 	}()
 	defer tokenSrv.Close()
 
-	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s/metadata",
+	respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s/metadata",
 		id), &tutils.AuthString0)
 	require.Equal(t, http.StatusNotFound, respStatusCode)
 	require.Contains(t, body, "Compose entry not found")
@@ -323,7 +323,7 @@ func TestGetComposes(t *testing.T) {
 	defer tokenSrv.Close()
 
 	var result ComposesResponse
-	respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/composes", &tutils.AuthString0)
+	respStatusCode, body := tutils.GetResponseBody(t, db_srv.URL+"/api/image-builder/v1/composes", &tutils.AuthString0)
 
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &result)
@@ -343,7 +343,7 @@ func TestGetComposes(t *testing.T) {
 	composeEntry, err := dbase.GetCompose(ctx, id, "000000")
 	require.NoError(t, err)
 
-	respStatusCode, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/composes", &tutils.AuthString0)
+	respStatusCode, body = tutils.GetResponseBody(t, db_srv.URL+"/api/image-builder/v1/composes", &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &result)
 	require.NoError(t, err)
@@ -368,7 +368,7 @@ func TestGetComposes(t *testing.T) {
 	err = dbase.InsertCompose(ctx, id6, "500000", "user100000@test.test", "000000", &imageName, json.RawMessage(`{"image_requests": [{"image_type": "edge-commit"}]}`), &clientId, &versionId)
 	require.NoError(t, err)
 
-	respStatusCode, body = tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/composes?ignoreImageTypes=edge-installer&ignoreImageTypes=aws", &tutils.AuthString0)
+	respStatusCode, body = tutils.GetResponseBody(t, db_srv.URL+"/api/image-builder/v1/composes?ignoreImageTypes=edge-installer&ignoreImageTypes=aws", &tutils.AuthString0)
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusOK, respStatusCode)
@@ -418,7 +418,7 @@ func TestReadinessProbeNotReady(t *testing.T) {
 	}()
 	defer tokenSrv.Close()
 
-	respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/ready", &tutils.AuthString0)
+	respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/ready", &tutils.AuthString0)
 	require.NotEqual(t, http.StatusOK, respStatusCode)
 	require.NotEqual(t, http.StatusNotFound, respStatusCode)
 }
@@ -443,7 +443,7 @@ func TestReadinessProbeReady(t *testing.T) {
 	}()
 	defer tokenSrv.Close()
 
-	respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/ready", &tutils.AuthString0)
+	respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/ready", &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	require.Contains(t, body, "{\"readiness\":\"ready\"}")
 }
@@ -456,7 +456,7 @@ func TestMetrics(t *testing.T) {
 	}()
 	defer tokenSrv.Close()
 
-	respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/metrics", nil)
+	respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/metrics", nil)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	require.Contains(t, body, "image_builder_crc_compose_requests_total")
 	require.Contains(t, body, "image_builder_crc_compose_errors")
@@ -529,7 +529,7 @@ func TestGetClones(t *testing.T) {
 	defer tokenSrv.Close()
 
 	var csResp ClonesResponse
-	respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s/clones", id), &tutils.AuthString0)
+	respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s/clones", id), &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &csResp)
 	require.NoError(t, err)
@@ -540,7 +540,7 @@ func TestGetClones(t *testing.T) {
 		Region:           "us-east-2",
 		ShareWithSources: &[]string{"1"},
 	}
-	respStatusCode, body = tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s/clone", id), cloneReq)
+	respStatusCode, body = tutils.PostResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s/clone", id), cloneReq)
 	require.Equal(t, http.StatusCreated, respStatusCode)
 
 	var cResp CloneResponse
@@ -548,7 +548,7 @@ func TestGetClones(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cloneId, cResp.Id)
 
-	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s/clones", id), &tutils.AuthString0)
+	respStatusCode, body = tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s/clones", id), &tutils.AuthString0)
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &csResp)
 	require.NoError(t, err)
@@ -624,7 +624,7 @@ func TestGetCloneStatus(t *testing.T) {
 	cloneReq := AWSEC2Clone{
 		Region: "us-east-2",
 	}
-	respStatusCode, body := tutils.PostResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/composes/%s/clone", id), cloneReq)
+	respStatusCode, body := tutils.PostResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/composes/%s/clone", id), cloneReq)
 	require.Equal(t, http.StatusCreated, respStatusCode)
 
 	var cResp CloneResponse
@@ -633,7 +633,7 @@ func TestGetCloneStatus(t *testing.T) {
 	require.Equal(t, cloneId, cResp.Id)
 
 	var usResp CloneStatusResponse
-	respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/clones/%s", cloneId), &tutils.AuthString0)
+	respStatusCode, body = tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/clones/%s", cloneId), &tutils.AuthString0)
 
 	require.Equal(t, http.StatusOK, respStatusCode)
 	err = json.Unmarshal([]byte(body), &usResp)
@@ -672,7 +672,7 @@ func TestGetArchitectures(t *testing.T) {
 	defer tokenSrv.Close()
 
 	t.Run("Basic centos-9", func(t *testing.T) {
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/architectures/centos-9", &tutils.AuthString0)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/architectures/centos-9", &tutils.AuthString0)
 		require.Equal(t, http.StatusOK, respStatusCode)
 
 		var result Architectures
@@ -708,12 +708,12 @@ func TestGetArchitectures(t *testing.T) {
 	})
 
 	t.Run("Restricted distribution", func(t *testing.T) {
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/architectures/fedora-39", &tutils.AuthString1)
+		respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/architectures/fedora-39", &tutils.AuthString1)
 		require.Equal(t, http.StatusForbidden, respStatusCode)
 	})
 
 	t.Run("Restricted, but allowed distribution", func(t *testing.T) {
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/architectures/fedora-39", &tutils.AuthString0)
+		respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/architectures/fedora-39", &tutils.AuthString0)
 		require.Equal(t, http.StatusOK, respStatusCode)
 	})
 }
@@ -734,7 +734,7 @@ func TestGetPackages(t *testing.T) {
 
 	t.Run("Simple search", func(t *testing.T) {
 		for _, arch := range architectures {
-			respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh", arch), &tutils.AuthString0)
+			respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 
 			var result PackagesResponse
@@ -748,7 +748,7 @@ func TestGetPackages(t *testing.T) {
 
 	t.Run("Empty search", func(t *testing.T) {
 		for _, arch := range architectures {
-			respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=4e3086991b3f452d82eed1f2122aefeb", arch), &tutils.AuthString0)
+			respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=4e3086991b3f452d82eed1f2122aefeb", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			var result PackagesResponse
 			err := json.Unmarshal([]byte(body), &result)
@@ -756,7 +756,7 @@ func TestGetPackages(t *testing.T) {
 			require.Empty(t, result.Data)
 			require.Contains(t, body, "\"data\":[]")
 
-			respStatusCode, body = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?offset=121039&distribution=rhel-8&architecture=%s&search=4e3086991b3f452d82eed1f2122aefeb", arch), &tutils.AuthString0)
+			respStatusCode, body = tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?offset=121039&distribution=rhel-8&architecture=%s&search=4e3086991b3f452d82eed1f2122aefeb", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			err = json.Unmarshal([]byte(body), &result)
 			require.NoError(t, err)
@@ -768,7 +768,7 @@ func TestGetPackages(t *testing.T) {
 
 	t.Run("Search with limit", func(t *testing.T) {
 		for _, arch := range architectures {
-			respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh&limit=1", arch), &tutils.AuthString0)
+			respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh&limit=1", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			var result PackagesResponse
 			err := json.Unmarshal([]byte(body), &result)
@@ -779,7 +779,7 @@ func TestGetPackages(t *testing.T) {
 
 	t.Run("Search with offset", func(t *testing.T) {
 		for _, arch := range architectures {
-			respStatusCode, body := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh&limit=1&offset=1", arch), &tutils.AuthString0)
+			respStatusCode, body := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh&limit=1&offset=1", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			var result PackagesResponse
 			err := json.Unmarshal([]byte(body), &result)
@@ -791,25 +791,25 @@ func TestGetPackages(t *testing.T) {
 
 	t.Run("Search with invalid parameters", func(t *testing.T) {
 		for _, arch := range architectures {
-			respStatusCode, _ := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh&limit=-13", arch), &tutils.AuthString0)
+			respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh&limit=-13", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
-			respStatusCode, _ = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh&limit=13&offset=-2193", arch), &tutils.AuthString0)
+			respStatusCode, _ = tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=rhel-8&architecture=%s&search=ssh&limit=13&offset=-2193", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
-			respStatusCode, _ = tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=none&architecture=%s&search=ssh", arch), &tutils.AuthString0)
+			respStatusCode, _ = tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=none&architecture=%s&search=ssh", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
 		}
 	})
 
 	t.Run("Search restricted distribution", func(t *testing.T) {
 		for _, arch := range architectures {
-			respStatusCode, _ := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=fedora-39&architecture=%s&search=ssh", arch), &tutils.AuthString1)
+			respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=fedora-39&architecture=%s&search=ssh", arch), &tutils.AuthString1)
 			require.Equal(t, http.StatusForbidden, respStatusCode)
 		}
 	})
 
 	t.Run("Search restricted, but allowed distribution", func(t *testing.T) {
 		for _, arch := range architectures {
-			respStatusCode, _ := tutils.GetResponseBody(t, fmt.Sprintf("http://localhost:8086/api/image-builder/v1/packages?distribution=fedora-39&architecture=%s&search=ssh", arch), &tutils.AuthString0)
+			respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/packages?distribution=fedora-39&architecture=%s&search=ssh", arch), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 		}
 	})
@@ -829,7 +829,7 @@ func TestGetDistributions(t *testing.T) {
 	defer tokenSrv.Close()
 
 	t.Run("Access to restricted distributions", func(t *testing.T) {
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/distributions", &tutils.AuthString0)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/distributions", &tutils.AuthString0)
 		require.Equal(t, http.StatusOK, respStatusCode)
 		var result DistributionsResponse
 		err := json.Unmarshal([]byte(body), &result)
@@ -842,7 +842,7 @@ func TestGetDistributions(t *testing.T) {
 	})
 
 	t.Run("No access to restricted distributions except global filter", func(t *testing.T) {
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/distributions", &tutils.AuthString1)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/distributions", &tutils.AuthString1)
 		require.Equal(t, http.StatusOK, respStatusCode)
 		var result DistributionsResponse
 		err := json.Unmarshal([]byte(body), &result)
@@ -873,7 +873,8 @@ func TestGetProfiles(t *testing.T) {
 			Rhel8, Rhel84, Rhel85, Rhel86, Rhel87, Rhel88, Rhel89, Rhel8Nightly,
 		} {
 			respStatusCode, body := tutils.GetResponseBody(t,
-				fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
+				srv.URL+
+					fmt.Sprintf("/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			var result DistributionProfileResponse
 			err := json.Unmarshal([]byte(body), &result)
@@ -904,7 +905,8 @@ func TestGetProfiles(t *testing.T) {
 			Rhel9, Rhel91, Rhel92, Rhel93, Rhel94, Rhel9Nightly, Centos9,
 		} {
 			respStatusCode, body := tutils.GetResponseBody(t,
-				fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
+				srv.URL+
+					fmt.Sprintf("/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			var result DistributionProfileResponse
 			err := json.Unmarshal([]byte(body), &result)
@@ -933,7 +935,8 @@ func TestGetProfiles(t *testing.T) {
 	t.Run("Access profiles on the other distros returns an error", func(t *testing.T) {
 		for _, dist := range []Distributions{Fedora37, Fedora38, Fedora39, Fedora40, Fedora41, Rhel90} {
 			respStatusCode, _ := tutils.GetResponseBody(t,
-				fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
+				srv.URL+
+					fmt.Sprintf("/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
 		}
 	})
@@ -952,7 +955,8 @@ func TestGetCustomizations(t *testing.T) {
 			Rhel8, Rhel84, Rhel85, Rhel86, Rhel87, Rhel88, Rhel8Nightly, Rhel9, Rhel91, Rhel92, Rhel9Nightly, Centos9,
 		} {
 			respStatusCode, body := tutils.GetResponseBody(t,
-				fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
+				srv.URL+
+					fmt.Sprintf("/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			var result DistributionProfileResponse
 			err := json.Unmarshal([]byte(body), &result)
@@ -961,7 +965,8 @@ func TestGetCustomizations(t *testing.T) {
 				// Get the customization from the API
 				var result Customizations
 				respStatusCode, body := tutils.GetResponseBody(t,
-					fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/%s/customizations", dist, profile), &tutils.AuthString0)
+					srv.URL+
+						fmt.Sprintf("/api/image-builder/v1/oscap/%s/%s/customizations", dist, profile), &tutils.AuthString0)
 				require.Equal(t, http.StatusOK, respStatusCode)
 				err := json.Unmarshal([]byte(body), &result)
 				require.NoError(t, err)
@@ -1004,14 +1009,16 @@ func TestGetCustomizations(t *testing.T) {
 	t.Run("Access customizations on a distro that does not have customizations returns an error", func(t *testing.T) {
 		for _, dist := range []Distributions{Rhel8} {
 			respStatusCode, body := tutils.GetResponseBody(t,
-				fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
+				srv.URL+
+					fmt.Sprintf("/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			var result DistributionProfileResponse
 			err := json.Unmarshal([]byte(body), &result)
 			require.NoError(t, err)
 			for _, profile := range result {
 				respStatusCode, _ := tutils.GetResponseBody(t,
-					fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/%s/customizations", Fedora40, profile), &tutils.AuthString0)
+					srv.URL+
+						fmt.Sprintf("/api/image-builder/v1/oscap/%s/%s/customizations", Fedora40, profile), &tutils.AuthString0)
 				require.Equal(t, http.StatusBadRequest, respStatusCode)
 			}
 		}
@@ -1019,13 +1026,15 @@ func TestGetCustomizations(t *testing.T) {
 	t.Run("Access non existing customizations on a distro returns an error", func(t *testing.T) {
 		for _, dist := range []Distributions{Rhel8} {
 			respStatusCode, body := tutils.GetResponseBody(t,
-				fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
+				srv.URL+
+					fmt.Sprintf("/api/image-builder/v1/oscap/%s/profiles", dist), &tutils.AuthString0)
 			require.Equal(t, http.StatusOK, respStatusCode)
 			var result DistributionProfileResponse
 			err := json.Unmarshal([]byte(body), &result)
 			require.NoError(t, err)
 			respStatusCode, _ = tutils.GetResponseBody(t,
-				fmt.Sprintf("http://localhost:8086/api/image-builder/v1/oscap/%s/%s/customizations", dist, "badprofile"), &tutils.AuthString0)
+				srv.URL+
+					fmt.Sprintf("/api/image-builder/v1/oscap/%s/%s/customizations", dist, "badprofile"), &tutils.AuthString0)
 			require.Equal(t, http.StatusBadRequest, respStatusCode)
 		}
 	})

--- a/internal/v1/server_identity_test.go
+++ b/internal/v1/server_identity_test.go
@@ -21,31 +21,31 @@ func TestRedHatIdentity(t *testing.T) {
 	defer tokenSrv.Close()
 
 	t.Run("VerifyIdentityHeaderMissing", func(t *testing.T) {
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", nil)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", nil)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "missing x-rh-identity header")
 	})
 
 	t.Run("Valid authstring", func(t *testing.T) {
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &tutils.AuthString0)
+		respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &tutils.AuthString0)
 		require.Equal(t, http.StatusOK, respStatusCode)
 	})
 
 	t.Run("Valid authstring without entitlements", func(t *testing.T) {
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &tutils.AuthString0WithoutEntitlements)
+		respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &tutils.AuthString0WithoutEntitlements)
 		require.Equal(t, http.StatusOK, respStatusCode)
 	})
 
 	t.Run("BogusAuthString", func(t *testing.T) {
 		auth := "notbase64"
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &auth)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &auth)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "unable to b64 decode x-rh-identity header")
 	})
 
 	t.Run("BogusBase64AuthString", func(t *testing.T) {
 		auth := "dGhpcyBpcyBkZWZpbml0ZWx5IG5vdCBqc29uCg=="
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &auth)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &auth)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "does not contain valid JSON")
 	})
@@ -53,14 +53,14 @@ func TestRedHatIdentity(t *testing.T) {
 	t.Run("EmptyAccountNumber", func(t *testing.T) {
 		// AccoundNumber equals ""
 		auth := tutils.GetCompleteBase64Header("000000")
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &auth)
+		respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &auth)
 		require.Equal(t, http.StatusOK, respStatusCode)
 	})
 
 	t.Run("EmptyOrgID", func(t *testing.T) {
 		// OrgID equals ""
 		auth := tutils.GetCompleteBase64Header("")
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &auth)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &auth)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "invalid or missing org_id")
 	})
@@ -79,31 +79,31 @@ func TestFedoraIdentity(t *testing.T) {
 	defer tokenSrv.Close()
 
 	t.Run("VerifyIdentityHeaderMissing", func(t *testing.T) {
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", nil)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", nil)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "Missing identity header")
 	})
 
 	t.Run("Valid authstring", func(t *testing.T) {
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &tutils.FedAuth)
+		respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &tutils.FedAuth)
 		require.Equal(t, http.StatusOK, respStatusCode)
 	})
 
 	t.Run("Valid authstring without entitlements", func(t *testing.T) {
-		respStatusCode, _ := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &tutils.FedAuth)
+		respStatusCode, _ := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &tutils.FedAuth)
 		require.Equal(t, http.StatusOK, respStatusCode)
 	})
 
 	t.Run("BogusAuthString", func(t *testing.T) {
 		auth := "notbase64"
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &auth)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &auth)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "Identity header does not contain valid JSON")
 	})
 
 	t.Run("BogusBase64AuthString", func(t *testing.T) {
 		auth := "dGhpcyBpcyBkZWZpbml0ZWx5IG5vdCBqc29uCg=="
-		respStatusCode, body := tutils.GetResponseBody(t, "http://localhost:8086/api/image-builder/v1/version", &auth)
+		respStatusCode, body := tutils.GetResponseBody(t, srv.URL+"/api/image-builder/v1/version", &auth)
 		require.Equal(t, http.StatusBadRequest, respStatusCode)
 		require.Contains(t, body, "Identity header does not contain valid JSON")
 	})


### PR DESCRIPTION
tests: tweak tutil to take `addr` and `path` instead of url

This commit avoids the hardcoded URL and uses the addr that the
echo server is using. This makes it easier to run the tests on
a different port.

Mostly auto-generated via `sed` (unfortunately some manual tweaking
was needed because the coding style is not very consistent).

