### PR TITLE
templates/image-builder: fix typo in image-builder sql statement

### DIFF
--- a/templates/image-builder.yml
+++ b/templates/image-builder.yml
@@ -210,7 +210,7 @@ objects:
         select
           v.blueprint_id::text as blueprint_id, v.version, b.deleted,
           b.metadata->>'exported_at' as exported_at,
-          b.metadata->>'parent_id' as parent_id
+          b.metadata->>'parent_id' as parent_id,
           b.metadata->>'is_on_prem' as is_on_prem
         from
           blueprint_versions v


### PR DESCRIPTION
fixes typo in image-builder sql statement…
Just came across the error in the logs
```console
cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError) syntax error at or near "b"
LINE 5: b.metadata->>'is_on_prem' as is_on_prem
^
[SQL: select
v.blueprint_id::text as blueprint_id, v.version, b.deleted,
b.metadata->>'exported_at' as exported_at,
b.metadata->>'parent_id' as parent_id
b.metadata->>'is_on_prem' as is_on_prem
from
blueprint_versions v
left outer join blueprints b ON v.blueprint_id = b.id]
(Background on this error at: https://sqlalche.me/e/20/f405)
```