### PR TITLE
osbuild: compare Go against JSON

### DIFF
--- a/pkg/osbuild/schema_validation_test.go
+++ b/pkg/osbuild/schema_validation_test.go
@@ -1,0 +1,616 @@
+package osbuild
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type schemaFieldInfo struct {
+	jsonName  string
+	goType    string
+	omitempty bool
+}
+
+type schemaProperty struct {
+	typ string
+}
+
+type stageSchema struct {
+	properties           map[string]schemaProperty
+	additionalProperties bool
+	required             []string
+}
+
+func TestStageOptionsMatchOsbuildSchemas(t *testing.T) {
+	stagesDir := os.Getenv("TEST_OSBUILD_STAGES_DIR")
+	if stagesDir == "" {
+		stagesDir = "/usr/lib/osbuild/stages"
+	}
+	if _, err := os.Stat(stagesDir); err != nil {
+		t.Skipf("osbuild stages directory not found at %s", stagesDir)
+	}
+
+	stageMap, structs, typeAliases := parseGoStageSource(t)
+	schemas := readOsbuildSchemas(t, stagesDir)
+
+	matched := 0
+	for typeString, optionsType := range stageMap {
+		schema, hasSchema := schemas[typeString]
+		if !hasSchema {
+			continue
+		}
+		fields, hasStruct := structs[optionsType]
+		if !hasStruct {
+			t.Logf("%s: options type %s not found in parsed structs", typeString, optionsType)
+			continue
+		}
+		matched++
+		t.Run(typeString, func(t *testing.T) {
+			compareGoFieldsToSchema(t, fields, schema, structs, typeAliases)
+		})
+	}
+
+	var goOnly []string
+	for ts := range stageMap {
+		if _, ok := schemas[ts]; !ok {
+			goOnly = append(goOnly, ts)
+		}
+	}
+	var schemaOnly []string
+	for ts := range schemas {
+		if _, ok := stageMap[ts]; !ok {
+			schemaOnly = append(schemaOnly, ts)
+		}
+	}
+	sort.Strings(goOnly)
+	sort.Strings(schemaOnly)
+	t.Logf("compared %d stages (%d Go stages total, %d osbuild schemas total, %d Go-only, %d schema-only)",
+		matched, len(stageMap), len(schemas), len(goOnly), len(schemaOnly))
+	if len(goOnly) > 0 {
+		t.Logf("stages in Go but not in osbuild schemas: %v", goOnly)
+	}
+	if len(schemaOnly) > 0 {
+		t.Logf("stages in osbuild schemas but not in Go: %v", schemaOnly)
+	}
+}
+
+func parseGoStageSource(t *testing.T) (stageMap map[string]string, structs map[string][]schemaFieldInfo, typeAliases map[string]string) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+
+	pkg, ok := pkgs["osbuild"]
+	require.True(t, ok, "osbuild package not found")
+
+	consts := collectStringConstants(pkg.Files)
+	stageMap = discoverStageConstructors(pkg.Files, consts)
+	structs = extractAllStructFields(pkg.Files)
+	typeAliases = collectTypeAliases(pkg.Files)
+	return
+}
+
+func collectStringConstants(files map[string]*ast.File) map[string]string {
+	consts := make(map[string]string)
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				valSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range valSpec.Names {
+					if i >= len(valSpec.Values) {
+						break
+					}
+					lit, ok := valSpec.Values[i].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					consts[name.Name] = strings.Trim(lit.Value, `"`)
+				}
+			}
+		}
+	}
+	return consts
+}
+
+func discoverStageConstructors(files map[string]*ast.File, consts map[string]string) map[string]string {
+	stageMap := make(map[string]string)
+
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			funcDecl, ok := decl.(*ast.FuncDecl)
+			if !ok || funcDecl.Recv != nil {
+				continue
+			}
+			if !funcReturnsStagePtr(funcDecl) {
+				continue
+			}
+
+			typeString := findStageTypeInFunc(funcDecl, consts)
+			if typeString == "" || !strings.HasPrefix(typeString, "org.osbuild.") {
+				continue
+			}
+
+			optionsType := findOptionsParamType(funcDecl)
+			if optionsType == "" {
+				optionsType = findOptionsTypeFromLiteral(funcDecl)
+			}
+			if optionsType == "" {
+				continue
+			}
+
+			if _, exists := stageMap[typeString]; !exists {
+				stageMap[typeString] = optionsType
+			}
+		}
+	}
+
+	return stageMap
+}
+
+func funcReturnsStagePtr(funcDecl *ast.FuncDecl) bool {
+	if funcDecl.Type.Results == nil {
+		return false
+	}
+	for _, result := range funcDecl.Type.Results.List {
+		starExpr, ok := result.Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		ident, ok := starExpr.X.(*ast.Ident)
+		if ok && ident.Name == "Stage" {
+			return true
+		}
+	}
+	return false
+}
+
+func findStageTypeInFunc(funcDecl *ast.FuncDecl, consts map[string]string) string {
+	var typeString string
+	ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+		if typeString != "" {
+			return false
+		}
+		compLit, ok := n.(*ast.CompositeLit)
+		if !ok || !isStageTypeLiteral(compLit) {
+			return true
+		}
+		for _, elt := range compLit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != "Type" {
+				continue
+			}
+			if lit, ok := kv.Value.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				typeString = strings.Trim(lit.Value, `"`)
+				return false
+			}
+			if ident, ok := kv.Value.(*ast.Ident); ok {
+				if val, found := consts[ident.Name]; found {
+					typeString = val
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return typeString
+}
+
+func isStageTypeLiteral(compLit *ast.CompositeLit) bool {
+	ident, ok := compLit.Type.(*ast.Ident)
+	return ok && ident.Name == "Stage"
+}
+
+func findOptionsParamType(funcDecl *ast.FuncDecl) string {
+	if funcDecl.Type.Params == nil {
+		return ""
+	}
+	for _, param := range funcDecl.Type.Params.List {
+		name := astTypeName(param.Type)
+		if strings.HasSuffix(name, "Options") {
+			return name
+		}
+	}
+	return ""
+}
+
+func findOptionsTypeFromLiteral(funcDecl *ast.FuncDecl) string {
+	var optionsType string
+	ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+		if optionsType != "" {
+			return false
+		}
+		compLit, ok := n.(*ast.CompositeLit)
+		if !ok || !isStageTypeLiteral(compLit) {
+			return true
+		}
+		for _, elt := range compLit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != "Options" {
+				continue
+			}
+			optionsType = extractOptionsTypeFromExpr(kv.Value)
+			if optionsType != "" {
+				return false
+			}
+		}
+		return true
+	})
+	return optionsType
+}
+
+func extractOptionsTypeFromExpr(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.UnaryExpr:
+		return extractOptionsTypeFromExpr(e.X)
+	case *ast.CompositeLit:
+		return astTypeName(e.Type)
+	}
+	return ""
+}
+
+func astTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return astTypeName(t.X)
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	}
+	return ""
+}
+
+func collectTypeAliases(files map[string]*ast.File) map[string]string {
+	aliases := make(map[string]string)
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				if _, isStruct := typeSpec.Type.(*ast.StructType); isStruct {
+					continue
+				}
+				aliases[typeSpec.Name.Name] = astTypeString(typeSpec.Type)
+			}
+		}
+	}
+	return aliases
+}
+
+func extractAllStructFields(files map[string]*ast.File) map[string][]schemaFieldInfo {
+	structs := make(map[string][]schemaFieldInfo)
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				structType, ok := typeSpec.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				fields := extractStructJSONFields(structType)
+				structs[typeSpec.Name.Name] = fields
+			}
+		}
+	}
+	return structs
+}
+
+func extractStructJSONFields(structType *ast.StructType) []schemaFieldInfo {
+	var fields []schemaFieldInfo
+	for _, field := range structType.Fields.List {
+		if field.Tag == nil || len(field.Names) == 0 {
+			continue
+		}
+		tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`"))
+		jsonTag := tag.Get("json")
+		if jsonTag == "" || jsonTag == "-" {
+			continue
+		}
+
+		name, opts, _ := strings.Cut(jsonTag, ",")
+		fields = append(fields, schemaFieldInfo{
+			jsonName:  name,
+			goType:    astTypeString(field.Type),
+			omitempty: strings.Contains(opts, "omitempty"),
+		})
+	}
+	return fields
+}
+
+func astTypeString(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return "*" + astTypeString(t.X)
+	case *ast.ArrayType:
+		return "[]" + astTypeString(t.Elt)
+	case *ast.MapType:
+		return "map[" + astTypeString(t.Key) + "]" + astTypeString(t.Value)
+	case *ast.SelectorExpr:
+		return astTypeString(t.X) + "." + t.Sel.Name
+	case *ast.InterfaceType:
+		return "interface{}"
+	}
+	return "unknown"
+}
+
+func readOsbuildSchemas(t *testing.T, stagesDir string) map[string]stageSchema {
+	t.Helper()
+
+	schemas := make(map[string]stageSchema)
+	entries, err := filepath.Glob(filepath.Join(stagesDir, "org.osbuild.*.meta.json"))
+	require.NoError(t, err)
+
+	for _, path := range entries {
+		base := filepath.Base(path)
+		typeString := strings.TrimSuffix(base, ".meta.json")
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Logf("skipping %s: %v", base, err)
+			continue
+		}
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Logf("skipping %s: invalid JSON: %v", base, err)
+			continue
+		}
+
+		schema := extractOptionsSchema(raw)
+		if schema.properties != nil {
+			schemas[typeString] = schema
+		}
+	}
+
+	return schemas
+}
+
+func extractOptionsSchema(raw map[string]interface{}) stageSchema {
+	if schema2, ok := raw["schema_2"].(map[string]interface{}); ok {
+		if options, ok := schema2["options"].(map[string]interface{}); ok {
+			return parseSchemaObject(options)
+		}
+	}
+	if schema, ok := raw["schema"].(map[string]interface{}); ok {
+		return parseSchemaObject(schema)
+	}
+	return stageSchema{}
+}
+
+func parseSchemaObject(obj map[string]interface{}) stageSchema {
+	result := stageSchema{
+		properties:           make(map[string]schemaProperty),
+		additionalProperties: true,
+	}
+
+	if ap, ok := obj["additionalProperties"].(bool); ok {
+		result.additionalProperties = ap
+	}
+
+	if req, ok := obj["required"].([]interface{}); ok {
+		for _, r := range req {
+			if s, ok := r.(string); ok {
+				result.required = append(result.required, s)
+			}
+		}
+	}
+
+	collectSchemaProperties(obj, result.properties)
+
+	for _, key := range []string{"oneOf", "anyOf"} {
+		branches, ok := obj[key].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, branch := range branches {
+			branchObj, ok := branch.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			collectSchemaProperties(branchObj, result.properties)
+			if req, ok := branchObj["required"].([]interface{}); ok {
+				for _, r := range req {
+					if s, ok := r.(string); ok {
+						result.required = append(result.required, s)
+					}
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+func collectSchemaProperties(obj map[string]interface{}, into map[string]schemaProperty) {
+	props, ok := obj["properties"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	for name, prop := range props {
+		if _, exists := into[name]; exists {
+			continue
+		}
+		sp := schemaProperty{}
+		if propObj, ok := prop.(map[string]interface{}); ok {
+			if t, ok := propObj["type"].(string); ok {
+				sp.typ = t
+			} else if ref, ok := propObj["$ref"].(string); ok {
+				sp.typ = resolveRefType(ref, obj)
+			}
+		}
+		into[name] = sp
+	}
+}
+
+func resolveRefType(ref string, root map[string]interface{}) string {
+	if !strings.HasPrefix(ref, "#/") {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(ref, "#/"), "/")
+	var current interface{} = root
+	for _, part := range parts {
+		obj, ok := current.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = obj[part]
+	}
+	if resolved, ok := current.(map[string]interface{}); ok {
+		if t, ok := resolved["type"].(string); ok {
+			return t
+		}
+	}
+	return ""
+}
+
+func compareGoFieldsToSchema(t *testing.T, fields []schemaFieldInfo, schema stageSchema, allStructs map[string][]schemaFieldInfo, typeAliases map[string]string) {
+	t.Helper()
+
+	for _, field := range fields {
+		_, inSchema := schema.properties[field.jsonName]
+		if !inSchema && !schema.additionalProperties {
+			t.Errorf("Go field %q not found in schema (additionalProperties: false)", field.jsonName)
+			continue
+		}
+		if !inSchema {
+			continue
+		}
+
+		prop := schema.properties[field.jsonName]
+		if prop.typ == "" {
+			continue
+		}
+		if !goTypeMatchesSchemaType(field.goType, prop.typ, allStructs, typeAliases) {
+			t.Errorf("type mismatch for %q: Go type %s, schema type %q", field.jsonName, field.goType, prop.typ)
+		}
+	}
+
+	goFields := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		goFields[f.jsonName] = true
+	}
+	var missing []string
+	for name := range schema.properties {
+		if !goFields[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Logf("schema properties not in Go struct: %v", missing)
+	}
+}
+
+func goTypeMatchesSchemaType(goType, schemaType string, allStructs map[string][]schemaFieldInfo, typeAliases map[string]string) bool {
+	goType = strings.TrimPrefix(goType, "*")
+
+	if underlying, ok := typeAliases[goType]; ok {
+		goType = underlying
+	}
+
+	switch schemaType {
+	case "string":
+		if goType == "string" {
+			return true
+		}
+		return !isGoNumericType(goType) &&
+			goType != "bool" &&
+			!strings.HasPrefix(goType, "[]") &&
+			!strings.HasPrefix(goType, "map[") &&
+			!isGoStructType(goType, allStructs)
+	case "number", "integer":
+		return isGoNumericType(goType)
+	case "boolean":
+		return goType == "bool"
+	case "array":
+		return strings.HasPrefix(goType, "[]")
+	case "object":
+		return strings.HasPrefix(goType, "map[") || isGoStructType(goType, allStructs)
+	}
+	return true
+}
+
+func isGoNumericType(goType string) bool {
+	switch goType {
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64",
+		"float32", "float64":
+		return true
+	}
+	return false
+}
+
+func isGoStructType(goType string, allStructs map[string][]schemaFieldInfo) bool {
+	_, ok := allStructs[goType]
+	return ok
+}
+
+func TestParseGoStageSource(t *testing.T) {
+	stageMap, structs, typeAliases := parseGoStageSource(t)
+
+	assert.Contains(t, stageMap, "org.osbuild.hostname")
+	assert.Equal(t, "HostnameStageOptions", stageMap["org.osbuild.hostname"])
+
+	assert.Contains(t, stageMap, "org.osbuild.locale")
+	assert.Equal(t, "LocaleStageOptions", stageMap["org.osbuild.locale"])
+
+	assert.Contains(t, stageMap, "org.osbuild.grub2")
+	assert.Equal(t, "GRUB2StageOptions", stageMap["org.osbuild.grub2"])
+
+	assert.Contains(t, stageMap, "org.osbuild.chrony")
+	assert.Contains(t, stageMap, "org.osbuild.kickstart")
+
+	assert.Greater(t, len(stageMap), 90, "expected to discover at least 90 stages")
+
+	hostnameFields := structs["HostnameStageOptions"]
+	require.Len(t, hostnameFields, 1)
+	assert.Equal(t, "hostname", hostnameFields[0].jsonName)
+	assert.Equal(t, "string", hostnameFields[0].goType)
+
+	assert.Equal(t, "[]UdevRule", typeAliases["UdevRules"])
+	assert.Equal(t, "[]ModprobeConfigCmd", typeAliases["ModprobeConfigCmdList"])
+}


### PR DESCRIPTION
New test that parses the Go implementation of the `osbuild` stages using the `ast` module (this was quite a bit of work, but surprisingly straightforward even if verbose).

Ensures types in the JSON files match types in the Go files, including any type aliases.

Outputs informational bits about missing properties on the Go side or osbuild side. Outputs information about stages that in osbuild that do not have any Go counterpart.

Does *not* properly validate `anyOf`/`enum`/etc. But this basic validation is already helpful and followups are very possible.

By default looks in `/usr/lib/osbuild`; if no stages can be found the test is skipped. Custom directory can be passed through `TEST_OSBUILD_STAGES_DIR`.

---

Example (verbose) output:

```
€ TEST_OSBUILD_STAGES_DIR=/home/user/src/github.com/osbuild/osbuild/stages go test ./pkg/osbuild -v -run TestStageOptionsMatchOsbuildSchemas
=== RUN   TestStageOptionsMatchOsbuildSchemas
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.zstd
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.tuned
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.lvm2.metadata
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.groups
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.selinux
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.selinux.config
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ovf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.encapsulate
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.modprobe
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.tar
    schema_validation_test.go:60: schema properties not in Go struct: [sparse]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.fix-bls
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootctl.install.root
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.udev.rules
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.zipl.inst
    schema_validation_test.go:60: schema properties not in Go struct: [kernel_opts_append]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.chrony
    schema_validation_test.go:60: schema properties not in Go struct: [timeservers]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.buildstamp
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.selinux
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.rhsm
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.container-deploy
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootiso.mono
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.qemu
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.init
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.rpm
    schema_validation_test.go:60: schema properties not in Go struct: [nodeps]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.authconfig
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.erofs
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd-logind
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.dnf-automatic.config
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.discinfo
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd.unit.create
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.xorrisofs
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd.unit
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.xz
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.sfdisk
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.timezone
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.firewall
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.nm.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.oscap.autotailor
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.deploy.container
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.keymap
    schema_validation_test.go:60: schema properties not in Go struct: [font]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.copy
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkfs.xfs
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.cloud-init
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.anaconda
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.dnf4.versionlock
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkfs.ext4
    schema_validation_test.go:60: schema properties not in Go struct: [lazy_init metadata_csum_seed orphan_file]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd-journald
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.fstab
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.containers.storage.conf
    schema_validation_test.go:60: schema properties not in Go struct: [filebase]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.config
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.chmod
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.wsl.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.insights-client.config
    schema_validation_test.go:60: schema properties not in Go struct: [path]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkfs.fat
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.luks2.remove-key
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.sgdisk
    schema_validation_test.go:60: schema properties not in Go struct: [label quote_partition_name]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkdir
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.oci-archive
    schema_validation_test.go:60: schema properties not in Go struct: [annotations]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.dnf.module-config
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.rhsm.facts
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.truncate
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.sysconfig
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.write-device
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.deploy
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.users
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.shell.init
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2.iso
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.kernel-cmdline
    schema_validation_test.go:60: schema properties not in Go struct: [kernel_cmdline_size]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ignition
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd.preset
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.first-boot
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.waagent.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.kickstart
    schema_validation_test.go:60: schema properties not in Go struct: [bootc]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.pull
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.oscap.remediation
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.locale
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.zipl
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkfs.btrfs
    schema_validation_test.go:60: schema properties not in Go struct: [metadata]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.chown
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.clevis.luks-bind
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.grub2
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.commit
    schema_validation_test.go:60: schema properties not in Go struct: [selinux-label-version]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.dracut.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.yum.config
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootc.install-to-filesystem
    schema_validation_test.go:60: schema properties not in Go struct: [boot-mount-spec bootupd-skip-boot-uuid root-mount-spec stateroot]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.mks390image
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.btrfs.subvol
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.gcp.guest-agent.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.remotes
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.preptree
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2.iso.legacy
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.vagrant
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.hmac
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.sysctld
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootupd
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.createaddrsize
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.nginx.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.flatpak.build-import-bundle.oci
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.pwquality.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootc.install.config
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.machine-id
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.yum.repos
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.authselect
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.isolinux
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd
    schema_validation_test.go:60: schema properties not in Go struct: [masked_generators]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.implantisomd5
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.tmpfilesd
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.os-init
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.fillvar
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.squashfs
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.pam.limits.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.update-crypto-policies
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.gzip
    schema_validation_test.go:60: schema properties not in Go struct: [level]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.dracut
    schema_validation_test.go:60: schema properties not in Go struct: [initoverlayfs omit_drivers remove]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.dnf.config
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.skopeo
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.lorax-script
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.lvm2.create
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2
    schema_validation_test.go:60: schema properties not in Go struct: [bootfs rootfs write_defaults]
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkswap
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.sshd.config
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2.legacy
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2.inst
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.hostname
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.wsl-distribution.conf
=== RUN   TestStageOptionsMatchOsbuildSchemas/org.osbuild.luks2.format
    schema_validation_test.go:60: schema properties not in Go struct: [integrity]
=== NAME  TestStageOptionsMatchOsbuildSchemas
    schema_validation_test.go:78: compared 125 stages (125 Go stages total, 175 osbuild schemas total, 0 Go-only, 50 schema-only)
    schema_validation_test.go:84: stages in osbuild schemas but not in Go: [org.osbuild.bfb org.osbuild.bootupd.gen-metadata org.osbuild.chattr org.osbuild.containers.unit.create org.osbuild.coreos.live-artifacts.mono org.osbuild.coreos.platform org.osbuild.cpio.out org.osbuild.cron.script org.osbuild.crypttab org.osbuild.debug-shell org.osbuild.dmverity org.osbuild.dnf4.mark org.osbuild.error org.osbuild.experimental.ostree.config org.osbuild.fdo org.osbuild.greenboot org.osbuild.grub2.d org.osbuild.gunzip org.osbuild.idmap org.osbuild.kernel-cmdline.bls-append org.osbuild.livesys org.osbuild.ln org.osbuild.mkinitcpio org.osbuild.nm.conn org.osbuild.noop org.osbuild.ostree org.osbuild.ostree.aleph org.osbuild.ostree.genkey org.osbuild.ostree.init-fs org.osbuild.ostree.passwd org.osbuild.ostree.post-copy org.osbuild.ostree.sign org.osbuild.pacman org.osbuild.pacman-keyring org.osbuild.pacman.conf org.osbuild.pacman.mirrorlist.conf org.osbuild.parted org.osbuild.pki.update-ca-trust org.osbuild.resolv-conf org.osbuild.rpm-ostree org.osbuild.rpm.macros org.osbuild.rpmkeys.import org.osbuild.systemd-repart.create org.osbuild.systemd-sysusers org.osbuild.systemd-sysusers.d org.osbuild.test org.osbuild.treeinfo org.osbuild.uki org.osbuild.untar org.osbuild.zip]
--- PASS: TestStageOptionsMatchOsbuildSchemas (0.03s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.zstd (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.tuned (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.lvm2.metadata (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.groups (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.selinux (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.selinux.config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ovf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.encapsulate (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.modprobe (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.tar (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.fix-bls (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootctl.install.root (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.udev.rules (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.zipl.inst (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.chrony (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.buildstamp (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.selinux (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.rhsm (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.container-deploy (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootiso.mono (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.qemu (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.init (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.rpm (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.authconfig (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.erofs (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd-logind (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.dnf-automatic.config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.discinfo (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd.unit.create (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.xorrisofs (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd.unit (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.xz (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.sfdisk (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.timezone (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.firewall (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.nm.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.oscap.autotailor (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.deploy.container (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.keymap (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.copy (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkfs.xfs (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.cloud-init (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.anaconda (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.dnf4.versionlock (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkfs.ext4 (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd-journald (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.fstab (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.containers.storage.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.chmod (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.wsl.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.insights-client.config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkfs.fat (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.luks2.remove-key (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.sgdisk (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkdir (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.oci-archive (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.dnf.module-config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.rhsm.facts (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.truncate (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.sysconfig (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.write-device (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.deploy (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.users (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.shell.init (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2.iso (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.kernel-cmdline (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ignition (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd.preset (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.first-boot (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.waagent.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.kickstart (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.pull (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.oscap.remediation (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.locale (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.zipl (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkfs.btrfs (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.chown (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.clevis.luks-bind (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.grub2 (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.commit (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.dracut.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.yum.config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootc.install-to-filesystem (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.mks390image (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.btrfs.subvol (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.gcp.guest-agent.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.remotes (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.preptree (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2.iso.legacy (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.vagrant (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.hmac (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.sysctld (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootupd (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.createaddrsize (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.nginx.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.flatpak.build-import-bundle.oci (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.pwquality.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.bootc.install.config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.machine-id (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.yum.repos (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.authselect (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.isolinux (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.systemd (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.implantisomd5 (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.tmpfilesd (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.os-init (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.ostree.fillvar (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.squashfs (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.pam.limits.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.update-crypto-policies (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.gzip (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.dracut (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.dnf.config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.skopeo (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.lorax-script (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.lvm2.create (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2 (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.mkswap (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.sshd.config (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2.legacy (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.grub2.inst (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.hostname (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.wsl-distribution.conf (0.00s)
    --- PASS: TestStageOptionsMatchOsbuildSchemas/org.osbuild.luks2.format (0.00s)
PASS
ok      github.com/osbuild/image-builder/pkg/osbuild    (cached)
```