### PR TITLE
image-installer: apply kernel.append to installed system via kickstart (HMS-11181)

### DIFF
--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -929,12 +929,24 @@ func imageInstallerImage(t *imageType,
 	img.Kickstart.Keyboard = img.OSCustomizations.Keyboard
 	img.Kickstart.Timezone = &img.OSCustomizations.Timezone
 
+	// customizations.kernel.append (and image-type defaults) belong on the
+	// *installed* system. For image-installer the OS payload is a tar with no
+	// partition table, so org.osbuild.kernel-cmdline is never emitted for it.
+	// Pass the options through kickstart `bootloader --append` instead.
+	img.Kickstart.KernelOptionsAppend = append(img.Kickstart.KernelOptionsAppend, kernelOptions(t, customizations)...)
+
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 
 	img.InstallerCustomizations, err = installerCustomizations(t, bp.Customizations, options)
 	if err != nil {
 		return nil, err
 	}
+
+	// installerCustomizations() currently copies OS kernel options into
+	// InstallerCustomizations.KernelOptionsAppend, which anaconda_tar_installer
+	// then places on the ISO GRUB cmdline. Clear those so blueprint/OS kargs
+	// are not applied to the installer media itself.
+	img.InstallerCustomizations.KernelOptionsAppend = nil
 
 	img.ISOCustomizations, err = isoCustomizations(t, bp.Customizations)
 	if err != nil {
@@ -951,6 +963,7 @@ func imageInstallerImage(t *imageType,
 	img.InstallerCustomizations.EnabledAnacondaModules = append(img.InstallerCustomizations.EnabledAnacondaModules, anaconda.ModuleUsers)
 
 	if img.Kickstart.Unattended {
+		// These remain ISO-only installer boot options (not installed-system kargs).
 		img.InstallerCustomizations.KernelOptionsAppend = append(installerConfig.KickstartUnattendedExtraKernelOpts, img.InstallerCustomizations.KernelOptionsAppend...)
 	}
 

--- a/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/pkg/manifest/anaconda_installer_iso_tree.go
@@ -882,6 +882,17 @@ func (p *AnacondaInstallerISOTree) makeKickstartStages(stageOptions *osbuild.Kic
 	if sudoersPost := makeKickstartSudoersPost(kickstartOptions.SudoNopasswd); sudoersPost != nil {
 		stageOptions.Post = append(stageOptions.Post, *sudoersPost)
 	}
+
+	// Apply installed-system kernel arguments via kickstart. This is the
+	// supported path for liveimg/tar payload installers (image-installer),
+	// where the OS tree has no partition table and therefore never runs the
+	// org.osbuild.kernel-cmdline stage.
+	if len(kickstartOptions.KernelOptionsAppend) > 0 {
+		stageOptions.Bootloader = &osbuild.BootloaderOptions{
+			Append: strings.Join(kickstartOptions.KernelOptionsAppend, " "),
+		}
+	}
+
 	stages = append(stages, osbuild.NewKickstartStage(stageOptions))
 
 	if p.SubscriptionPipeline != nil {


### PR DESCRIPTION
## Summary
- Fixes `customizations.kernel.append` for classic `image-installer` ISOs.
- Previously, these options were applied to the installer ISO boot cmdline.
- Now they are applied to the installed system via kickstart `bootloader --append`.
- Installer-only unattended ISO options remain on the ISO boot cmdline.

## Why
Blueprint kernel append is intended for the installed system bootloader.
For `image-installer`, the OS payload is a liveimg tar (no disk partition table), so
`org.osbuild.kernel-cmdline` is not emitted for the payload. Kickstart is the correct path.

## Changes
- `pkg/distro/generic/images.go`: copy kernel options to `Kickstart.KernelOptionsAppend`, clear them from `InstallerCustomizations.KernelOptionsAppend`.
- `pkg/manifest/anaconda_installer_iso_tree.go`: emit `bootloader --append` in `makeKickstartStages`.

Related to #2175 (previous attempt, closed unmerged).