### PR TITLE
test: enable codecov to be able to see the updated coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,11 +62,11 @@ jobs:
       - name: Run unit tests
         run: make unit-tests
 
-      # disabled as 'pinging codecov' hangs
-      # see https://github.com/codecov/feedback/issues/354
-      # - name: Send coverage to codecov.io
-      #   run: bash <(curl -s https://codecov.io/bash)
-
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
   speccheck:
     name: "📋 openapi spec check"
     runs-on: ubuntu-latest


### PR DESCRIPTION
this commit enable codecov to be able to see the updated coverage
this issue https://github.com/codecov/feedback/issues/354 was fixed 