### PR TITLE
pkg/container: fix overriding sourceSpec input val

### DIFF
--- a/pkg/container/resolver.go
+++ b/pkg/container/resolver.go
@@ -73,11 +73,11 @@ func (r *asyncResolver) Add(spec SourceSpec) {
 	go func() {
 		ctx, cancelTimeout := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancelTimeout()
-		spec, err := client.Resolve(ctx, spec.Name, spec.Local)
+		resolved, err := client.Resolve(ctx, spec.Name, spec.Local)
 		if err != nil {
 			err = fmt.Errorf("'%s': %w", spec.Source, err)
 		}
-		r.queue <- resolveResult{spec: spec, err: err}
+		r.queue <- resolveResult{spec: resolved, err: err}
 	}()
 }
 

--- a/pkg/container/resolver_test.go
+++ b/pkg/container/resolver_test.go
@@ -122,6 +122,19 @@ func TestResolverFail(t *testing.T) {
 	assert.Len(t, specs, 0)
 }
 
+func TestResolverErrorIncludesSource(t *testing.T) {
+	resolver := container.NewResolver("amd64")
+	missing := "localhost/image-builder-missing-payload:debug"
+	_, err := resolver.Resolve(container.SourceSpec{
+		Source: missing,
+		Name:   missing,
+		Local:  true,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), missing)
+	assert.NotRegexp(t, `failed to resolve container: '':`, err.Error())
+}
+
 func TestResolverLocalManifest(t *testing.T) {
 	currentUser, err := user.Current()
 	assert.NoError(t, err)


### PR DESCRIPTION
On failure, Resolve returns an empty Spec. Add assigned that value the same variable as the input argument, so the error wrap used a new value returned from a failed function instead of the image that failed to resolve.