### PR TITLE
v1: empty recommendation is warning now

### DIFF
--- a/internal/v1/handler_recommend_package.go
+++ b/internal/v1/handler_recommend_package.go
@@ -47,7 +47,7 @@ func (h *Handlers) handleRecommendationsResponse(ctx echo.Context, uploadPackage
 	}
 
 	if len(responsePackages.Packages) == 0 {
-		ctx.Logger().Errorf("User should define packages")
+		ctx.Logger().Warn("User should define packages")
 		return RecommendationsResponse{}, nil
 	}
 


### PR DESCRIPTION
This error is cluttering glitchtip there are over 2k events and counting. This does not need to be an error:

<img width="1419" alt="obrazek" src="https://github.com/user-attachments/assets/89e61733-c9cb-4f59-ab39-fb52d5e432e4">
