### PR TITLE
Makefile: implement running DB tests locally

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,6 @@ jobs:
           PGPORT: 5432
         run: |
           make dev-prerequisites
-          ./tools/dbtest-run-migrations.sh
           ./tools/dbtest-entrypoint.sh
 
   kube-linter:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,10 +123,9 @@ jobs:
           PGHOST: localhost
           PGPORT: 5432
         run: |
-          go install github.com/jackc/tern@latest
-          tern migrate -m "$TERN_MIGRATIONS_DIR"
-          make image-builder-db-test
-          ./image-builder-db-test
+          make dev-prerequisites
+          ./tools/dbtest-run-migrations.sh
+          ./tools/dbtest-entrypoint.sh
 
   kube-linter:
     name: "🎀 kube-linter"

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ db-tests: dev-prerequisites
 	    PGHOST=localhost \
 	    PGPORT=$$($(CONTAINER_EXECUTABLE) inspect -f '{{ (index .NetworkSettings.Ports "5432/tcp" 0).HostPort }}' image-builder-test-db) \
 	    TERN_MIGRATIONS_DIR=internal/db/migrations-tern \
-	    sh -c './tools/dbtest-run-migrations.sh ; ./tools/dbtest-entrypoint.sh'
+	    ./tools/dbtest-entrypoint.sh
 	# we'll leave the image-builder-test-db container running
 	# for easier inspection is something fails
 	@echo "The database is available for inspection at"

--- a/tools/dbtest-entrypoint.sh
+++ b/tools/dbtest-entrypoint.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+# compile and execute instead of a plain
+# "go test", to have the correct working directory
+
 go test -c -tags=integration -o image-builder-db-test ./cmd/image-builder-db-test/
 ./image-builder-db-test

--- a/tools/dbtest-entrypoint.sh
+++ b/tools/dbtest-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+go test -c -tags=integration -o image-builder-db-test ./cmd/image-builder-db-test/
+./image-builder-db-test

--- a/tools/dbtest-run-migrations.sh
+++ b/tools/dbtest-run-migrations.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-TERN_MIGRATIONS_DIR=${TERN_MIGRATIONS_DIR:-internal/db/migrations-tern}
-
-# make path absolute to find migrations for sure
-TERN_MIGRATIONS_DIR=$(realpath "$TERN_MIGRATIONS_DIR" --relative-base="$(dirname "$0")")
-
-"$(go env GOPATH)"/bin/tern migrate -m "$TERN_MIGRATIONS_DIR"

--- a/tools/dbtest-run-migrations.sh
+++ b/tools/dbtest-run-migrations.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+TERN_MIGRATIONS_DIR=${TERN_MIGRATIONS_DIR:-internal/db/migrations-tern}
+
+# make path absolute to find migrations for sure
+TERN_MIGRATIONS_DIR=$(realpath "$TERN_MIGRATIONS_DIR" --relative-base="$(dirname "$0")")
+
+"$(go env GOPATH)"/bin/tern migrate -m "$TERN_MIGRATIONS_DIR"


### PR DESCRIPTION
In the endeavor to implement pruning the customer data after two years (see https://issues.redhat.com/browse/HMS-4244 )
We first implement running the DB test locally by spinning up a container with postgres.
This is as close as possible to the implementation in the github action and enables to develop more DB tests and execute them.

Also changed here: `image-builder-db-test` is not compiled and run, but just executed as test, as we don't really need the binary