### PR TITLE
experimental: `image-version`, `image-id`

### DIFF
--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -22,6 +22,7 @@ import (
 	"github.com/osbuild/image-builder/pkg/customizations/subscription"
 	"github.com/osbuild/image-builder/pkg/customizations/users"
 	"github.com/osbuild/image-builder/pkg/distro"
+	"github.com/osbuild/image-builder/pkg/experimentalflags"
 	"github.com/osbuild/image-builder/pkg/flatpak"
 	"github.com/osbuild/image-builder/pkg/image"
 	"github.com/osbuild/image-builder/pkg/manifest"
@@ -376,6 +377,13 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 
 	if tweaks := t.arch.distro.GetTweaks(); tweaks != nil && tweaks.RPMKeys != nil && tweaks.RPMKeys.BinPath != "" {
 		osc.RPMKeysBinary = tweaks.RPMKeys.BinPath
+	}
+
+	if imageID := experimentalflags.String("image-id"); imageID != "" {
+		osc.ImageID = imageID
+	}
+	if imageVersion := experimentalflags.String("image-version"); imageVersion != "" {
+		osc.ImageVersion = imageVersion
 	}
 
 	if sshdCust := c.GetSshd(); sshdCust != nil && imageConfig.SshdConfig != nil {

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -203,6 +203,13 @@ type OSCustomizations struct {
 
 	// Use this RPMKeysBinary from the tree instead of the default one
 	RPMKeysBinary string
+
+	// Environmental bits that can be set during the RPM stage to affect
+	// the installation of certain packages, for example when a distros
+	// `-release` package uses this to adjust what it writes into
+	// `os-release` or if we want to adjust `os-release ourselves.
+	ImageID      string
+	ImageVersion string
 }
 
 // OS represents the filesystem tree of the target image. This roughly
@@ -552,6 +559,7 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 	}
 
 	baseRPMOptions := &osbuild.RPMStageOptions{}
+
 	if p.OSCustomizations.ExcludeDocs {
 		baseRPMOptions.Exclude = &osbuild.Exclude{Docs: true}
 	}
@@ -573,6 +581,22 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 		baseRPMOptions.DisableDracut = true
 	}
 	baseRPMOptions.InstallLangs = p.OSCustomizations.InstallLangs
+
+	if len(p.OSCustomizations.ImageID) > 0 {
+		if baseRPMOptions.GenericEnv == nil {
+			baseRPMOptions.GenericEnv = make(map[string]string)
+		}
+
+		baseRPMOptions.GenericEnv["IMAGE_ID"] = p.OSCustomizations.ImageID
+	}
+
+	if len(p.OSCustomizations.ImageVersion) > 0 {
+		if baseRPMOptions.GenericEnv == nil {
+			baseRPMOptions.GenericEnv = make(map[string]string)
+		}
+
+		baseRPMOptions.GenericEnv["IMAGE_VERSION"] = p.OSCustomizations.ImageVersion
+	}
 
 	bootloader := p.platform.GetBootloader()
 


### PR DESCRIPTION
Allow use of the experimental flags to set `image-version` and `image-id`. We don't have a good idea yet how to pass these values otherwise and introducing command line flags is too early at this point.
    
This PR is based on top of [1].

[1]: https://github.com/osbuild/image-builder/pull/2586
