### PR TITLE
gce: ensure disk images are GiB-aligned

### DIFF
--- a/data/distrodefs/bootc-generic/imagetypes.yaml
+++ b/data/distrodefs/bootc-generic/imagetypes.yaml
@@ -153,6 +153,7 @@ image_types:
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     exports: ["gce"]
+    disk_image_gib_aligned: true
 
   ova:
     <<: *raw_image_type

--- a/data/distrodefs/eln-11/disk.yaml
+++ b/data/distrodefs/eln-11/disk.yaml
@@ -820,6 +820,7 @@ image_types:
     exports: ["archive"]
     bootable: true
     default_size: "20 GiB"
+    disk_image_gib_aligned: true
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_uefi_platform

--- a/data/distrodefs/fedora/imagetypes.yaml
+++ b/data/distrodefs/fedora/imagetypes.yaml
@@ -2765,6 +2765,7 @@ image_types:
     filename: "image.tar.gz"
     mime_type: "application/gzip"
     exports: ["archive"]
+    disk_image_gib_aligned: true
     # Note the larger size here, upstream descriptions mention that GCE has bad perf with small disks
     default_size: "10 GiB"
     package_sets:

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -2267,6 +2267,7 @@ image_types:
     exports: ["archive"]
     bootable: true
     default_size: "20 GiB"
+    disk_image_gib_aligned: true
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_uefi_platform

--- a/data/distrodefs/rhel-8/imagetypes.yaml
+++ b/data/distrodefs/rhel-8/imagetypes.yaml
@@ -2502,6 +2502,7 @@ image_types:
     exports: ["archive"]
     bootable: true
     default_size: "20 GiB"
+    disk_image_gib_aligned: true
     # The configuration for non-RHUI images does not touch the RHSM configuration at all.
     # https://issues.redhat.com/browse/COMPOSER-2157
     image_config: &gce_image_config

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -2696,6 +2696,7 @@ image_types:
     exports: ["archive"]
     bootable: true
     default_size: "20 GiB"
+    disk_image_gib_aligned: true
     required_partition_sizes: *default_required_dir_sizes
     platforms:
       - <<: *x86_64_uefi_platform

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -558,6 +558,7 @@ type ImageTypeYAML struct {
 	InstallWeakDeps *bool `yaml:"install_weak_deps"`
 
 	DiskImageVPCForceSize *bool `yaml:"disk_image_vpc_force_size"`
+	DiskImageGiBAligned   bool  `yaml:"disk_image_gib_aligned"`
 
 	SupportedPartitioningModes []partition.PartitioningMode `yaml:"supported_partitioning_modes"`
 

--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -962,6 +962,9 @@ func (t *bootcImageType) genPartitionTableFsCust(basept *disk.PartitionTable, fs
 	if basept.Size != 0 {
 		imageSize = basept.Size
 	}
+	if t.ImageTypeYAML.DiskImageGiBAligned {
+		imageSize = datasizes.Size((uint64(imageSize) + uint64(datasizes.GiB) - 1) &^ (uint64(datasizes.GiB) - 1))
+	}
 
 	return disk.NewPartitionTable(basept, fsCustomizations, imageSize, partitioningMode, t.arch.arch, nil, bd.defaultFs, rng)
 }

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -134,6 +134,9 @@ func (t *imageType) Size(size uint64) uint64 {
 	if size == 0 {
 		size = t.ImageTypeYAML.DefaultSize.Uint64()
 	}
+	if t.ImageTypeYAML.DiskImageGiBAligned {
+		size = (size + datasizes.GibiByte - 1) &^ (datasizes.GibiByte - 1)
+	}
 	return size
 }
 


### PR DESCRIPTION
GCP requires disk files to be aligned to a GiB boundary. Add a disk_image_gib_aligned flag to ImageTypeYAML and enable it for all GCE image type definitions.

Closes: #2413