### PR TITLE
Makefile: pull new ubi-container always

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ check-api-spec:
 
 .PHONY: ubi-container
 ubi-container:
-	podman build -t osbuild/image-builder -f distribution/Dockerfile-ubi .
+	podman build --pull=always -t osbuild/image-builder -f distribution/Dockerfile-ubi .
 
 .PHONY: generate-openscap-blueprints
 generate-openscap-blueprints:


### PR DESCRIPTION
in my setup it took me a while to figure out that I had an old golang version as my cached container was old.
It should not hurt to always check if it's new