### PR TITLE
codecov.yml: change codecov to avoid new comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,6 @@ coverage:
 codecov:
   require_ci_to_pass: no
 comment:
-    behavior: new
-    layout: "condensed_header, files, condensed_footer"
+    layout: "condensed_header, files"
     hide_project_coverage: TRUE
 


### PR DESCRIPTION
Generating a new comment seems fine, but I guess generates too many E-Mail which might get annoying.

So we'll try this behavior and the footer also seems not necessary
