### PR TITLE
ci: fake podman calls

### DIFF
--- a/pkg/bootc/resolver_test.go
+++ b/pkg/bootc/resolver_test.go
@@ -184,11 +184,24 @@ func TestNewFakedUnhappy(t *testing.T) {
 	}
 
 	fakePodman := `#!/bin/sh
-if [ "$1" = "mount" ]; then
-    >&2 echo "forced-crash"
-    exit 2
-fi
-exec /usr/bin/podman "$@"
+case "$1" in
+    run)
+        echo "fake-container-id"
+        ;;
+    inspect)
+        echo "amd64"
+        ;;
+    mount)
+        >&2 echo "forced-crash"
+        exit 2
+        ;;
+    stop|rm)
+        exit 0
+        ;;
+    *)
+        exec /usr/bin/podman "$@"
+        ;;
+esac
 `
 	makeFakePodman(t, fakePodman)
 	_, err := bootc.NewContainer(testingImage)


### PR DESCRIPTION
Actually executing podman fails for likely reasons related to [1]; trying to work around it is very annoying. Mock things instead so we don't execute actual podman when not necessary.

[1]: https://github.com/actions/runner-images/issues/14473
