### PR TITLE
templates/image-builder: stop using konflux images

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -235,7 +235,7 @@ objects:
 
 parameters:
   - name: IMAGE
-    value: quay.io/redhat-services-prod/insights-management-tenant/insights-image-builder/image-builder-backend
+    value: quay.io/cloudservices/image-builder
     required: true
   - name: IMAGE_TAG
     required: true


### PR DESCRIPTION
Konflux is too unreliable at this stage.