### PR TITLE
many: support `kernel.version` customization

### DIFF
--- a/cmd/check-host-config/check/kernel.go
+++ b/cmd/check-host-config/check/kernel.go
@@ -34,6 +34,19 @@ func kernelCheck(meta *Metadata, config *buildconfig.BuildConfig) error {
 		log.Printf("Kernel name check passed: %s is installed\n", expected.Name)
 	}
 
+	if expected.Version != "" {
+		stdout, _, _, err := ExecString("rpm", "-q", "--queryformat", "%{VERSION}-%{RELEASE}", expected.Name)
+		if err != nil {
+			return Fail("failed to query kernel version:", err)
+		}
+
+		if !strings.HasPrefix(stdout, expected.Version) {
+			return Fail("kernel version mismatch: expected", expected.Version, "got", stdout)
+		}
+
+		log.Printf("Kernel version check passed: %s matches %s\n", stdout, expected.Version)
+	}
+
 	if len(expected.Append) > 0 {
 		cmdline, err := ReadFile("/proc/cmdline")
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/blueprint v1.32.0
+	github.com/osbuild/blueprint v1.33.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/blueprint v1.32.0 h1:5uZ2SDPI+pUdmFn5T5G6H8mUw18wK9NzxQGiJ0QQ70E=
-github.com/osbuild/blueprint v1.32.0/go.mod h1:zFiI1IULOe85F/OM8YPhHek7YCpWZENJoxZezJgRvto=
+github.com/osbuild/blueprint v1.33.0 h1:TewO/XA3QZ/HBYKPycsLBOSz7x++o9iay4wyG8sGYOQ=
+github.com/osbuild/blueprint v1.33.0/go.mod h1:zFiI1IULOe85F/OM8YPhHek7YCpWZENJoxZezJgRvto=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -53,8 +53,10 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 		// an argument as fallback or make it not return the standard "kernel"
 		// when it's unset.
 		osc.KernelName = c.GetKernel().Name
+		osc.KernelVersion = c.GetKernel().Version
 		if imageConfig.DefaultKernelName != nil {
 			osc.KernelName = *imageConfig.DefaultKernelName
+			osc.KernelVersion = ""
 		}
 		osc.KernelOptionsAppend = kernelOptions(t, c)
 		if imageConfig.KernelOptionsBootloader != nil {

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -72,6 +72,11 @@ type OSCustomizations struct {
 	// package.
 	KernelName string
 
+	// KernelVersion optionally pins the kernel to a specific version.
+	// When set, the version is appended to KernelName as a DNF version
+	// constraint for depsolving (e.g. "kernel-6.12.0-211").
+	KernelVersion string
+
 	// KernelOptionsAppend are appended to the kernel commandline
 	KernelOptionsAppend []string
 
@@ -283,8 +288,11 @@ func (p *OS) getPackageSetChain(Distro) ([]rpmmd.PackageSet, error) {
 	}
 
 	if p.OSCustomizations.KernelName != "" {
-		// kernel is considered part of the platform package set
-		platformPackages = append(platformPackages, p.OSCustomizations.KernelName)
+		kernelSpec := p.OSCustomizations.KernelName
+		if p.OSCustomizations.KernelVersion != "" {
+			kernelSpec += "-" + p.OSCustomizations.KernelVersion
+		}
+		platformPackages = append(platformPackages, kernelSpec)
 	}
 
 	customizationPackages := make([]string, 0)


### PR DESCRIPTION
Support optionally pinning the kernel version through the kernel customization. This can be useful when debugging with older kernel packages or when dealing with certain NVIDIA drivers.

---

Will need https://github.com/osbuild/blueprint/pull/55 to land first so draft.