### PR TITLE
v1: fix yum configs of snapshot repositories (HMS-4784)

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -292,7 +292,8 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 		// Don't enable custom repositories, as they require further setup to be useable.
 		customRepo := composer.CustomRepository{
 			Id:      *snap.RepositoryUuid,
-			Baseurl: &[]string{h.server.csReposURL.JoinPath(*snap.Match.RepositoryPath).String()},
+			Name:    snap.Match.RepositoryName,
+			Baseurl: &[]string{*snap.Match.Url},
 			Enabled: common.ToPtr(false),
 		}
 		if repo.GpgKey != nil && *repo.GpgKey != "" {

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -893,6 +893,8 @@ func TestComposeWithSnapshots(t *testing.T) {
 							Match: &content_sources.ApiSnapshotResponse{
 								CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
 								RepositoryPath: common.ToPtr("/snappy/baseos"),
+								Url:            common.ToPtr("http://snappy-url/snappy/baseos"),
+								RepositoryName: common.ToPtr("baseos"),
 							},
 							RepositoryUuid: common.ToPtr(repoBaseId.String()),
 						},
@@ -901,6 +903,8 @@ func TestComposeWithSnapshots(t *testing.T) {
 							Match: &content_sources.ApiSnapshotResponse{
 								CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
 								RepositoryPath: common.ToPtr("/snappy/appstream"),
+								Url:            common.ToPtr("http://snappy-url/snappy/appstream"),
+								RepositoryName: common.ToPtr("appstream"),
 							},
 							RepositoryUuid: common.ToPtr(repoAppstrId.String()),
 						},
@@ -916,6 +920,8 @@ func TestComposeWithSnapshots(t *testing.T) {
 							Match: &content_sources.ApiSnapshotResponse{
 								CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
 								RepositoryPath: common.ToPtr("/snappy/payload"),
+								Url:            common.ToPtr("http://snappy-url/snappy/payload"),
+								RepositoryName: common.ToPtr("payload"),
 							},
 							RepositoryUuid: common.ToPtr(repoPayloadId.String()),
 						},
@@ -934,6 +940,8 @@ func TestComposeWithSnapshots(t *testing.T) {
 							Match: &content_sources.ApiSnapshotResponse{
 								CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
 								RepositoryPath: common.ToPtr("/snappy/payload"),
+								Url:            common.ToPtr("http://snappy-url/snappy/payload"),
+								RepositoryName: common.ToPtr("payload"),
 							},
 							RepositoryUuid: common.ToPtr(repoPayloadId.String()),
 						},
@@ -942,6 +950,8 @@ func TestComposeWithSnapshots(t *testing.T) {
 							Match: &content_sources.ApiSnapshotResponse{
 								CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
 								RepositoryPath: common.ToPtr("/snappy/payload2"),
+								Url:            common.ToPtr("http://snappy-url/snappy/payload2"),
+								RepositoryName: common.ToPtr("payload2"),
 							},
 							RepositoryUuid: common.ToPtr(repoPayloadId2.String()),
 						},
@@ -1100,14 +1110,16 @@ func TestComposeWithSnapshots(t *testing.T) {
 					},
 					CustomRepositories: &[]composer.CustomRepository{
 						{
-							Baseurl:  &[]string{"https://content-sources.org/snappy/payload"},
+							Baseurl:  &[]string{"http://snappy-url/snappy/payload"},
+							Name:     common.ToPtr("payload"),
 							CheckGpg: common.ToPtr(true),
 							Enabled:  common.ToPtr(false),
 							Gpgkey:   &[]string{"some-gpg-key"},
 							Id:       repoPayloadId.String(),
 						},
 						{
-							Baseurl: &[]string{"https://content-sources.org/snappy/payload2"},
+							Baseurl: &[]string{"http://snappy-url/snappy/payload2"},
+							Name:    common.ToPtr("payload2"),
 							Enabled: common.ToPtr(false),
 							Id:      repoPayloadId2.String(),
 						},
@@ -1200,7 +1212,8 @@ func TestComposeWithSnapshots(t *testing.T) {
 					},
 					CustomRepositories: &[]composer.CustomRepository{
 						{
-							Baseurl:  &[]string{"https://content-sources.org/snappy/payload"},
+							Baseurl:  &[]string{"http://snappy-url/snappy/payload"},
+							Name:     common.ToPtr("payload"),
 							CheckGpg: common.ToPtr(true),
 							Enabled:  common.ToPtr(false),
 							Gpgkey:   &[]string{"some-gpg-key"},


### PR DESCRIPTION
Corrects the name to match the repo name in the cs service, and the URL to point to the cert.console endpoint rather than the internal one.