### PR TITLE
test: mock host arch for package search

### DIFF
--- a/cmd/image-builder/export_test.go
+++ b/cmd/image-builder/export_test.go
@@ -121,6 +121,14 @@ func MockManifestgenContainerResolver(fn manifestgen.ContainerResolverFunc) (res
 	}
 }
 
+func MockGetHostArch(f func() string) (restore func()) {
+	saved := getHostArch
+	getHostArch = f
+	return func() {
+		getHostArch = saved
+	}
+}
+
 func MockPkgSearcher(f func(distro.Distro, string, string, []rpmmd.RepoConfig, []string) (rpmmd.PackageList, error)) (restore func()) {
 	saved := pkgSearcher
 	pkgSearcher = f

--- a/cmd/image-builder/pkgsearch.go
+++ b/cmd/image-builder/pkgsearch.go
@@ -60,6 +60,10 @@ func (*jsonPkgFormatter) Output(w io.Writer, pkgs rpmmd.PackageList) error {
 
 // pkgSearcher performs the actual package search. It is a variable so
 // tests can replace it with a fake that doesn't require osbuild-depsolve-dnf.
+var getHostArch = func() string {
+	return arch.Current().String()
+}
+
 var pkgSearcher = func(d distro.Distro, archStr, cacheDir string, repos []rpmmd.RepoConfig, packages []string) (rpmmd.PackageList, error) {
 	solver := depsolvednf.NewSolver(d.ModulePlatformID(), d.Releasever(), archStr, d.Name(), cacheDir)
 	return solver.SearchMetadata(repos, packages)
@@ -111,7 +115,7 @@ func cmdPkgSearch(cmd *cobra.Command, args []string) error {
 	}
 
 	if archStr == "" {
-		archStr = arch.Current().String()
+		archStr = getHostArch()
 	}
 
 	imageType, err := cmd.Flags().GetString("type")

--- a/cmd/image-builder/pkgsearch_test.go
+++ b/cmd/image-builder/pkgsearch_test.go
@@ -72,6 +72,7 @@ func TestCmdPkgSearch(t *testing.T) {
 		expectedErr      string
 		expectedCacheDir string
 		mockHostDistro   string
+		mockHostArch     string
 	}{
 		{
 			name:         "with type",
@@ -129,12 +130,20 @@ func TestCmdPkgSearch(t *testing.T) {
 			name:         "default arch from host",
 			args:         []string{"pkgsearch", "bash", "--distro=centos-9"},
 			expectedPkgs: 2,
+			mockHostArch: "x86_64",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.mockHostDistro != "" {
 				restore := main.MockDistroGetHostDistroName(func() (string, error) {
 					return tc.mockHostDistro, nil
+				})
+				defer restore()
+			}
+
+			if tc.mockHostArch != "" {
+				restore := main.MockGetHostArch(func() string {
+					return tc.mockHostArch
 				})
 				defer restore()
 			}


### PR DESCRIPTION
Mock the host architecture for package search. When running tests on riscv64 the distribution used in the test does *not* have available repositories which causes the test to fail.

Mock it.