### PR TITLE
depsolver: serialize priority field

### DIFF
--- a/pkg/depsolvednf/v2.go
+++ b/pkg/depsolvednf/v2.go
@@ -46,6 +46,7 @@ type v2Repository struct {
 	SSLClientCert  string   `json:"sslclientcert,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
+	Priority       *int     `json:"priority,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
 }
 
@@ -423,6 +424,7 @@ func (h *v2Handler) reposFromRPMMD(cfg *solverConfig, rpmRepos []rpmmd.RepoConfi
 			SSLClientKey:   rr.SSLClientKey,
 			SSLClientCert:  rr.SSLClientCert,
 			ModuleHotfixes: common.ClonePtr(rr.ModuleHotfixes),
+			Priority:       common.ClonePtr(rr.Priority),
 		}
 
 		if rr.IgnoreSSL != nil {

--- a/pkg/depsolvednf/v2_test.go
+++ b/pkg/depsolvednf/v2_test.go
@@ -230,6 +230,11 @@ func TestV2HandlerMakeDepsolveRequest(t *testing.T) {
 		SSLClientCert: "/cert",
 		SSLClientKey:  "/key",
 	}
+	priorityRepo := rpmmd.RepoConfig{
+		Name:     "priority-repo",
+		BaseURLs: []string{"https://example.org/priority"},
+		Priority: common.ToPtr(10),
+	}
 
 	testCases := []struct {
 		name        string
@@ -481,6 +486,35 @@ func TestV2HandlerMakeDepsolveRequest(t *testing.T) {
 					"optional-metadata": ["filelists"]
 				}
 			}`, baseOS.Hash(), appstream.Hash(), mtlsRepo.Hash()),
+		},
+		{
+			name: "priority passed",
+			packageSets: []rpmmd.PackageSet{
+				{
+					Include:      []string{"pkg1"},
+					Repositories: []rpmmd.RepoConfig{baseOS, appstream, priorityRepo},
+				},
+			},
+			wantJSON: fmt.Sprintf(`{
+				"api_version": 2,
+				"command": "depsolve",
+				"module_platform_id": "platform:el8",
+				"releasever": "8",
+				"arch": "x86_64",
+				"cachedir": "/cache",
+				"arguments": {
+					"repos": [
+						{"id": %[1]q, "name": "baseos", "baseurl": ["https://example.org/baseos"]},
+						{"id": %[2]q, "name": "appstream", "baseurl": ["https://example.org/appstream"]},
+						{"id": %[3]q, "name": "priority-repo", "baseurl": ["https://example.org/priority"], "priority": 10}
+					],
+					"transactions": [
+						{"package-specs": ["pkg1"], "repo-ids": [%[1]q, %[2]q, %[3]q], "install_weak_deps": false}
+					],
+					"root_dir": "/root",
+					"optional-metadata": ["filelists"]
+				}
+			}`, baseOS.Hash(), appstream.Hash(), priorityRepo.Hash()),
 		},
 		{
 			name: "2 transactions + withSbom flag",


### PR DESCRIPTION
We already allowed the priority field in repository configs but never actually pass it on to the dependency solver. Let's do that; it already supports receiving it.

We explicitly don't include it in the reverse as this is listed as an input only field in the depsolver on the `osbuild` side.

---

I'll be needing this for the omni kernels on the riscv PR as they come from a separate repository with higher priority as the omni kernels sometimes lag the generic kernel.