### PR TITLE
server: use error type ErrServerClosed in test

### DIFF
--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -192,9 +192,7 @@ func startServer(t *testing.T, tscc *testServerClientsConf, conf *ServerConfig) 
 	// execute in parallel b/c .Run() will block execution
 	go func() {
 		err = echoServer.Start("localhost:8086")
-		if err.Error() != "http: Server closed" {
-			require.NoError(t, err)
-		}
+		require.Equal(t, err, http.ErrServerClosed)
 	}()
 
 	// wait until server is ready


### PR DESCRIPTION
Instead of string comparing use the http.ErrServerClosed when checking for echoServer.Start()