### PR TITLE
disk: check all partitions for boot partition requirement

### DIFF
--- a/pkg/disk/partition_table.go
+++ b/pkg/disk/partition_table.go
@@ -1697,46 +1697,58 @@ func needsBoot(disk *blueprint.DiskCustomization) bool {
 	}
 
 	var foundBtrfsOrLVM bool
+	var hasPlainRoot bool
+	var hasPlainBoot bool
+	var lvmOrBtrfsRootNeedsBoot bool
+	var hasBtrfsRootWithBootSubvol bool
+
+	// Do not use early returns in the loop below, we need to check all partitions.
 	for _, part := range disk.Partitions {
 		switch part.Type {
 		case "plain", "":
-			if part.Mountpoint == "/" {
-				return false
-			}
-			if part.Mountpoint == "/boot" {
-				return false
+			switch part.Mountpoint {
+			case "/":
+				hasPlainRoot = true
+			case "/boot":
+				hasPlainBoot = true
 			}
 		case "lvm":
 			foundBtrfsOrLVM = true
-			// check if any of the LVs is root
 			for _, lv := range part.LogicalVolumes {
 				if lv.Mountpoint == "/" {
-					return true
+					lvmOrBtrfsRootNeedsBoot = true
 				}
 			}
 		case "btrfs":
 			foundBtrfsOrLVM = true
-
-			// check if any of the subvols is root and no subvol is boot
 			hasRoot := false
-			hasBoot := false
+			hasBootSubvol := false
 
 			for _, subvol := range part.Subvolumes {
 				if subvol.Mountpoint == "/" {
 					hasRoot = true
 				}
 				if subvol.Mountpoint == "/boot" {
-					hasBoot = true
+					hasBootSubvol = true
 				}
 			}
 
-			if hasRoot {
-				return !hasBoot
+			if hasRoot && hasBootSubvol {
+				hasBtrfsRootWithBootSubvol = true
+			} else if hasRoot {
+				lvmOrBtrfsRootNeedsBoot = true
 			}
 
 		default:
 			// NOTE: invalid types should be validated elsewhere
 		}
+	}
+
+	if hasPlainRoot || hasPlainBoot || hasBtrfsRootWithBootSubvol {
+		return false
+	}
+	if lvmOrBtrfsRootNeedsBoot {
+		return true
 	}
 	return foundBtrfsOrLVM
 }

--- a/pkg/disk/partition_table_test.go
+++ b/pkg/disk/partition_table_test.go
@@ -3517,3 +3517,64 @@ func TestNewCustomPartitionTablePolicyNoXBOOTLDR(t *testing.T) {
 		assert.Equal(t, noBootPolicy, pt.Policy)
 	})
 }
+
+// Regression test for https://redhat.atlassian.net/browse/HMS-10805
+func TestNewCustomPartitionTableLVMWithExplicitBootAfterLVM(t *testing.T) {
+	/* #nosec G404 */
+	rnd := rand.New(rand.NewSource(0))
+
+	customizations := &blueprint.DiskCustomization{
+		Partitions: []blueprint.PartitionCustomization{
+			{
+				Type:    "plain",
+				MinSize: 1 * datasizes.GiB,
+				FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+					Mountpoint: "/boot/efi",
+					FSType:     "vfat",
+				},
+			},
+			{
+				Type:    "lvm",
+				MinSize: 1 * datasizes.GiB,
+				VGCustomization: blueprint.VGCustomization{
+					Name: "vg",
+					LogicalVolumes: []blueprint.LVCustomization{
+						{
+							Name:    "lv_root",
+							MinSize: 20 * datasizes.GiB,
+							FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+								Mountpoint: "/",
+								FSType:     "xfs",
+							},
+						},
+					},
+				},
+			},
+			{
+				Type:    "plain",
+				MinSize: 2 * datasizes.GiB,
+				FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+					Mountpoint: "/boot",
+					FSType:     "xfs",
+				},
+			},
+		},
+	}
+	options := &disk.CustomPartitionTableOptions{
+		DefaultFSType:      disk.FS_XFS,
+		BootMode:           platform.BOOT_NONE,
+		PartitionTableType: disk.PT_GPT,
+		Architecture:       arch.ARCH_X86_64,
+	}
+
+	pt, err := disk.NewCustomPartitionTable(customizations, options, nil, rnd)
+	require.NoError(t, err)
+
+	bootCount := 0
+	for _, part := range pt.Partitions {
+		if fs, ok := part.Payload.(*disk.Filesystem); ok && fs.Mountpoint == "/boot" {
+			bootCount++
+		}
+	}
+	assert.Equal(t, 1, bootCount, "expected exactly one /boot partition, not an auto-created duplicate")
+}


### PR DESCRIPTION
Function needsBoot exited early if it found a plain root or boot partition or a btrfs root with a boot subvolume. This was not correct, we need to check all partitions to avoid:

panic: the device name "boot" has been generated for two different devices

Example customization that caused the panic:

        [[customizations.disk.partitions]]
        type = "plain"
        fs_type = "vfat"
        minsize = "1 GiB"
        mountpoint = "/boot/efi"

        [[customizations.disk.partitions]]
        name = "vg"
        type = "lvm"
        minsize = "1 GiB"

        [[customizations.disk.partitions.logical_volumes]]
        name = "lv_root"
        fs_type = "xfs"
        minsize = "20 GiB"
        mountpoint = "/"

        [[customizations.disk.partitions]]
        type = "plain"
        fs_type = "xfs"
        minsize = "2 GiB"
        mountpoint = "/boot"

Reordering the partitions would fix the problem, but this was a insights customer who were running into this.

---

https://redhat.atlassian.net/browse/HMS-10805