### PR TITLE
cmd/image-builder: only run findDistro once

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -500,10 +500,7 @@ func generateManifest(pbar progress.ProgressBar, cmd *cobra.Command, args []stri
 		return nil, err
 	}
 	if bootcRef == "" {
-		distroStr, err = findDistro(distroStr, bp.Distro)
-		if err != nil {
-			return nil, err
-		}
+		distroStr = img.ImgType.Arch().Distro().Name()
 	} else {
 		distroStr = "bootc-based"
 		// XXX: hack to skip repo loading for the bootc image.


### PR DESCRIPTION
`findDistro` should only be run once per command, when using it as an input for `getOneImage`. Once an `imagefilter.Result` is created, the distro can be accessed through the `distro.ImageType` interface.

`getOneImage` is called for `describe`, `pkgsearch`, `manifest` and `build`.