### PR TITLE
Run privileged unit tests on gitlab

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,11 +59,8 @@ jobs:
 
       - name: Run unit tests
         # Skip tests that resolve manifests from local container storage.
-        # They are tested separately (see below: requires root)
+        # They are tested separately (see gitlab-ci.yml)
         run: go test -count=1 -race -timeout 20m ./... -test.skip 'TestBlockingResolverLocalManifest|TestResolverLocalManifest|TestGetManifestLocal'
-
-      - name: Run tests for bootc container
-        run: sudo go test -count=1 ./pkg/distro/bootc/... ./pkg/distro/generic/...
 
       - name: Run depsolver tests with force-dnf to make sure it's not skipped
         run: go test -count=1 -race ./pkg/depsolvednf/... -force-dnf
@@ -72,43 +69,6 @@ jobs:
         run: |
           sudo sed -i 's/"use_dnf5": false/"use_dnf5": true/' /usr/lib/osbuild/solver.json
           go test -count=1 -race ./pkg/depsolvednf/... -force-dnf
-
-  container-resolver-tests:
-    name: "🛃 Container resolver tests"
-    runs-on: ubuntu-24.04
-    env:
-      # workaround for expired cert at source of indirect dependency
-      # (go.opencensus.io/trace)
-      GOPROXY: "https://proxy.golang.org|direct"
-
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: "1.24.12"
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          set-safe-directory: true
-
-      - name: Apt update
-        run: sudo apt update
-
-      # This is needed for the container resolver dependencies
-      - &apt_install_dependencies
-        name: Install libgpgme devel package
-        run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev podman
-
-      # We need to run the test as root, since we use the root
-      # containers-storage for the local resolvers
-      - name: Run unit tests for container resolve
-        run: sudo go test -count=1 ./pkg/container/... --force-local-resolver
-
-      - name: Run unit tests for bib container
-        run: sudo go test -count=1 ./pkg/bootc/... --fail-if-podman-missing
 
   unit-tests-cs:
     strategy:
@@ -189,8 +149,9 @@ jobs:
       - name: Install libvirt devel package
         run: sudo apt install -y libvirt-dev
 
-      # This is needed for the container upload dependencies
-      - *apt_install_dependencies
+      # This is needed for the container resolver dependencies
+      - name: Install libgpgme devel package
+        run: sudo apt install -y libgpgme-dev libbtrfs-dev libdevmapper-dev podman
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 ---
 stages:
   - init
+  - test
   - gen
   - build
   - ostree-gen
@@ -68,6 +69,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [centos-10, x86_64]":
@@ -83,6 +86,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [centos-9, aarch64]":
@@ -98,6 +103,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [centos-9, x86_64]":
@@ -113,6 +120,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [eln-11, aarch64]":
@@ -128,6 +137,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [eln-11, x86_64]":
@@ -143,6 +154,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [fedora-43, aarch64]":
@@ -158,6 +171,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [fedora-43, x86_64]":
@@ -173,6 +188,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [fedora-44, aarch64]":
@@ -188,6 +205,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [fedora-44, x86_64]":
@@ -203,6 +222,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [fedora-45, aarch64]":
@@ -218,6 +239,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [fedora-45, x86_64]":
@@ -233,6 +256,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-10.0, aarch64]":
@@ -248,6 +273,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-10.0, x86_64]":
@@ -263,6 +290,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-10.2, aarch64]":
@@ -278,6 +307,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-10.2, x86_64]":
@@ -293,6 +324,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-10.3, aarch64]":
@@ -308,6 +341,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-10.3, x86_64]":
@@ -323,6 +358,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-7.9, x86_64]":
@@ -338,6 +375,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-8.10, aarch64]":
@@ -353,6 +392,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-8.10, x86_64]":
@@ -368,6 +409,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-8.4, aarch64]":
@@ -383,6 +426,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-8.4, x86_64]":
@@ -398,6 +443,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-8.6, aarch64]":
@@ -413,6 +460,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-8.6, x86_64]":
@@ -428,6 +477,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-8.8, aarch64]":
@@ -443,6 +494,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-8.8, x86_64]":
@@ -458,6 +511,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.0, aarch64]":
@@ -473,6 +528,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.0, x86_64]":
@@ -488,6 +545,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.2, aarch64]":
@@ -503,6 +562,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.2, x86_64]":
@@ -518,6 +579,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.4, aarch64]":
@@ -533,6 +596,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.4, x86_64]":
@@ -548,6 +613,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.6, aarch64]":
@@ -563,6 +630,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.6, x86_64]":
@@ -578,6 +647,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.8, aarch64]":
@@ -593,6 +664,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.8, x86_64]":
@@ -608,6 +681,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.9, aarch64]":
@@ -623,6 +698,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 
 "generate-build-config: [rhel-9.9, x86_64]":
@@ -638,6 +715,8 @@ fail:
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 
 "image-build-trigger: [centos-10, aarch64]":
   stage: build
@@ -1069,7 +1148,7 @@ fail:
 
 
 "bootc-image-builder/test/test_build_cross.py [x86_64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-x86_64
@@ -1083,10 +1162,12 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_cross.py
+  needs:
+    - init
 
 
 "bootc-image-builder/test/test_build_disk.py [x86_64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-x86_64
@@ -1100,10 +1181,12 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_disk.py
+  needs:
+    - init
 
 
 "bootc-image-builder/test/test_build_iso.py [x86_64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-x86_64
@@ -1117,10 +1200,12 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_iso.py
+  needs:
+    - init
 
 
 "bootc-image-builder/test/test_manifest.py [x86_64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-x86_64
@@ -1134,10 +1219,12 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_manifest.py
+  needs:
+    - init
 
 
 "bootc-image-builder/test/test_opts.py [x86_64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-x86_64
@@ -1151,10 +1238,12 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_opts.py
+  needs:
+    - init
 
 
 "bootc-image-builder/test/test_build_cross.py [aarch64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-aarch64
@@ -1168,10 +1257,12 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_cross.py
+  needs:
+    - init
 
 
 "bootc-image-builder/test/test_build_disk.py [aarch64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-aarch64
@@ -1185,10 +1276,12 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_disk.py
+  needs:
+    - init
 
 
 "bootc-image-builder/test/test_manifest.py [aarch64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-aarch64
@@ -1202,10 +1295,12 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_manifest.py
+  needs:
+    - init
 
 
 "bootc-image-builder/test/test_opts.py [aarch64]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: aws/fedora-44-aarch64
@@ -1219,6 +1314,8 @@ fail:
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_opts.py
+  needs:
+    - init
 
 "generate-ostree-build-config: [centos-9, aarch64]":
   stage: ostree-gen
@@ -2052,6 +2149,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [centos-10, s390x]":
@@ -2076,6 +2175,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [centos-9, ppc64le]":
@@ -2100,6 +2201,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [centos-9, s390x]":
@@ -2124,6 +2227,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [eln-11, ppc64le]":
@@ -2148,6 +2253,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [eln-11, s390x]":
@@ -2172,6 +2279,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [fedora-43, ppc64le]":
@@ -2196,6 +2305,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [fedora-43, s390x]":
@@ -2220,6 +2331,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [fedora-44, ppc64le]":
@@ -2244,6 +2357,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [fedora-44, s390x]":
@@ -2268,6 +2383,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [fedora-45, ppc64le]":
@@ -2292,6 +2409,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [fedora-45, s390x]":
@@ -2316,6 +2435,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-10.0, ppc64le]":
@@ -2340,6 +2461,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-10.0, s390x]":
@@ -2364,6 +2487,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-10.2, ppc64le]":
@@ -2388,6 +2513,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-10.2, s390x]":
@@ -2412,6 +2539,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-10.3, ppc64le]":
@@ -2436,6 +2565,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-10.3, s390x]":
@@ -2460,6 +2591,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-8.10, ppc64le]":
@@ -2484,6 +2617,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-8.10, s390x]":
@@ -2508,6 +2643,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-8.4, ppc64le]":
@@ -2532,6 +2669,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-8.4, s390x]":
@@ -2556,6 +2695,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-8.6, ppc64le]":
@@ -2580,6 +2721,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-8.6, s390x]":
@@ -2604,6 +2747,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-8.8, ppc64le]":
@@ -2628,6 +2773,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-8.8, s390x]":
@@ -2652,6 +2799,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.0, ppc64le]":
@@ -2676,6 +2825,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.0, s390x]":
@@ -2700,6 +2851,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.2, ppc64le]":
@@ -2724,6 +2877,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.2, s390x]":
@@ -2748,6 +2903,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.4, ppc64le]":
@@ -2772,6 +2929,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.4, s390x]":
@@ -2796,6 +2955,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.6, ppc64le]":
@@ -2820,6 +2981,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.6, s390x]":
@@ -2844,6 +3007,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.8, ppc64le]":
@@ -2868,6 +3033,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.8, s390x]":
@@ -2892,6 +3059,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.9, ppc64le]":
@@ -2916,6 +3085,8 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 
 
 "generate-manifests: [rhel-9.9, s390x]":
@@ -2940,3 +3111,5 @@ fail:
       fi;
     done
     exit "$errors"
+  needs:
+    - init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3113,3 +3113,34 @@ fail:
     exit "$errors"
   needs:
     - init
+
+# The unit tests that require root and/or access to the host root container storage and sometimes misbehave on GitHub
+# runners
+"Unit tests [x86_64]":
+  stage: test
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-44-x86_64
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo go test -count=1 ./pkg/distro/bootc/... ./pkg/distro/generic/...
+    - sudo go test -count=1 ./pkg/container/... --force-local-resolver
+    - sudo go test -count=1 ./pkg/bootc/... --fail-if-podman-missing
+  needs:
+    - init
+
+
+# The unit tests that require root and/or access to the host root container storage and sometimes misbehave on GitHub
+# runners
+"Unit tests [aarch64]":
+  stage: test
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-44-aarch64
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo go test -count=1 ./pkg/distro/bootc/... ./pkg/distro/generic/...
+    - sudo go test -count=1 ./pkg/container/... --force-local-resolver
+    - sudo go test -count=1 ./pkg/bootc/... --fail-if-podman-missing
+  needs:
+    - init

--- a/pkg/bootc/resolver_test.go
+++ b/pkg/bootc/resolver_test.go
@@ -175,7 +175,6 @@ func makeFakePodman(t *testing.T, content string) {
 	err := os.WriteFile(filepath.Join(tmpdir, "podman"), []byte(content), 0755)
 	assert.NoError(t, err)
 }
-
 func TestNewFakedUnhappy(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("skipping test; not running as root")
@@ -193,10 +192,8 @@ exec /usr/bin/podman "$@"
 `
 	makeFakePodman(t, fakePodman)
 	_, err := bootc.NewContainer(testingImage)
-	// Exact error message matching fails in GitHub Actions because of changes
-	// in the podman package in the ubuntu runner. Checking only that it
-	// failed.
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, fmt.Sprintf("mounting %s container failed: ", testingImage))
+	assert.ErrorContains(t, err, "stderr:\nforced-crash")
 }
 
 func TestRootfsTypeHappy(t *testing.T) {

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -15,6 +15,7 @@ OSTREE_DISTROS = ["fedora", "rhel-8", "rhel-9", "centos-9"]
 BASE_CONFIG = """---
 stages:
   - init
+  - test
   - gen
   - build
   - ostree-gen
@@ -68,6 +69,8 @@ GEN_TEMPLATE = """
   artifacts:
     paths:
       - build-config.yml
+  needs:
+    - init
 """
 
 TRIGGER_TEMPLATE = """
@@ -137,11 +140,13 @@ MANIFEST_GEN_TEMPLATE = """
       fi;
     done
     exit "$errors"
+  needs:
+    - init
 """
 
 BOOTC_IMAGE_BUILDER_TEMPLATE = """
 "{test_file_path} [{arch}]":
-  stage: gen
+  stage: test
   extends: .terraform
   variables:
     RUNNER: {runner}-{arch}
@@ -155,6 +160,8 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
     - sudo ./test/scripts/install-dependencies
     - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
     - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests {test_file_path}
+  needs:
+    - init
 """
 
 

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -164,6 +164,23 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
     - init
 """
 
+UNIT_TESTS_TEMPLATE = """
+# The unit tests that require root and/or access to the host root container storage and sometimes misbehave on GitHub
+# runners
+"Unit tests [{arch}]":
+  stage: test
+  extends: .terraform
+  variables:
+    RUNNER: {runner}-{arch}
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo go test -count=1 ./pkg/distro/bootc/... ./pkg/distro/generic/...
+    - sudo go test -count=1 ./pkg/container/... --force-local-resolver
+    - sudo go test -count=1 ./pkg/bootc/... --fail-if-podman-missing
+  needs:
+    - init
+"""
+
 
 def sort_configs(configs):
     return sorted(configs, key=lambda img: img["distro"]+img["arch"]+img["image-type"])
@@ -242,6 +259,14 @@ def main():
                 test_file_path=test_file_path,
             ))
 
+    # run select unit tests on the default runner for both arches
+    test_stage = []
+    for arch in ARCHITECTURES:
+        test_stage.append(UNIT_TESTS_TEMPLATE.format(
+            runner=RUNNER,
+            arch=arch,
+        ))
+
     with open(config_path, "w", encoding="utf-8") as config_file:
         config_file.write(BASE_CONFIG.format(runner=RUNNER))
         config_file.write(testlib.core.BASE_CONFIG)
@@ -250,6 +275,7 @@ def main():
         config_file.write("\n".join(ostree_gen_stage))
         config_file.write("\n".join(ostree_trigger_stage))
         config_file.write("\n".join(man_gen_stage))
+        config_file.write("\n".join(test_stage))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some of our unit tests require root and/or access to the host container storage.  These become tricky to run in GitHub actions because of a combination of a couple of reasons.  The Ubuntu runners were recently updated and seem to be having a lot of issues with podman.  Running them in the Fedora container that we use for the other unit tests has issues with using the container storage.

Run these tests in GitLab where we have better control of the environment.  This also much more closely matches production environments.

---

This is a follow-up from #2602.  The tests there succeeded, but I've been seeing some intermittent failures on the resolver tests still, like this one https://github.com/osbuild/image-builder/actions/runs/32161286115/job/95790547360?pr=2600