### PR TITLE
internal/v1/server_test.go: cancel tests on failed test server

### DIFF
--- a/internal/v1/server_test.go
+++ b/internal/v1/server_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -207,7 +208,9 @@ func startServer(t *testing.T, tscc *testServerClientsConf, conf *ServerConfig) 
 	URL := "http://" + addr
 	go func() {
 		err = echoServer.Start(addr)
-		require.Equal(t, err, http.ErrServerClosed)
+		if !errors.Is(err, http.ErrServerClosed) {
+			panic(fmt.Errorf("starting test server failed %w", err))
+		}
 	}()
 
 	// wait until server is ready


### PR DESCRIPTION
The current implementation just creates a "failed test" entry (e.g. if the port is in use) and continues testing

I had the problem again of some other debug service running and the error (of port in use) was lost in console output