### PR TITLE
fix: distribution comment typo

### DIFF
--- a/internal/distribution/distroregistry.go
+++ b/internal/distribution/distroregistry.go
@@ -75,7 +75,7 @@ func (dr DistroRegistry) Map() map[string]*DistributionFile {
 }
 
 // Get returns a distribution with a specific name.
-// If it's not found, ErrDistributionNot is returned.
+// If it's not found, ErrDistributionNotFound is returned.
 func (dr DistroRegistry) Get(name string) (*DistributionFile, error) {
 	df, found := dr.distros[name]
 	if !found {


### PR DESCRIPTION
Just fixing typo introduced in https://github.com/osbuild/image-builder/pull/1473