### PR TITLE
Enable bootc-image-builder ISO tests on aarch64 [HMS-11073]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1224,6 +1224,25 @@ fail:
     - init
 
 
+"bootc-image-builder/test/test_build_iso.py [aarch64]":
+  stage: test
+  extends: .terraform
+  variables:
+    RUNNER: aws/fedora-44-aarch64
+  rules:
+    # 1. Skip the job if we're on the github merge queue
+    - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
+      when: never
+    # 2. Fallback rule for any other branch name
+    - if: '$CI_COMMIT_BRANCH'
+  script:
+    - sudo ./test/scripts/install-dependencies
+    - sudo mkdir -pv /var/tmp/bootc-image-builder-tests
+    - sudo -E XDG_RUNTIME_DIR= PYTHONPATH=. pytest -vv --basetemp=/var/tmp/bootc-image-builder-tests bootc-image-builder/test/test_build_iso.py
+  needs:
+    - init
+
+
 "bootc-image-builder/test/test_manifest.py [aarch64]":
   stage: test
   extends: .terraform

--- a/bootc-image-builder/test/test_build_disk.py
+++ b/bootc-image-builder/test/test_build_disk.py
@@ -145,7 +145,7 @@ def registry_conf_fixture(shared_tmpdir, request):
             "--restart", "always",
             "--name", registry_container_name,
             # We use a copy of docker.io registry to avoid running into docker.io pull rate limits
-            "ghcr.io/osbuild/bootc-image-builder/registry:2"
+            "ghcr.io/osbuild/image-builder/registry:2"
         ], check=True)
 
     registry_container_state = subprocess.run([

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -281,11 +281,6 @@ def main():
     # Run bootc-image-builder tests on Fedora 44 only for now (both arches)
     for arch in ("x86_64", "aarch64"):
         for test_file_path in collect_bib_tests():
-            # EXCEPTION: This test is failing during setup and it's not related to the test itself. Investigate the
-            # issue, fix, and re-enable.
-            # https://gitlab.com/redhat/services/products/image-builder/ci/images/-/jobs/15479057832
-            if arch == "aarch64" and test_file_path.endswith("test_build_iso.py"):
-                continue
             trigger_stage.append(BOOTC_IMAGE_BUILDER_TEMPLATE.format(
                 runner=RUNNER,
                 arch=arch,


### PR DESCRIPTION
**bootc-image-builder: update registry ref**

We use a clone of the registry container, pushed to our own ghcr.io
namespace, so that we don't hit dockerhub rate limits when running too
many tests.  The new ref has been updated with the latest amd64 and
arm64 registry containers.  The old one under bootc-image-builder only
had a copy of the amd64 container which was causing issues with the ISO
tests on aarch64.

---

**ci: run test_build_iso on aarch64**

With the registry container now having both architectures, the tests
should be ok now.

---
