### PR TITLE
v1: expose groups in user customization (HMS-4901)

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -959,7 +959,10 @@ type UploadTypes string
 // On update empty string can be used to remove password or ssh_key,
 // but at least one of them still must be present.
 type User struct {
-	Name string `json:"name"`
+	// Groups List of groups to add the user to. The 'wheel' group should be added explicitly, as the
+	// default value is empty.
+	Groups *[]string `json:"groups,omitempty"`
+	Name   string    `json:"name"`
 
 	// Password Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
 	// The password is never returned in the response.

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1905,6 +1905,14 @@ components:
         name:
           type: string
           example: "user1"
+        groups:
+          type: array
+          items:
+            type: string
+          description: |
+            List of groups to add the user to. The 'wheel' group should be added explicitly, as the
+            default value is empty.
+          example: ['wheel']
         ssh_key:
           type: string
           example: "ssh-rsa AAAAB3NzaC1"

--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -751,13 +751,12 @@ func (h *Handlers) buildCustomizations(ctx echo.Context, cr *ComposeRequest, d *
 	if cust.Users != nil {
 		var users []composer.User
 		for _, u := range *cust.Users {
-			groups := &[]string{"wheel"}
 			u.RedactPassword()
 			users = append(users, composer.User{
 				Name:     u.Name,
 				Key:      u.SshKey,
 				Password: u.Password,
-				Groups:   groups,
+				Groups:   u.Groups,
 			})
 		}
 		res.Users = &users


### PR DESCRIPTION
When adding a user, immediately add it to the specified groups.


---

It should be fine to drop the default as the edge-api always adds the groups already
https://github.com/RedHatInsights/edge-api/blob/622244f04989159709332e67788c04296989e431/pkg/clients/imagebuilder/client.go#L353-L358