### PR TITLE
cmd/image-builder: upload messages progress bar

### DIFF
--- a/cmd/image-builder/upload.go
+++ b/cmd/image-builder/upload.go
@@ -68,7 +68,16 @@ func uploadImageWithProgress(uploader cloud.Uploader, pbar progress.ProgressBar,
 	pbar.Start()
 	pbar.SetPulseMsgf("Uploading step")
 
-	return uploader.UploadAndRegister(r, size, osStderr)
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	go func() {
+		scanner := bufio.NewScanner(pr)
+		for scanner.Scan() {
+			pbar.SetPulseMsgf("%s", scanner.Text())
+		}
+	}()
+
+	return uploader.UploadAndRegister(r, size, pw)
 }
 
 func uploaderCheckWithProgress(pbar progress.ProgressBar, uploader cloud.Uploader) error {


### PR DESCRIPTION
During upload, status messages (e.g. "Registering AMI...") are written directly to stderr while the progress bar is still rendering sequences to the same stream. This causes garbage terminal output during the registration step.

Closes: #2625