### PR TITLE
v1/handlers: Return 404 correctly when Blueprint not found (HMS-4243)

### DIFF
--- a/internal/v1/handler_blueprints.go
+++ b/internal/v1/handler_blueprints.go
@@ -339,6 +339,9 @@ func (h *Handlers) UpdateBlueprint(ctx echo.Context, blueprintId uuid.UUID) erro
 	if blueprintRequest.Customizations.Users != nil {
 		be, err := h.server.db.GetBlueprint(ctx.Request().Context(), blueprintId, userID.OrgID(), nil)
 		if err != nil {
+			if errors.Is(err, db.BlueprintNotFoundError) {
+				return echo.NewHTTPError(http.StatusNotFound, err)
+			}
 			return err
 		}
 		eb, err := BlueprintFromEntry(be)
@@ -406,6 +409,9 @@ func (h *Handlers) ComposeBlueprint(ctx echo.Context, id openapi_types.UUID) err
 
 	blueprintEntry, err := h.server.db.GetBlueprint(ctx.Request().Context(), id, userID.OrgID(), nil)
 	if err != nil {
+		if errors.Is(err, db.BlueprintNotFoundError) {
+			return echo.NewHTTPError(http.StatusNotFound, err)
+		}
 		return err
 	}
 	blueprint, err := BlueprintFromEntryWithRedactedPasswords(blueprintEntry)

--- a/internal/v1/handler_blueprints_test.go
+++ b/internal/v1/handler_blueprints_test.go
@@ -499,9 +499,14 @@ func TestHandlers_UpdateBlueprint(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Invalid blueprint name", jsonResp.Errors[0].Title)
 
+	// Test non-existing blueprint
 	body["name"] = "Changing to correct body"
 	respStatusCodeNotFound, _ := tutils.PutResponseBody(t, db_srv.URL+fmt.Sprintf("/api/image-builder/v1/blueprints/%s", uuid.New()), body)
 	require.Equal(t, http.StatusNotFound, respStatusCodeNotFound)
+
+	body["customizations"] = map[string]interface{}{"users": []map[string]interface{}{{"name": "test", "password": "test"}}}
+	statusCode, _ = tutils.PutResponseBody(t, db_srv.URL+fmt.Sprintf("/api/image-builder/v1/blueprints/%s", uuid.New()), body)
+	require.Equal(t, http.StatusNotFound, statusCode)
 }
 
 func TestHandlers_ComposeBlueprint(t *testing.T) {
@@ -618,6 +623,10 @@ func TestHandlers_ComposeBlueprint(t *testing.T) {
 			}
 		})
 	}
+	t.Run("non-existing blueprint", func(t *testing.T) {
+		respStatusCode, _ := tutils.PostResponseBody(t, srv.URL+fmt.Sprintf("/api/image-builder/v1/blueprints/%s/compose", uuid.New()), ComposeBlueprintJSONBody{})
+		require.Equal(t, http.StatusNotFound, respStatusCode)
+	})
 }
 
 func TestHandlers_GetBlueprintComposes(t *testing.T) {


### PR DESCRIPTION
Return correct status on non-existent blueprint for blueprint/<id>/compose endpoint.