### PR TITLE
v1: create directory before inserting openscap tailoring data

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -703,11 +703,15 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 					Filepath:  "/etc/osbuild/openscap-tailoring.json",
 				},
 			}
+			res.Directories = &[]composer.Directory{
+				{
+					Path: "/etc/osbuild",
+				},
+			}
 			res.Files = &[]composer.File{
 				{
-					Path:          "/etc/osbuild/openscap-tailoring.json",
-					EnsureParents: common.ToPtr(true),
-					Data:          common.ToPtr(string(pdata.TailoringData)),
+					Path: "/etc/osbuild/openscap-tailoring.json",
+					Data: common.ToPtr(string(pdata.TailoringData)),
 				},
 			}
 		}
@@ -826,7 +830,12 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 				User:          user,
 			})
 		}
-		res.Directories = &dirs
+		// OpenSCAP tailoring creates a directory
+		if res.Directories != nil && len(*res.Directories) > 0 {
+			res.Directories = common.ToPtr(append(*res.Directories, dirs...))
+		} else {
+			res.Directories = &dirs
+		}
 	}
 
 	if cust.Files != nil {

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2497,11 +2497,15 @@ func TestComposeCustomizations(t *testing.T) {
 							Filepath:  "/etc/osbuild/openscap-tailoring.json",
 						},
 					},
+					Directories: &[]composer.Directory{
+						{
+							Path: "/etc/osbuild",
+						},
+					},
 					Files: &[]composer.File{
 						{
-							Path:          "/etc/osbuild/openscap-tailoring.json",
-							EnsureParents: common.ToPtr(true),
-							Data:          common.ToPtr("{ \"data\": \"some-tailoring-data\"}"),
+							Path: "/etc/osbuild/openscap-tailoring.json",
+							Data: common.ToPtr("{ \"data\": \"some-tailoring-data\"}"),
 						},
 					},
 				},


### PR DESCRIPTION
EnsureParents doesn't actually work on files, so create the directory first.

---

Adding the directory customisation in manually makes it work!