### PR TITLE
internal/oauth2/lazy_token: avoid printing the token to the logs

### DIFF
--- a/internal/oauth2/lazy_token.go
+++ b/internal/oauth2/lazy_token.go
@@ -52,9 +52,9 @@ func (lt *LazyToken) acquireNewToken(ctx context.Context, forceRefresh bool) (st
 		lt.AccessToken = tokenRes.AccessToken
 		lt.Expiration = time.Now().Add(time.Duration(tokenRes.ExpiresIn) * time.Second)
 
-		logrus.WithContext(ctx).Infof("Acquired new token %s with expiration at: %s", lt.AccessToken, lt.Expiration)
+		logrus.WithContext(ctx).Infof("Acquired new token with expiration at: %s", lt.Expiration)
 	} else {
-		logrus.WithContext(ctx).Infof("AccessToken reused: %s (expires at %s)", lt.AccessToken, lt.Expiration)
+		logrus.WithContext(ctx).Infof("AccessToken reused, which expires at %s", lt.Expiration)
 	}
 
 	return lt.AccessToken, nil

--- a/vendor/github.com/sirupsen/logrus/hooks/test/test.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/test/test.go
@@ -1,0 +1,91 @@
+// The Test package is used for testing logrus.
+// It provides a simple hooks which register logged messages.
+package test
+
+import (
+	"io/ioutil"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Hook is a hook designed for dealing with logs in test scenarios.
+type Hook struct {
+	// Entries is an array of all entries that have been received by this hook.
+	// For safe access, use the AllEntries() method, rather than reading this
+	// value directly.
+	Entries []logrus.Entry
+	mu      sync.RWMutex
+}
+
+// NewGlobal installs a test hook for the global logger.
+func NewGlobal() *Hook {
+
+	hook := new(Hook)
+	logrus.AddHook(hook)
+
+	return hook
+
+}
+
+// NewLocal installs a test hook for a given local logger.
+func NewLocal(logger *logrus.Logger) *Hook {
+
+	hook := new(Hook)
+	logger.AddHook(hook)
+
+	return hook
+
+}
+
+// NewNullLogger creates a discarding logger and installs the test hook.
+func NewNullLogger() (*logrus.Logger, *Hook) {
+
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	return logger, NewLocal(logger)
+
+}
+
+func (t *Hook) Fire(e *logrus.Entry) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = append(t.Entries, *e)
+	return nil
+}
+
+func (t *Hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// LastEntry returns the last entry that was logged or nil.
+func (t *Hook) LastEntry() *logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	i := len(t.Entries) - 1
+	if i < 0 {
+		return nil
+	}
+	return &t.Entries[i]
+}
+
+// AllEntries returns all entries that were logged.
+func (t *Hook) AllEntries() []*logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	// Make a copy so the returned value won't race with future log requests
+	entries := make([]*logrus.Entry, len(t.Entries))
+	for i := 0; i < len(t.Entries); i++ {
+		// Make a copy, for safety
+		entries[i] = &t.Entries[i]
+	}
+	return entries
+}
+
+// Reset removes all Entries from this test hook.
+func (t *Hook) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = make([]logrus.Entry, 0)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,6 +235,7 @@ github.com/redhatinsights/platform-go-middlewares/logging/cloudwatch
 # github.com/sirupsen/logrus v1.9.3
 ## explicit; go 1.13
 github.com/sirupsen/logrus
+github.com/sirupsen/logrus/hooks/test
 # github.com/stretchr/objx v0.5.2
 ## explicit; go 1.20
 github.com/stretchr/objx


### PR DESCRIPTION
Avoid printing the token to the logs