### PR TITLE
clients/compliance: use minor version instead of tailoring id

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -690,8 +690,6 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				return nil, echo.NewHTTPError(http.StatusForbidden, fmt.Sprintf("User is not authorized to get compliance data for given policy ID (%s)", policy.PolicyId.String()))
 			} else if errors.Is(compliance.ErrorMajorVersion, err) {
 				return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) does not support requested major version %d", policy.PolicyId.String(), major))
-			} else if errors.Is(compliance.ErrorMinorVersion, err) {
-				return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) does not support requested minor version %d", policy.PolicyId.String(), minor))
 			} else if errors.Is(compliance.ErrorNotFound, err) {
 				return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Compliance policy (%s) or its tailorings weren't found", policy.PolicyId.String()))
 			} else if err != nil {

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -1302,31 +1302,7 @@ func TestComposeCustomizations(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			err := json.NewEncoder(w).Encode(policyData)
 			require.NoError(t, err)
-		case fmt.Sprintf("/policies/%s/tailorings", policyID):
-			tailoring := struct {
-				Data []struct {
-					ID             string `json:"id"`
-					OSMajorVersion int    `json:"os_major_version"`
-					OSMinorVersion int    `json:"os_minor_version"`
-				} `json:"data"`
-			}{
-				Data: []struct {
-					ID             string `json:"id"`
-					OSMajorVersion int    `json:"os_major_version"`
-					OSMinorVersion int    `json:"os_minor_version"`
-				}{
-					{
-						ID:             "tailoring-id",
-						OSMajorVersion: 8,
-						OSMinorVersion: 10,
-					},
-				},
-			}
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			err := json.NewEncoder(w).Encode(tailoring)
-			require.NoError(t, err)
-		case fmt.Sprintf("/policies/%s/tailorings/tailoring-id/tailoring_file.json", policyID):
+		case fmt.Sprintf("/policies/%s/tailorings/10/tailoring_file.json", policyID):
 			tailoringData := "{ \"data\": \"some-tailoring-data\"}"
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(tailoringData))


### PR DESCRIPTION
There's only a single tailoring item per rhel minor version per policy, and
    you can index the tailorings by id or by rhel minor version.

---

The tailoring id was hardcoded and the test didn't catch it because it was the same id as the hardcoded one in the test :facepalm: 