### PR TITLE
pkg/crypt: add support for yescrypt hashed passwords

### DIFF
--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -42,13 +42,13 @@ func genSalt(length int) (string, error) {
 // PasswordIsCrypted returns true if the password appears to be an encrypted
 // one, according to a very simple heuristic.
 //
-// Any string starting with one of $2$, $6$ or $5$ is considered to be
+// Any string starting with one of $2$, $6$, $5$ or $y$ is considered to be
 // encrypted. Any other string is consdirede to be unencrypted.
 //
 // This functionality is taken from pylorax.
 func PasswordIsCrypted(s string) bool {
 	// taken from lorax src: src/pylorax/api/compose.py:533
-	prefixes := [...]string{"$2b$", "$6$", "$5$"}
+	prefixes := [...]string{"$2b$", "$6$", "$5$", "$y$"}
 
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(s, prefix) {

--- a/pkg/crypt/crypt_test.go
+++ b/pkg/crypt/crypt_test.go
@@ -28,6 +28,10 @@ func Test_crypt_PasswordIsCrypted(t *testing.T) {
 			password: "$6$1234567890123456$d.pgKQFaiD8bRiExg5NesbGR/3u51YvxeYaQXPzx4C6oSYREw8VoReiuYZjx0V9OhGVTZFqhc6emAxT1RC5BV.",
 			want:     true,
 		}, {
+			name:     "yescrypt",
+			password: "$y$j9T$1234567890123456$A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0U1v2",
+			want:     true,
+		}, {
 			name:     "scrypt",
 			password: "$7$123456789012345", //not actual hash output from scrypt
 			want:     false,


### PR DESCRIPTION
Detect yescript hashes via the `$y$` prefix.
Before, if a yescript hash was provided, it got re-hashed with sha-512, leading to broken login credentials.