### PR TITLE
v1: add policyID to compose request to composer

### DIFF
--- a/internal/clients/composer/openapi.v2.gen.go
+++ b/internal/clients/composer/openapi.v2.gen.go
@@ -315,8 +315,12 @@ type BlueprintFirewall struct {
 type BlueprintOpenSCAP struct {
 	Datastream    *string                `json:"datastream,omitempty"`
 	JsonTailoring *OpenSCAPJSONTailoring `json:"json_tailoring,omitempty"`
-	ProfileId     string                 `json:"profile_id"`
-	Tailoring     *OpenSCAPTailoring     `json:"tailoring,omitempty"`
+
+	// PolicyId Puts a specified policy ID in the RHSM facts, so that any instances registered to
+	// insights will be automatically connected to the compliance policy in the console.
+	PolicyId  *openapi_types.UUID `json:"policy_id,omitempty"`
+	ProfileId string              `json:"profile_id"`
+	Tailoring *OpenSCAPTailoring  `json:"tailoring,omitempty"`
 }
 
 // BlueprintRepository defines model for BlueprintRepository.
@@ -941,8 +945,12 @@ type ObjectReference struct {
 // OpenSCAP defines model for OpenSCAP.
 type OpenSCAP struct {
 	JsonTailoring *OpenSCAPJSONTailoring `json:"json_tailoring,omitempty"`
-	ProfileId     string                 `json:"profile_id"`
-	Tailoring     *OpenSCAPTailoring     `json:"tailoring,omitempty"`
+
+	// PolicyId Puts a specified policy ID in the RHSM facts, so that any instances registered to
+	// insights will be automatically connected to the compliance policy in the console.
+	PolicyId  *openapi_types.UUID `json:"policy_id,omitempty"`
+	ProfileId string              `json:"profile_id"`
+	Tailoring *OpenSCAPTailoring  `json:"tailoring,omitempty"`
 }
 
 // OpenSCAPJSONTailoring defines model for OpenSCAPJSONTailoring.

--- a/internal/clients/composer/openapi.v2.yml
+++ b/internal/clients/composer/openapi.v2.yml
@@ -975,6 +975,12 @@ components:
       required:
         - profile_id
       properties:
+        policy_id:
+          type: string
+          format: uuid
+          description: |
+            Puts a specified policy ID in the RHSM facts, so that any instances registered to
+            insights will be automatically connected to the compliance policy in the console.
         profile_id:
           type: string
         tailoring:
@@ -986,6 +992,12 @@ components:
       required:
         - profile_id
       properties:
+        policy_id:
+          type: string
+          format: uuid
+          description: |
+            Puts a specified policy ID in the RHSM facts, so that any instances registered to
+            insights will be automatically connected to the compliance policy in the console.
         profile_id:
           type: string
         datastream:

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -698,6 +698,7 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 
 			res.Openscap = &composer.OpenSCAP{
 				ProfileId: pdata.ProfileID,
+				PolicyId:  &policy.PolicyId,
 				JsonTailoring: &composer.OpenSCAPJSONTailoring{
 					ProfileId: pdata.ProfileID,
 					Filepath:  "/etc/osbuild/openscap-tailoring.json",

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -2492,6 +2492,7 @@ func TestComposeCustomizations(t *testing.T) {
 				Customizations: &composer.Customizations{
 					Openscap: &composer.OpenSCAP{
 						ProfileId: "openscap-ref-id",
+						PolicyId:  &policyID,
 						JsonTailoring: &composer.OpenSCAPJSONTailoring{
 							ProfileId: "openscap-ref-id",
 							Filepath:  "/etc/osbuild/openscap-tailoring.json",


### PR DESCRIPTION
The policy ID will be added to the RHSM facts, allowing the compliance service to tie instances to the specified compliance policy.