### PR TITLE
ci: tag containers

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -4,6 +4,7 @@ name: Containers
 on:  # yamllint disable-line rule:truthy
   push:
     branches: ["main"]
+    tags: ["v*"]
   pull_request:
     branches: ["main"]
   merge_group:


### PR DESCRIPTION
See [1] for details, this also builds, uploads, and tags containers when a new tag is pushed into the repository.

[1]: https://github.com/osbuild/image-builder/issues/2574