### PR TITLE
bootc-image-builder: boot AMI in AWS after cross-arch building [HMS-11073]

### DIFF
--- a/bootc-image-builder/test/test_build_cross.py
+++ b/bootc-image-builder/test/test_build_cross.py
@@ -1,7 +1,9 @@
 import platform
 
+import imgtestlib as testlib
 import pytest
 
+import testutil
 # pylint: disable=unused-import
 from test_build_disk import (ImageBuildResult, assert_disk_image_boots,
                              build_container_fixture, gpg_conf_fixture,
@@ -12,9 +14,25 @@ from testcases import gen_testcases
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
 @pytest.mark.parametrize("image_type", gen_testcases("ami-cross"), indirect=["image_type"])
-@pytest.mark.skip("disabled while rewriting to boot in AWS")
-def test_image_boots_cross(image_type):
-    assert_disk_image_boots(image_type)
+def test_image_boots_cross(image_type: ImageBuildResult, force_aws_upload):
+    if not testutil.write_aws_creds("/dev/null"):
+        if force_aws_upload:
+            # upload forced but credentials aren't set
+            raise RuntimeError("AWS credentials not available")
+        pytest.skip("AWS credentials not available (upload not forced)")
+
+    # check that upload progress is in the output log. Uploads looks like:
+    # 4.30 GiB / 10.00 GiB [------------>____________] 43.02% 58.04 MiB p/s
+    assert "] 100.00%" in image_type.bib_output
+
+    arch = {
+        "amd64": "x86_64",
+        "arm64": "aarch64",
+    }[image_type.img_arch]
+    with testlib.vm.AWS(image_type.metadata["ami_id"], arch) as test_vm:
+        test_vm.run("true", user=image_type.username, password=image_type.password)
+        ret = test_vm.run(["echo", "hello"], user=image_type.username, password=image_type.password)
+        assert "hello" in ret.stdout
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")

--- a/bootc-image-builder/test/test_build_cross.py
+++ b/bootc-image-builder/test/test_build_cross.py
@@ -11,13 +11,13 @@ from testcases import gen_testcases
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
-@pytest.mark.parametrize("image_type", gen_testcases("qemu-cross"), indirect=["image_type"])
+@pytest.mark.parametrize("image_type", gen_testcases("ami-cross"), indirect=["image_type"])
 @pytest.mark.skip("disabled while rewriting to boot in AWS")
 def test_image_boots_cross(image_type):
     assert_disk_image_boots(image_type)
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="boot test only runs on linux right now")
-@pytest.mark.parametrize("image_type", gen_testcases("qemu-cross"), indirect=["image_type"])
+@pytest.mark.parametrize("image_type", gen_testcases("ami-cross"), indirect=["image_type"])
 def test_image_builds_cross(image_type: ImageBuildResult):
     assert image_type.img_path.exists()

--- a/bootc-image-builder/test/testcases.py
+++ b/bootc-image-builder/test/testcases.py
@@ -94,12 +94,12 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             TestCaseC9S(image="anaconda-iso"),
             TestCaseC10S(image="anaconda-iso"),
         ]
-    if what == "qemu-cross":
+    if what == "ami-cross":
         arch = platform.machine()
         if arch == "x86_64":
-            return [TestCaseC10S(image="raw", target_arch="arm64")]
+            return [TestCaseC10S(image="ami", target_arch="arm64")]
         if arch == "aarch64":
-            return [TestCaseC10S(image="raw", target_arch="amd64")]
+            return [TestCaseC10S(image="ami", target_arch="amd64")]
         raise RuntimeError(f"unknown host plarform architecture for cross-arch testing: {arch}")
     if what == "qemu-boot":
         return [

--- a/bootc-image-builder/test/testcases.py
+++ b/bootc-image-builder/test/testcases.py
@@ -100,7 +100,7 @@ def gen_testcases(what):  # pylint: disable=too-many-return-statements
             return [TestCaseC10S(image="ami", target_arch="arm64")]
         if arch == "aarch64":
             return [TestCaseC10S(image="ami", target_arch="amd64")]
-        raise RuntimeError(f"unknown host plarform architecture for cross-arch testing: {arch}")
+        raise RuntimeError(f"unknown host platform architecture for cross-arch testing: {arch}")
     if what == "qemu-boot":
         return [
             # test default partitioning


### PR DESCRIPTION
**bootc-image-builder: rename qemu-cross test case to ami-cross**

The test case was already building a raw image, which is identical to
the ami.  Explicitly building an "ami" (as opposed to "raw") takes care
of uploading to AWS.

---

**bootc-image-builder: boot AMI in AWS after cross-arch building**

Boot testing the artifact of a cross-arch build with emulation is slow
and unreliable.  For cross-arch tests, build and upload AMIs and test
them on machines that match the image architecture.

---
