### PR TITLE
Add 'raw-xz' image type to bootc-generic

### DIFF
--- a/data/distrodefs/bootc-generic/imagetypes.yaml
+++ b/data/distrodefs/bootc-generic/imagetypes.yaml
@@ -34,8 +34,7 @@
       x86_64:
         type: "gpt"
         partitions:
-          -
-            size: "1 MiB"
+          - size: "1 MiB"
             bootable: true
             type: *bios_boot_partition_guid
           - &default_partition_table_part_efi
@@ -123,6 +122,12 @@ image_types:
       kernel_options: *bootc_kernel_options
     blueprint:
       supported_options: *supported_options_disk
+
+  "raw-xz":
+    <<: *raw_image_type
+    filename: "disk.raw.xz"
+    compression: "xz"
+    mime_type: "application/xz"
 
   "ami":
     <<: *raw_image_type

--- a/internal/bibimg/imagetypes.go
+++ b/internal/bibimg/imagetypes.go
@@ -20,6 +20,7 @@ var supportedImageTypes = map[string]imageType{
 	"ami":             imageType{Export: "image"},
 	"qcow2":           imageType{Export: "qcow2"},
 	"raw":             imageType{Export: "image"},
+	"raw-xz":          imageType{Export: "image"},
 	"vmdk":            imageType{Export: "vmdk"},
 	"vhd":             imageType{Export: "vpc"},
 	"gce":             imageType{Export: "gce"},

--- a/internal/bibimg/imagetypes_test.go
+++ b/internal/bibimg/imagetypes_test.go
@@ -58,6 +58,11 @@ func TestImageTypes(t *testing.T) {
 			expectedExports: []string{"xz"},
 			expectISO:       false,
 		},
+		"raw-xz": {
+			imageTypes:      []string{"raw-xz"},
+			expectedExports: []string{"image"},
+			expectISO:       false,
+		},
 		"bad-mix": {
 			imageTypes:  []string{"vmdk", "anaconda-iso"},
 			expectedErr: errors.New("cannot mix ISO/disk images in request [vmdk anaconda-iso]"),
@@ -72,15 +77,15 @@ func TestImageTypes(t *testing.T) {
 		},
 		"bad-image-type": {
 			imageTypes:  []string{"bad"},
-			expectedErr: errors.New(`unsupported image type "bad", valid types are ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, vhd, vmdk`),
+			expectedErr: errors.New(`unsupported image type "bad", valid types are ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, raw-xz, vhd, vmdk`),
 		},
 		"bad-in-good": {
 			imageTypes:  []string{"ami", "raw", "vmdk", "qcow2", "something-else-what-is-this"},
-			expectedErr: errors.New(`unsupported image type "something-else-what-is-this", valid types are ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, vhd, vmdk`),
+			expectedErr: errors.New(`unsupported image type "something-else-what-is-this", valid types are ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, raw-xz, vhd, vmdk`),
 		},
 		"all-bad": {
 			imageTypes:  []string{"bad1", "bad2", "bad3", "bad4", "bad5", "bad42"},
-			expectedErr: errors.New(`unsupported image type "bad1", valid types are ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, vhd, vmdk`),
+			expectedErr: errors.New(`unsupported image type "bad1", valid types are ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, raw-xz, vhd, vmdk`),
 		},
 	}
 


### PR DESCRIPTION
This allows building compressed raw images from a bootc reference. 