### PR TITLE
image-builder-maintenance: fix typo in variable name

### DIFF
--- a/cmd/image-builder-maintenance/config.go
+++ b/cmd/image-builder-maintenance/config.go
@@ -9,15 +9,15 @@ import (
 
 // Do not write this config to logs or stdout, it contains secrets!
 type Config struct {
-	DryRun                bool   `env:"DRY_RUN"`
-	EnableDBMaintenance   bool   `env:"ENABLE_DB_MAINTENANCE"`
-	ClonesRetentionMonths int    `env:"DB_CLONES_RETENTION_MONTHS"`
-	PGHost                string `env:"PGHOST"`
-	PGPort                string `env:"PGPORT"`
-	PGDatabase            string `env:"PGDATABASE"`
-	PGUser                string `env:"PGUSER"`
-	PGPassword            string `env:"PGPASSWORD"`
-	PGSSLMode             string `env:"PGSSLMODE"`
+	DryRun                  bool   `env:"DRY_RUN"`
+	EnableDBMaintenance     bool   `env:"ENABLE_DB_MAINTENANCE"`
+	ComposesRetentionMonths int    `env:"DB_COMPOSES_RETENTION_MONTHS"`
+	PGHost                  string `env:"PGHOST"`
+	PGPort                  string `env:"PGPORT"`
+	PGDatabase              string `env:"PGDATABASE"`
+	PGUser                  string `env:"PGUSER"`
+	PGPassword              string `env:"PGPASSWORD"`
+	PGSSLMode               string `env:"PGSSLMODE"`
 }
 
 // *string means the value is not required

--- a/cmd/image-builder-maintenance/db.go
+++ b/cmd/image-builder-maintenance/db.go
@@ -140,7 +140,7 @@ func (d *maintenanceDB) LogVacuumStats(ctx context.Context) (int64, error) {
 
 }
 
-func DBCleanup(ctx context.Context, dbURL string, dryRun bool, ClonesRetentionMonths int) error {
+func DBCleanup(ctx context.Context, dbURL string, dryRun bool, ComposesRetentionMonths int) error {
 	db, err := newDB(ctx, dbURL)
 	if err != nil {
 		return err
@@ -154,7 +154,7 @@ func DBCleanup(ctx context.Context, dbURL string, dryRun bool, ClonesRetentionMo
 	var rowsClones int64
 	var rows int64
 
-	emailRetentionDate := time.Now().AddDate(0, ClonesRetentionMonths*-1, 0)
+	emailRetentionDate := time.Now().AddDate(0, ComposesRetentionMonths*-1, 0)
 
 	for {
 		select {

--- a/cmd/image-builder-maintenance/db_test.go
+++ b/cmd/image-builder-maintenance/db_test.go
@@ -34,10 +34,10 @@ func testExpireCompose(ctx context.Context, t *testing.T) {
 	d, err := newDB(ctx, connStr)
 	require.NoError(t, err)
 
-	dbClonesRetentionMonths := 5
+	dbComposesRetentionMonths := 5
 
-	alreadyExpiredTime := time.Now().AddDate(0, (dbClonesRetentionMonths+1)*-1, 0)
-	emailRetentionDate := time.Now().AddDate(0, dbClonesRetentionMonths*-1, 0)
+	alreadyExpiredTime := time.Now().AddDate(0, (dbComposesRetentionMonths+1)*-1, 0)
+	emailRetentionDate := time.Now().AddDate(0, dbComposesRetentionMonths*-1, 0)
 
 	composeId := uuid.New()
 	insert := "INSERT INTO composes(job_id, request, created_at, account_number, org_id) VALUES ($1, $2, $3, $4, $5)"
@@ -83,11 +83,11 @@ func testExpireByCallingDBCleanup(ctx context.Context, t *testing.T) {
 	internalDB, err := db.InitDBConnectionPool(ctx, connStr)
 	require.NoError(t, err)
 
-	dbClonesRetentionMonths := 5
+	dbComposesRetentionMonths := 5
 
 	notYetExpiredTime := time.Now()
-	alreadyExpiredTime := time.Now().AddDate(0, (dbClonesRetentionMonths+1)*-1, 0)
-	emailRetentionDate := time.Now().AddDate(0, dbClonesRetentionMonths*-1, 0)
+	alreadyExpiredTime := time.Now().AddDate(0, (dbComposesRetentionMonths+1)*-1, 0)
+	emailRetentionDate := time.Now().AddDate(0, dbComposesRetentionMonths*-1, 0)
 
 	composeIdNotYetExpired := uuid.New()
 	insert := "INSERT INTO composes(job_id, request, created_at, account_number, org_id) VALUES ($1, $2, $3, $4, $5)"
@@ -113,7 +113,7 @@ func testExpireByCallingDBCleanup(ctx context.Context, t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
-	err = DBCleanup(ctx, connStr, false, dbClonesRetentionMonths)
+	err = DBCleanup(ctx, connStr, false, dbComposesRetentionMonths)
 	require.NoError(t, err)
 
 	rows, err = d.ExpiredComposesCount(ctx, emailRetentionDate)
@@ -141,10 +141,10 @@ func testDryRun(ctx context.Context, t *testing.T) {
 	d, err := newDB(ctx, connStr)
 	require.NoError(t, err)
 
-	dbClonesRetentionMonths := 5
+	dbComposesRetentionMonths := 5
 
-	alreadyExpiredTime := time.Now().AddDate(0, (dbClonesRetentionMonths+1)*-1, 0)
-	emailRetentionDate := time.Now().AddDate(0, dbClonesRetentionMonths*-1, 0)
+	alreadyExpiredTime := time.Now().AddDate(0, (dbComposesRetentionMonths+1)*-1, 0)
+	emailRetentionDate := time.Now().AddDate(0, dbComposesRetentionMonths*-1, 0)
 
 	composeIdExpired := uuid.New()
 	insert := "INSERT INTO composes(job_id, request, created_at, account_number, org_id) VALUES ($1, $2, $3, $4, $5)"
@@ -154,7 +154,7 @@ func testDryRun(ctx context.Context, t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
-	err = DBCleanup(ctx, connStr, true, dbClonesRetentionMonths)
+	err = DBCleanup(ctx, connStr, true, dbComposesRetentionMonths)
 	require.NoError(t, err)
 
 	// still there

--- a/cmd/image-builder-maintenance/main.go
+++ b/cmd/image-builder-maintenance/main.go
@@ -38,9 +38,9 @@ func main() {
 	logrus.SetReportCaller(true)
 
 	conf := Config{
-		DryRun:                true,
-		EnableDBMaintenance:   false,
-		ClonesRetentionMonths: 24,
+		DryRun:                  true,
+		EnableDBMaintenance:     false,
+		ComposesRetentionMonths: 24,
 	}
 
 	err := LoadConfigFromEnv(&conf)
@@ -64,7 +64,7 @@ func main() {
 		conf.PGDatabase,
 		conf.PGSSLMode,
 	)
-	err = DBCleanup(ctx, dbURL, conf.DryRun, conf.ClonesRetentionMonths)
+	err = DBCleanup(ctx, dbURL, conf.DryRun, conf.ComposesRetentionMonths)
 	if err != nil {
 		logrus.Fatalf("Error during DBCleanup: %v", err)
 	}

--- a/templates/maintenance.yml
+++ b/templates/maintenance.yml
@@ -78,8 +78,8 @@ objects:
                 value: "${MAINTENANCE_DRY_RUN}"
               - name: ENABLE_DB_MAINTENANCE
                 value: "${ENABLE_DB_MAINTENANCE}"
-              - name: DB_CLONES_RETENTION_MONTHS
-                value: "${DB_CLONES_RETENTION_MONTHS}"
+              - name: DB_COMPOSES_RETENTION_MONTHS
+                value: "${DB_COMPOSES_RETENTION_MONTHS}"
 
 - apiVersion: v1
   kind: ServiceAccount
@@ -118,8 +118,8 @@ parameters:
     # don't change this value, overwrite it in app-interface for a specific namespace
     value: "false"
     required: true
-  - description: Retention period for entries in the "clones" table (in months)
-    name: DB_CLONES_RETENTION_MONTHS
+  - description: Retention period for entries in the "composes" table (in months)
+    name: DB_COMPOSES_RETENTION_MONTHS
     required: false
   - description: postgres sslmode to use when connecting to the db
     name: PGSSLMODE


### PR DESCRIPTION
The main table to delete data from, is actually "composes".
Data in the "clones" table is deleted implicitly.