### PR TITLE
floorplan: Export files customization

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -196,6 +196,8 @@ objects:
           c.request->'customizations'->'filesystem' as filesystem,
           c.request->'customizations'->'payload_repositories' as payload_repositories,
           c.request->'customizations'->'openscap' as openscap,
+          c.request->'customizations'->'files' as files,
+          c.request->'customizations'->'services' as services,
           jsonb_array_length(c.request->'customizations'->'users') as num_users
         from
           composes c


### PR DESCRIPTION
This should allow us to track the usage of the first boot script feature.

I looked into the json request and what we're interested in the most is probably the path. While we can almost rule out that a lot of customers are using the files customization (because overall API usage is low) and therefore our data wouldn't be skewed too much, it'd be great to limit the results we account for to `/etc/systemd/system/custom-first-boot.service`

Or would it be more efficient/reliable to use the services customization to check for `"custom-first-boot"` in `enabled`?