### PR TITLE
internal/v1: BlueprintResoponse version field (COMPOSER-2419)

### DIFF
--- a/internal/v1/api.go
+++ b/internal/v1/api.go
@@ -293,6 +293,7 @@ type BlueprintResponse struct {
 	// ImageRequests Array of image requests. Having more image requests in a single blueprint is currently not supported.
 	ImageRequests []ImageRequest `json:"image_requests"`
 	Name          string         `json:"name"`
+	Version       *int           `json:"version,omitempty"`
 }
 
 // BlueprintsResponse defines model for BlueprintsResponse.

--- a/internal/v1/api.yaml
+++ b/internal/v1/api.yaml
@@ -1039,6 +1039,8 @@ components:
           type: string
         description:
           type: string
+        version:
+          type: integer
         distribution:
           $ref: '#/components/schemas/Distributions'
         image_requests:


### PR DESCRIPTION
We need it for converting on-prem blueprints to hosted ones in the frontend.