### PR TITLE
client: Respect CONTAINERS_GRAPHROOT and CONTAINERS_RUNROOT

### DIFF
--- a/pkg/bootc/resolver.go
+++ b/pkg/bootc/resolver.go
@@ -99,7 +99,10 @@ func (cnt *Container) start(network string, mountSecrets bool) error {
 		"--entrypoint", "sleep", // The entrypoint might be arbitrary, so let's just override it with sleep, we don't want to run anything
 	}
 
-	if isRootless, _ := isPodmanRootless(); isRootless {
+	// If the store location is overridden via the environment (CONTAINERS_GRAPHROOT
+	// / CONTAINERS_RUNROOT), podman picks those up on its own, so leave storeOpts
+	// empty and don't add flags that would override them.
+	if isRootless, _ := isPodmanRootless(); isRootless && os.Getenv("CONTAINERS_GRAPHROOT") == "" {
 		// When running bc-i-b In a rootless container, its typically the case that /var/lib/containers/storage
 		// is a bind-mount of ~/.local/share/containers/storage, and we can't use this directly with podman
 		// because it will complain:
@@ -107,6 +110,7 @@ func (cnt *Container) start(network string, mountSecrets bool) error {
 		//     static dir "/var/lib/containers/storage/libpod": database configuration mismatch
 		// To avoid this we use an empty graphroot, and point --imagestore at /var/lib/containers/storage.
 		// This means the database is in the right place, and we only look at the image layers in the real store.
+		// We don't do this if a custom CONTAINERS_GRAPHROOT is in use though.
 		cnt.storeOpts = []string{
 			"--root=/run/osbuild/containers/store",
 			"--imagestore=/var/lib/containers/storage",

--- a/pkg/container/client.go
+++ b/pkg/container/client.go
@@ -138,6 +138,15 @@ func defaultStorePaths() (string, string) {
 		}
 	}
 
+	// Allow callers to point us at a custom store (e.g. a build-image store)
+	// via the environment, overriding the computed defaults.
+	if v := os.Getenv("CONTAINERS_GRAPHROOT"); v != "" {
+		graphRoot = v
+	}
+	if v := os.Getenv("CONTAINERS_RUNROOT"); v != "" {
+		runRoot = v
+	}
+
 	return graphRoot, runRoot
 }
 

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -153,7 +153,7 @@ func validateCanRunTargetArch(targetArch string) error {
 
 func ValidateHasContainerTags(imgref string) error {
 	extraOpts := []string{}
-	if isRootless, _ := podmanutil.IsRootless(); isRootless {
+	if isRootless, _ := podmanutil.IsRootless(); isRootless && os.Getenv("CONTAINERS_GRAPHROOT") == "" {
 		// When running image-builder in a rootless container, its typically the case that /var/lib/containers/storage
 		// is a bind-mount of ~/.local/share/containers/storage, and we can't use this directly with podman
 		// because it will complain:
@@ -161,6 +161,7 @@ func ValidateHasContainerTags(imgref string) error {
 		//     static dir "/var/lib/containers/storage/libpod": database configuration mismatch
 		// To avoid this we use an empty graphroot, and point --imagestore at /var/lib/containers/storage.
 		// This means the database is in the right place, and we only look at the image layers in the real store.
+		// We don't do this if a custom CONTAINERS_GRAPHROOT is in use though.
 		extraOpts = append(extraOpts,
 			"--root=/run/osbuild/containers/store",
 			"--imagestore=/var/lib/containers/storage")


### PR DESCRIPTION
These are set by podman unshare when in a rootless mode so that e.g. podman will pick up ~/.local/share/container/storage instead of /var/lib/container/storage even though uid is 0 in the unshare.

It is also a useful way to make image-builder use a custom container storage.

This matches what osbuild already does since:
 https://github.com/osbuild/osbuild/pull/2550