### PR TITLE
build: pin oapi-gen until toolbox gets 1.21.13

### DIFF
--- a/internal/clients/composer/package.go
+++ b/internal/clients/composer/package.go
@@ -1,4 +1,4 @@
-//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yaml openapi.v2.yml
+//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.3.0 --config client.cfg.yaml openapi.v2.yml
 
 // Generated OpenAPI clients for the Composer service.
 package composer

--- a/internal/clients/content_sources/package.go
+++ b/internal/clients/content_sources/package.go
@@ -1,4 +1,4 @@
-//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yaml content-sources.v1.json
+//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.3.0 --config client.cfg.yaml content-sources.v1.json
 
 // Generated OpenAPI clients for the Content Sources service.
 package content_sources

--- a/internal/clients/provisioning/package.go
+++ b/internal/clients/provisioning/package.go
@@ -1,4 +1,4 @@
-//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yml provisioning.v1.yml
+//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.3.0 --config client.cfg.yml provisioning.v1.yml
 
 // Generated OpenAPI clients for the Provisioning service.
 package provisioning

--- a/internal/clients/recommendations/package.go
+++ b/internal/clients/recommendations/package.go
@@ -1,2 +1,2 @@
-//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config client.cfg.yml recommendations.v3.json
+//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.3.0 --config client.cfg.yml recommendations.v3.json
 package recommendations

--- a/internal/v1/server.go
+++ b/internal/v1/server.go
@@ -1,4 +1,4 @@
-//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config server.cfg.yaml api.yaml
+//go:generate go run -mod=mod github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.3.0 --config server.cfg.yaml api.yaml
 package v1
 
 import (

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -3,6 +3,7 @@ set -eux
 
 GO_VERSION=1.21.9
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
+OAPI_VERSION=2.3.0
 
 # this is the official way to get a different version of golang
 # see https://go.dev/doc/manage-install
@@ -12,7 +13,8 @@ $GO_BINARY download
 # Ensure dev tools are installed
 which goimports || $GO_BINARY install golang.org/x/tools/cmd/goimports@latest
 
-# Ensure that all code has been regenerated from its sources
+# Ensure that all code has been regenerated from its sources with the pinned oapi version
+git grep -l "go:generate.*github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen" | grep -v prepare-source.sh | xargs sed -i "s|github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen[v@.0-9]*|github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v$OAPI_VERSION|g"
 $GO_BINARY generate -mod=mod ./...
 
 # ... the code is formatted correctly, ...


### PR DESCRIPTION
Unsure how to implement pinning effectively for vendored projects. What I usually do is manually `go get` those libraries in a prepare script or Makefile.