### PR TITLE
installers: grub2 timeout everywhere

### DIFF
--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -333,9 +333,14 @@ func (t *bootcImageType) initAnacondaInstallerBaseFromSourceInfo(img *image.Anac
 	if err != nil {
 		return err
 	}
-	if instCust != nil && instCust.Modules != nil {
-		img.InstallerCustomizations.EnabledAnacondaModules = append(img.InstallerCustomizations.EnabledAnacondaModules, instCust.Modules.Enable...)
-		img.InstallerCustomizations.DisabledAnacondaModules = append(img.InstallerCustomizations.DisabledAnacondaModules, instCust.Modules.Disable...)
+	if instCust != nil {
+		if instCust.Modules != nil {
+			img.InstallerCustomizations.EnabledAnacondaModules = append(img.InstallerCustomizations.EnabledAnacondaModules, instCust.Modules.Enable...)
+			img.InstallerCustomizations.DisabledAnacondaModules = append(img.InstallerCustomizations.DisabledAnacondaModules, instCust.Modules.Disable...)
+		}
+		if instCust.Bootloader != nil && instCust.Bootloader.Grub2 != nil {
+			img.InstallerCustomizations.MenuTimeout = instCust.Bootloader.Grub2.MenuTimeout
+		}
 	}
 	img.InstallerCustomizations.EnabledAnacondaModules = append(img.InstallerCustomizations.EnabledAnacondaModules,
 		anaconda.ModuleUsers,

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -531,6 +531,10 @@ func installerCustomizations(t *imageType, c *blueprint.Customizations, o distro
 			isc.DisabledAnacondaModules = append(isc.DisabledAnacondaModules, installerCust.Modules.Disable...)
 		}
 
+		if installerCust.Bootloader != nil && installerCust.Bootloader.Grub2 != nil {
+			isc.MenuTimeout = installerCust.Bootloader.Grub2.MenuTimeout
+		}
+
 		if installerCust.Payload != nil && installerCust.Payload.Flatpaks != nil {
 			flatpakMeta := installerCust.Payload.Flatpaks
 

--- a/pkg/image/iso_bootloaders.go
+++ b/pkg/image/iso_bootloaders.go
@@ -37,6 +37,7 @@ func (img *ISOBootloaders) Bootloaders(buildPipeline manifest.Build, platform pl
 		grub2.ISOLabel = img.ISOCustomizations.Label
 		grub2.KernelOpts = kernelOpts
 		grub2.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+		grub2.MenuTimeout = img.InstallerCustomizations.MenuTimeout
 
 		for _, entry := range img.Custom {
 			grub2.Custom = append(grub2.Custom, manifest.ISOGrub2MenuEntry{
@@ -55,6 +56,7 @@ func (img *ISOBootloaders) Bootloaders(buildPipeline manifest.Build, platform pl
 		grub2ppc64.ISOLabel = img.ISOCustomizations.Label
 		grub2ppc64.KernelOpts = kernelOpts
 		grub2ppc64.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+		grub2ppc64.MenuTimeout = img.InstallerCustomizations.MenuTimeout
 
 		for _, entry := range img.Custom {
 			grub2ppc64.Custom = append(grub2ppc64.Custom, manifest.ISOGrub2MenuEntry{
@@ -80,6 +82,7 @@ func (img *ISOBootloaders) Bootloaders(buildPipeline manifest.Build, platform pl
 		efiPipeline.UEFIVendor = platform.GetUEFIVendor()
 		efiPipeline.ISOLabel = img.ISOCustomizations.Label
 		efiPipeline.DefaultMenu = img.InstallerCustomizations.DefaultMenu
+		efiPipeline.MenuTimeout = img.InstallerCustomizations.MenuTimeout
 		efiPipeline.KernelOpts = kernelOpts
 
 		for _, entry := range img.Custom {

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -135,6 +135,7 @@ type InstallerCustomizations struct {
 	InstallWeakDeps bool
 
 	DefaultMenu int
+	MenuTimeout *int
 
 	Product   string
 	Variant   string

--- a/pkg/manifest/iso_bootloaders.go
+++ b/pkg/manifest/iso_bootloaders.go
@@ -63,6 +63,8 @@ type Grub2X86Boot struct {
 
 	// Default Grub2 menu on the ISO
 	DefaultMenu int
+	// Default Grub2 menu timeout on the ISO
+	MenuTimeout *int
 	// Custom menu entries (overrides all default entries)
 	Custom []ISOGrub2MenuEntry
 }
@@ -84,6 +86,15 @@ func (boot *Grub2X86Boot) GetISOBootStages(inputName string, _ *disk.PartitionTa
 	if boot.DefaultMenu > 0 {
 		grub2config = &osbuild.Grub2Config{
 			Default: boot.DefaultMenu,
+		}
+	}
+	if boot.MenuTimeout != nil {
+		if grub2config == nil {
+			grub2config = &osbuild.Grub2Config{
+				Timeout: *boot.MenuTimeout,
+			}
+		} else {
+			grub2config.Timeout = *boot.MenuTimeout
 		}
 	}
 	options := &osbuild.Grub2ISOLegacyStageOptions{
@@ -142,6 +153,8 @@ type Grub2PPC64Boot struct {
 
 	// Default Grub2 menu on the ISO
 	DefaultMenu int
+	// Default Grub2 menu timeout on the ISO
+	MenuTimeout *int
 	// Custom menu entries (overrides all default entries)
 	Custom []ISOGrub2MenuEntry
 }
@@ -163,6 +176,15 @@ func (boot *Grub2PPC64Boot) GetISOBootStages(inputName string, _ *disk.Partition
 	if boot.DefaultMenu > 0 {
 		grub2config = &osbuild.Grub2Config{
 			Default: boot.DefaultMenu,
+		}
+	}
+	if boot.MenuTimeout != nil {
+		if grub2config == nil {
+			grub2config = &osbuild.Grub2Config{
+				Timeout: *boot.MenuTimeout,
+			}
+		} else {
+			grub2config.Timeout = *boot.MenuTimeout
 		}
 	}
 	options := &osbuild.Grub2ISOLegacyStageOptions{


### PR DESCRIPTION
When `installer.bootloader.grub2.menu-timeout` is set in the blueprint make sure it applies to *all* installer types. Closes #2223.