### PR TITLE
rootless: Don't disallow --in-vm in rootless non-container

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -673,10 +673,6 @@ func cmdBuild(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if runInVm && !setup.IsContainer() {
-		return fmt.Errorf("running in VM outside container is not supported yet")
-	}
-
 	img, err := getImage(cmd, args)
 	if err != nil {
 		return err


### PR DESCRIPTION
This just removes an error as this works now.

Marking this draft, because really it just kinda works, the following MRs are needed for it to work completely:

- [x] https://github.com/osbuild/image-builder/pull/2617
- [ ] https://github.com/osbuild/osbuild/pull/2552
- [ ] https://github.com/osbuild/osbuild/pull/2551
- [x] https://github.com/osbuild/osbuild/pull/2550
