### PR TITLE
v1: ignore empty, not-nil gpg keys from content sources (HMS-5310)

### DIFF
--- a/internal/v1/handler_compose_image.go
+++ b/internal/v1/handler_compose_image.go
@@ -280,7 +280,9 @@ func (h *Handlers) buildRepositorySnapshots(ctx echo.Context, repoURLs []string,
 			Rhsm:    common.ToPtr(false),
 		}
 
-		composerRepo.Gpgkey = repo.GpgKey
+		if repo.GpgKey != nil && *repo.GpgKey != "" {
+			composerRepo.Gpgkey = repo.GpgKey
+		}
 		if composerRepo.Gpgkey != nil && *composerRepo.Gpgkey != "" {
 			composerRepo.CheckGpg = common.ToPtr(true)
 		}
@@ -344,19 +346,19 @@ func (h *Handlers) buildPayloadRepositories(ctx echo.Context, payloadRepos []Rep
 
 		if pyrepo.CheckGpg != nil {
 			res[i].CheckGpg = pyrepo.CheckGpg
-		} else if repo.GpgKey != nil {
+		} else if repo.GpgKey != nil && *repo.GpgKey != "" {
 			res[i].CheckGpg = common.ToPtr(true)
 		}
 
 		if pyrepo.CheckRepoGpg != nil {
 			res[i].CheckRepoGpg = pyrepo.CheckRepoGpg
-		} else if repo.MetadataVerification != nil {
+		} else if repo.MetadataVerification != nil && *repo.GpgKey != "" {
 			res[i].CheckRepoGpg = repo.MetadataVerification
 		}
 
 		if pyrepo.Gpgkey != nil {
 			res[i].Gpgkey = pyrepo.Gpgkey
-		} else if repo.GpgKey != nil {
+		} else if repo.GpgKey != nil && *repo.GpgKey != "" {
 			res[i].Gpgkey = repo.GpgKey
 		}
 
@@ -412,19 +414,19 @@ func (h *Handlers) buildCustomRepositories(ctx echo.Context, custRepos []CustomR
 
 		if curepo.CheckGpg != nil {
 			res[i].CheckGpg = curepo.CheckGpg
-		} else if repo.GpgKey != nil {
+		} else if repo.GpgKey != nil && *repo.GpgKey != "" {
 			res[i].CheckGpg = common.ToPtr(true)
 		}
 
 		if curepo.CheckRepoGpg != nil {
 			res[i].CheckRepoGpg = curepo.CheckRepoGpg
-		} else if repo.MetadataVerification != nil {
+		} else if repo.MetadataVerification != nil && *repo.GpgKey != "" {
 			res[i].CheckRepoGpg = repo.MetadataVerification
 		}
 
 		if curepo.Gpgkey != nil {
 			res[i].Gpgkey = curepo.Gpgkey
-		} else if repo.GpgKey != nil {
+		} else if repo.GpgKey != nil && *repo.GpgKey != "" {
 			res[i].Gpgkey = common.ToPtr([]string{*repo.GpgKey})
 		}
 

--- a/internal/v1/handler_post_compose_test.go
+++ b/internal/v1/handler_post_compose_test.go
@@ -1270,6 +1270,83 @@ func TestComposeWithSnapshots(t *testing.T) {
 				},
 			},
 		},
+		// 1 payload & custom repository with an empty, but not-nil gpg key
+		{
+			imageBuilderRequest: v1.ComposeRequest{
+				Distribution: "rhel-95",
+				ImageRequests: []v1.ImageRequest{
+					{
+						Architecture: "x86_64",
+						ImageType:    v1.ImageTypesGuestImage,
+						SnapshotDate: common.ToPtr("1999-01-30T00:00:00Z"),
+						UploadRequest: v1.UploadRequest{
+							Type:    v1.UploadTypesAwsS3,
+							Options: uo,
+						},
+					},
+				},
+				Customizations: &v1.Customizations{
+					PayloadRepositories: &[]v1.Repository{
+						{
+							Id: common.ToPtr(mocks.RepoPLID3),
+						},
+					},
+					CustomRepositories: &[]v1.CustomRepository{
+						{
+							Id: mocks.RepoPLID3,
+						},
+					},
+				},
+			},
+			composerRequest: composer.ComposeRequest{
+				Distribution: "rhel-9.5",
+				ImageRequest: &composer.ImageRequest{
+					Architecture: "x86_64",
+					ImageType:    composer.ImageTypesGuestImage,
+					Repositories: []composer.Repository{
+						{
+							Baseurl:     common.ToPtr("https://content-sources.org/snappy/baseos"),
+							Rhsm:        common.ToPtr(false),
+							Gpgkey:      common.ToPtr(mocks.RhelGPG),
+							CheckGpg:    common.ToPtr(true),
+							IgnoreSsl:   nil,
+							Metalink:    nil,
+							Mirrorlist:  nil,
+							PackageSets: nil,
+						},
+						{
+							Baseurl:     common.ToPtr("https://content-sources.org/snappy/appstream"),
+							Rhsm:        common.ToPtr(false),
+							Gpgkey:      common.ToPtr(mocks.RhelGPG),
+							CheckGpg:    common.ToPtr(true),
+							IgnoreSsl:   nil,
+							Metalink:    nil,
+							Mirrorlist:  nil,
+							PackageSets: nil,
+						},
+					},
+					UploadOptions: makeUploadOptions(t, composer.AWSS3UploadOptions{
+						Region: "",
+					}),
+				},
+				Customizations: &composer.Customizations{
+					PayloadRepositories: &[]composer.Repository{
+						{
+							Baseurl: common.ToPtr("https://content-sources.org/snappy/payload3"),
+							Rhsm:    common.ToPtr(false),
+						},
+					},
+					CustomRepositories: &[]composer.CustomRepository{
+						{
+							Baseurl: &[]string{"http://snappy-url/snappy/payload3"},
+							Name:    common.ToPtr("payload3"),
+							Enabled: common.ToPtr(false),
+							Id:      mocks.RepoPLID3,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for idx, payload := range payloads {
@@ -1685,6 +1762,9 @@ func TestComposeCustomizations(t *testing.T) {
 							IgnoreSsl:    common.ToPtr(false),
 							Rhsm:         false,
 						},
+						{
+							Id: common.ToPtr(mocks.RepoPLID3),
+						},
 					},
 					CustomRepositories: &[]v1.CustomRepository{
 						{
@@ -1692,6 +1772,9 @@ func TestComposeCustomizations(t *testing.T) {
 							Baseurl:  &[]string{"https://some-repo-base-url.org"},
 							Gpgkey:   &[]string{"some-gpg-key"},
 							CheckGpg: common.ToPtr(true),
+						},
+						{
+							Id: mocks.RepoPLID3,
 						},
 						{
 							Id:       "non-content-sources",
@@ -1725,6 +1808,11 @@ func TestComposeCustomizations(t *testing.T) {
 							IgnoreSsl:    common.ToPtr(false),
 							Rhsm:         common.ToPtr(false),
 						},
+						{
+							Baseurl:      common.ToPtr("https://some-repo-base-url3.org"),
+							CheckRepoGpg: common.ToPtr(false),
+							Rhsm:         common.ToPtr(false),
+						},
 					},
 					CustomRepositories: &[]composer.CustomRepository{
 						{
@@ -1733,6 +1821,11 @@ func TestComposeCustomizations(t *testing.T) {
 							Gpgkey:   &[]string{"some-gpg-key"},
 							CheckGpg: common.ToPtr(true),
 							Name:     common.ToPtr("payload"),
+						},
+						{
+							Id:      mocks.RepoPLID3,
+							Baseurl: &[]string{"https://some-repo-base-url3.org"},
+							Name:    common.ToPtr("payload3"),
 						},
 						{
 							Id:       "non-content-sources",

--- a/internal/v1/mocks/content_sources.go
+++ b/internal/v1/mocks/content_sources.go
@@ -22,6 +22,7 @@ var (
 	RepoAppstrID = "dbd21dfc-1733-4877-b1c8-8fb5a98beeb4"
 	RepoPLID     = "a7ec8864-0e3c-4af2-8c06-567891280af5"
 	RepoPLID2    = "c01c2d9c-4624-4558-9ca9-8abcc5eb4437"
+	RepoPLID3    = "d064585d-5d25-4e10-88d0-9ab4d192b21d"
 )
 
 func rhRepos(ids []string, urls []string) (res []content_sources.ApiRepositoryResponse) {
@@ -65,6 +66,16 @@ func extRepos(ids []string, urls []string) (res []content_sources.ApiRepositoryR
 			Url:      common.ToPtr("https://some-repo-base-url2.org"),
 			Snapshot: common.ToPtr(true),
 			Name:     common.ToPtr("payload2"),
+		})
+	}
+
+	if slices.Contains(urls, "https://some-repo-base-url3.org") || slices.Contains(ids, RepoPLID3) {
+		res = append(res, content_sources.ApiRepositoryResponse{
+			GpgKey:   common.ToPtr(""),
+			Uuid:     common.ToPtr(RepoPLID3),
+			Url:      common.ToPtr("https://some-repo-base-url3.org"),
+			Snapshot: common.ToPtr(true),
+			Name:     common.ToPtr("payload3"),
 		})
 	}
 
@@ -119,6 +130,18 @@ func snaps(uuids []string) (res []content_sources.ApiSnapshotForDate) {
 			RepositoryUuid: common.ToPtr(RepoPLID2),
 		})
 	}
+
+	if slices.Contains(uuids, RepoPLID3) {
+		res = append(res, content_sources.ApiSnapshotForDate{
+			IsAfter: common.ToPtr(false),
+			Match: &content_sources.ApiSnapshotResponse{
+				CreatedAt:      common.ToPtr("1998-01-30T00:00:00Z"),
+				RepositoryPath: common.ToPtr("/snappy/payload3"),
+				Url:            common.ToPtr("http://snappy-url/snappy/payload3"),
+			},
+			RepositoryUuid: common.ToPtr(RepoPLID3),
+		})
+	}
 	return res
 }
 
@@ -149,6 +172,13 @@ func exports(uuids []string) (res []content_sources.ApiRepositoryExportResponse)
 			GpgKey: common.ToPtr("some-gpg-key"),
 			Name:   common.ToPtr("payload2"),
 			Url:    common.ToPtr("http://snappy-url/snappy/payload2"),
+		})
+	}
+	if slices.Contains(uuids, RepoPLID3) {
+		res = append(res, content_sources.ApiRepositoryExportResponse{
+			GpgKey: common.ToPtr(""),
+			Name:   common.ToPtr("payload3"),
+			Url:    common.ToPtr("http://snappy-url/snappy/payload3"),
 		})
 	}
 	return res


### PR DESCRIPTION
If a gpg key is not added, the content sources api will still return an empty string. Composer cannot deal with an empty, not-nil gpg key, so just ignore the key in this case.

JIRA: [HMS-5310](https://issues.redhat.com/browse/HMS-5310)