### PR TITLE
pr_check: don't remove resources for notifications

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -17,7 +17,7 @@ export EXTRA_DEPLOY_ARGS="sources unleash-proxy"
 export REF_ENV="insights-stage"
 export RESERVE_DURATION="2h"
 export DEPLOY_TIMEOUT="1200"
-export COMPONENTS_W_RESOURCES="compliance"
+export COMPONENTS_W_RESOURCES="compliance notifications-backend notifications-engine"
 
 # Install bonfire repo/initialize
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bootstrap.sh


### PR DESCRIPTION
They probably set their limits wrong for ephemeral so don't strip them otherwise the deployment fails.