### PR TITLE
c10s/el10: support gcp and image-installer img types

### DIFF
--- a/distributions/centos-10/centos-10.json
+++ b/distributions/centos-10/centos-10.json
@@ -8,7 +8,7 @@
     "restricted_access": true
   },
   "x86_64": {
-    "image_types": [ "ami", "aws", "azure", "guest-image", "oci", "openstack", "vsphere", "vsphere-ova", "wsl"],
+    "image_types": [ "ami", "aws", "azure", "gcp", "guest-image", "image-installer", "oci", "openstack", "vsphere", "vsphere-ova", "wsl"],
     "repositories": [{
       "id": "baseos",
       "baseurl": "https://composes.stream.centos.org/stream-10/production/latest-CentOS-Stream/compose/BaseOS/x86_64/os/",
@@ -21,6 +21,18 @@
       "rhsm": false,
       "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQINBFzMWxkBEADHrskpBgN9OphmhRkc7P/YrsAGSvvl7kfu+e9KAaU6f5MeAVyn\nrIoM43syyGkgFyWgjZM8/rur7EMPY2yt+2q/1ZfLVCRn9856JqTIq0XRpDUe4nKQ\n8BlA7wDVZoSDxUZkSuTIyExbDf0cpw89Tcf62Mxmi8jh74vRlPy1PgjWL5494b3X\n5fxDidH4bqPZyxTBqPrUFuo+EfUVEqiGF94Ppq6ZUvrBGOVo1V1+Ifm9CGEK597c\naevcGc1RFlgxIgN84UpuDjPR9/zSndwJ7XsXYvZ6HXcKGagRKsfYDWGPkA5cOL/e\nf+yObOnC43yPUvpggQ4KaNJ6+SMTZOKikM8yciyBwLqwrjo8FlJgkv8Vfag/2UR7\nJINbyqHHoLUhQ2m6HXSwK4YjtwidF9EUkaBZWrrskYR3IRZLXlWqeOi/+ezYOW0m\nvufrkcvsh+TKlVVnuwmEPjJ8mwUSpsLdfPJo1DHsd8FS03SCKPaXFdD7ePfEjiYk\nnHpQaKE01aWVSLUiygn7F7rYemGqV9Vt7tBw5pz0vqSC72a5E3zFzIIuHx6aANry\nGat3aqU3qtBXOrA/dPkX9cWE+UR5wo/A2UdKJZLlGhM2WRJ3ltmGT48V9CeS6N9Y\nm4CKdzvg7EWjlTlFrd/8WJ2KoqOE9leDPeXRPncubJfJ6LLIHyG09h9kKQARAQAB\ntDpDZW50T1MgKENlbnRPUyBPZmZpY2lhbCBTaWduaW5nIEtleSkgPHNlY3VyaXR5\nQGNlbnRvcy5vcmc+iQI3BBMBCAAhAhsDBgsJCAcDAgYVCAIJCgsDFgIBAh4BAheA\nBQJczFsaAAoJEAW1VbOEg8ZdvOgQAMFTGIQokADy5+CynFKjfO7R0VVpJxmYGVr1\nTjnKaHmjxnJaYqoha9ukGgmLu0r+lJ42Kk6nREk1vlxfRAfiWd00Zkm+K3IMq1/D\nE0heC2vX8qqjsLJs3jzq0hgNvo9X0uHDaA4J1BHsD8sE5in/f4SivjbngvFovRGU\n1XLNCgoqpFNcROP18LqKUw8WtqgWdnYBa5i6D5qx+WMRX0NHNwcCMy1lz+sTFxIU\n9mW6cLsMaacPGD8pUXIVli8P9Vlv3jBk1wFIqRgQPW01ph/3bM7pf9hyM9FAfU4X\nAFcyb1oYI4/82EkICUe6jeuZrz67dPeLVAlYrGW4hp/825g0fqJHxPDp25GS4rAa\n4RqyibLzNjSGdXYeLj2NcB/8OqaP+T1hv3JDaqe70QoYa/GIC4rh15NyXVbUP+LG\nV4vUiL7mb9ynzvF5zYHJbcg4R7dOsiZHrMFwy7FZesQaVrXeJlxRcEj65rpm1ZtZ\nmwAE1k2LsRkvLyr9hpZkXnMeOKYIPwpdmBjXNVNVbq7097OxZOYPPos+iZKMWfl4\nUQnMsCVxonZtamdI4qEc3jMkSZPJKgOplGOms5jdY+EdSvsFWEQ0Snd3dChfU7DV\no4Rbcy5klwHrvuZIOLaovhyxuRPhP6gV9+gzpTK/7vrvDlFbbZE6s212mDZ13RWB\nmTfAxz4h\n=agO/\n-----END PGP PUBLIC KEY BLOCK-----\n",
       "check_gpg": true
+    }, {
+      "id": "google-compute-engine",
+      "baseurl": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable",
+      "rhsm": false,
+      "image_type_tags": ["gcp"],
+      "check_gpg": false
+    }, {
+      "id": "google-cloud-sdk",
+      "baseurl": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64",
+      "rhsm": false,
+      "image_type_tags": ["gcp"],
+      "check_gpg": false
     }]
   },
   "aarch64": {

--- a/distributions/rhel-10-nightly/rhel-10-nightly.json
+++ b/distributions/rhel-10-nightly/rhel-10-nightly.json
@@ -12,11 +12,11 @@
     "image_types": ["aws", "azure", "gcp", "guest-image", "image-installer", "openstack", "vsphere", "vsphere-ova"],
     "repositories": [{
       "id": "baseos",
-      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/BaseOS/x86_64/os/",
+      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/compose/BaseOS/x86_64/os/",
       "rhsm": false
     }, {
       "id": "appstream",
-      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/AppStream/x86_64/os/",
+      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/compose/AppStream/x86_64/os/",
       "rhsm": false
     }, {
       "id": "google-compute-engine",
@@ -36,11 +36,11 @@
     "image_types": [ "aws", "azure", "guest-image", "openstack"],
     "repositories": [{
       "id": "baseos",
-      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/BaseOS/aarch64/os/",
+      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/compose/BaseOS/aarch64/os/",
       "rhsm": false
     }, {
       "id": "appstream",
-      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/AppStream/aarch64/os/",
+      "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/compose/AppStream/aarch64/os/",
       "rhsm": false
     }]
   }

--- a/distributions/rhel-10-nightly/rhel-10-nightly.json
+++ b/distributions/rhel-10-nightly/rhel-10-nightly.json
@@ -9,7 +9,7 @@
     "restricted_access": true
   },
   "x86_64": {
-    "image_types": ["aws", "azure", "guest-image", "openstack", "vsphere", "vsphere-ova"],
+    "image_types": ["aws", "azure", "gcp", "guest-image", "image-installer", "openstack", "vsphere", "vsphere-ova"],
     "repositories": [{
       "id": "baseos",
       "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/BaseOS/x86_64/os/",
@@ -18,6 +18,18 @@
       "id": "appstream",
       "baseurl": "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10/compose/AppStream/x86_64/os/",
       "rhsm": false
+    }, {
+      "id": "google-compute-engine",
+      "baseurl": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable",
+      "rhsm": false,
+      "image_type_tags": ["gcp"],
+      "check_gpg": false
+    }, {
+      "id": "google-cloud-sdk",
+      "baseurl": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64",
+      "rhsm": false,
+      "image_type_tags": ["gcp"],
+      "check_gpg": false
     }]
   },
   "aarch64": {


### PR DESCRIPTION
These were added by [1], so let's enable them in the service.

There are no GCP guest tools repos for c10s / el10 yet, so use those from el9 for now.

Also update the RHEL-10-nightly repos to non-Beta URLs, since those already contain composes.

[1] https://github.com/osbuild/osbuild-composer/pull/4314