### PR TITLE
internal: Switch snapshot date to RFC3339

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -217,9 +217,9 @@ func buildRepositories(arch *distribution.Architecture, imageType ImageTypes) []
 }
 
 func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string, external bool, snapshotDate string) ([]composer.Repository, []composer.CustomRepository, error) {
-	date, err := time.Parse(time.DateOnly, snapshotDate)
+	date, err := time.Parse(time.RFC3339, snapshotDate)
 	if err != nil {
-		return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Snapshot date %s is not in DateOnly (yyyy-mm-dd) format", snapshotDate))
+		return nil, nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Snapshot date %s is not in RFC3339 (yyyy-mm-ddThh:mm:ssZ) format", snapshotDate))
 	}
 
 	repoUUIDs := []string{}

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -778,7 +778,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						SnapshotDate: common.ToPtr("1999-01-30"),
+						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
 						UploadRequest: v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
@@ -827,7 +827,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						SnapshotDate: common.ToPtr("1999-01-30"),
+						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
 						UploadRequest: v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
@@ -926,7 +926,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGuestImage,
-						SnapshotDate: common.ToPtr("1999-01-30"),
+						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
 						UploadRequest: v1.UploadRequest{
 							Type:    v1.UploadTypesAwsS3,
 							Options: uo,
@@ -1022,7 +1022,7 @@ func TestComposeWithSnapshots(t *testing.T) {
 					{
 						Architecture: "x86_64",
 						ImageType:    v1.ImageTypesGcp,
-						SnapshotDate: common.ToPtr("1999-01-30"),
+						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
 						UploadRequest: v1.UploadRequest{
 							Type:    v1.UploadTypesGcp,
 							Options: uoGCP,


### PR DESCRIPTION
Addition to #1252

This switches the snapshot date from a DateOnly format to RFC3339 in one more place.