### PR TITLE
many: Go templates for default_name

### DIFF
--- a/data/distrodefs/eln-11/wsl.yaml
+++ b/data/distrodefs/eln-11/wsl.yaml
@@ -18,7 +18,7 @@ image_types:
             enabled: true
             icon: /usr/share/pixmaps/fedora-logo.ico
           oobe:
-            default_name: Fedora-ELN-%s
+            default_name: "Fedora-ELN-{{.Distro.VersionString}}"
             default_uid: 1000
     package_sets:
       os:

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -1918,7 +1918,7 @@ image_types:
                 <<: *wsl_distribution_config
                 oobe:
                   <<: *wsl_distribution_oobe_config
-                  default_name: RedHatEnterpriseLinux-%s
+                  default_name: "RedHatEnterpriseLinux-{{.Distro.VersionString}}"
         "wsl config for almalinux":
           when:
             distro_name: "almalinux"
@@ -1929,7 +1929,7 @@ image_types:
                 <<: *wsl_distribution_config
                 oobe:
                   <<: *wsl_distribution_oobe_config
-                  default_name: AlmaLinux-%s
+                  default_name: "AlmaLinux-{{.Distro.VersionString}}"
         "wsl config for rocky":
           when:
             distro_name: "rocky"
@@ -1940,7 +1940,7 @@ image_types:
                 <<: *wsl_distribution_config
                 oobe:
                   <<: *wsl_distribution_oobe_config
-                  default_name: Rocky-%s
+                  default_name: "Rocky-{{.Distro.VersionString}}"
         "wsl config for almalinuxkitten":
           when:
             distro_name: "almalinux_kitten"

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -2464,7 +2464,7 @@ image_types:
                 <<: *wsl_distribution_config
                 oobe:
                   <<: *wsl_distribution_oobe_config
-                  default_name: RedHatEnterpriseLinux-%s
+                  default_name: "RedHatEnterpriseLinux-{{.Distro.VersionString}}"
         "wsl config for almalinux":
           when:
             distro_name: "almalinux"
@@ -2475,7 +2475,7 @@ image_types:
                 <<: *wsl_distribution_config
                 oobe:
                   <<: *wsl_distribution_oobe_config
-                  default_name: AlmaLinux-%s
+                  default_name: "AlmaLinux-{{.Distro.VersionString}}"
         "wsl config for rocky":
           when:
             distro_name: "rocky"
@@ -2486,7 +2486,7 @@ image_types:
                 <<: *wsl_distribution_config
                 oobe:
                   <<: *wsl_distribution_oobe_config
-                  default_name: Rocky-%s
+                  default_name: "Rocky-{{.Distro.VersionString}}"
         "cloud-init config for non-centos":
           when:
             not_distro_name: "centos"

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -830,7 +830,7 @@ func (imgType *ImageTypeYAML) PartitionTable(id distro.ID, archName string) (*di
 }
 
 // ImageConfig returns the image type specific ImageConfig
-func (imgType *ImageTypeYAML) ImageConfig(id distro.ID, archName string) *distro.ImageConfig {
+func (imgType *ImageTypeYAML) ImageConfig(id distro.ID, archName string) (*distro.ImageConfig, error) {
 	imgConfig := imgType.ImageConfigYAML.ImageConfig
 	for _, cond := range imgType.ImageConfigYAML.Conditions {
 		if cond.When.Eval(id, archName) {
@@ -839,7 +839,10 @@ func (imgType *ImageTypeYAML) ImageConfig(id distro.ID, archName string) *distro
 		}
 	}
 
-	return imgConfig
+	if err := imgConfig.ExpandTemplates(id, archName); err != nil {
+		return nil, err
+	}
+	return imgConfig, nil
 }
 
 // InstallerConfig returns the InstallerConfig for the given imgType

--- a/pkg/distro/defs/loader_test.go
+++ b/pkg/distro/defs/loader_test.go
@@ -800,7 +800,8 @@ image_types:
 `
 	it := makeTestImageType(t, fakeDistroYaml)
 
-	imgConfig := it.ImageConfig(distro.ID{Name: "test-distro", MajorVersion: 1, MinorVersion: -1}, "test_arch")
+	imgConfig, err := it.ImageConfig(distro.ID{Name: "test-distro", MajorVersion: 1, MinorVersion: -1}, "test_arch")
+	require.NoError(t, err)
 	assert.Equal(t, &distro.ImageConfig{
 		Hostname:      common.ToPtr("test-arch-hn"),
 		Locale:        common.ToPtr("en_US.UTF-8"),

--- a/pkg/distro/generic/bootc_imagetype.go
+++ b/pkg/distro/generic/bootc_imagetype.go
@@ -238,7 +238,10 @@ func (t *bootcImageType) manifestForDisk(bp *blueprint.Blueprint, options distro
 		img.DiskCustomizations.MountConfiguration = *bd.sourceInfo.MountConfiguration
 	}
 
-	imageConfig := t.ImageTypeYAML.ImageConfig(bd.id, t.arch.Name())
+	imageConfig, err := t.ImageTypeYAML.ImageConfig(bd.id, t.arch.Name())
+	if err != nil {
+		return nil, nil, err
+	}
 	if imageConfig != nil {
 		img.OSCustomizations.KernelOptionsAppend = imageConfig.KernelOptions
 	}
@@ -716,7 +719,10 @@ func (t *bootcImageType) manifestForPXETar(bp *blueprint.Blueprint, options dist
 		img.DiskCustomizations.MountConfiguration = *bd.sourceInfo.MountConfiguration
 	}
 
-	imageConfig := t.ImageTypeYAML.ImageConfig(bd.id, t.arch.Name())
+	imageConfig, err := t.ImageTypeYAML.ImageConfig(bd.id, t.arch.Name())
+	if err != nil {
+		return nil, nil, err
+	}
 	if imageConfig != nil {
 		img.OSCustomizations.KernelOptionsAppend = imageConfig.KernelOptions
 	}

--- a/pkg/distro/generic/export_test.go
+++ b/pkg/distro/generic/export_test.go
@@ -21,7 +21,7 @@ type (
 	Distribution = distribution
 )
 
-func (t *imageType) GetDefaultImageConfig() *distro.ImageConfig {
+func (t *imageType) GetDefaultImageConfig() (*distro.ImageConfig, error) {
 	return t.getDefaultImageConfig()
 }
 

--- a/pkg/distro/generic/images.go
+++ b/pkg/distro/generic/images.go
@@ -30,21 +30,27 @@ import (
 	"github.com/osbuild/image-builder/pkg/rpmmd"
 )
 
-func kernelOptions(t *imageType, c *blueprint.Customizations) []string {
-	imageConfig := t.getDefaultImageConfig()
+func kernelOptions(t *imageType, c *blueprint.Customizations) ([]string, error) {
+	imageConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return nil, err
+	}
 
 	kernelOptions := imageConfig.KernelOptions
 	if bpKernel := c.GetKernel(); bpKernel.Append != "" {
 		kernelOptions = append(kernelOptions, bpKernel.Append)
 	}
-	return kernelOptions
+	return kernelOptions, nil
 }
 
 func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distro.ImageOptions, containers []container.SourceSpec, bp *blueprint.Blueprint) (manifest.OSCustomizations, error) {
 	c := bp.Customizations
 	osc := manifest.OSCustomizations{}
 
-	imageConfig := t.getDefaultImageConfig()
+	imageConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return osc, err
+	}
 	if t.ImageTypeYAML.Bootable || t.ImageTypeYAML.IsOSTreeBasedImageType() {
 		// TODO: for now the only image types that define a default kernel are
 		// ones that use UKIs and don't allow overriding, so this works.
@@ -56,7 +62,11 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 		if imageConfig.DefaultKernelName != nil {
 			osc.KernelName = *imageConfig.DefaultKernelName
 		}
-		osc.KernelOptionsAppend = kernelOptions(t, c)
+		kopts, err := kernelOptions(t, c)
+		if err != nil {
+			return osc, err
+		}
+		osc.KernelOptionsAppend = kopts
 		if imageConfig.KernelOptionsBootloader != nil {
 			osc.KernelOptionsBootloader = *imageConfig.KernelOptionsBootloader
 		}
@@ -197,7 +207,6 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 		osc.RHSMFacts = options.Facts
 	}
 
-	var err error
 	osc.Directories, err = blueprint.DirectoryCustomizationsToFsNodeDirectories(c.GetDirectories())
 	if err != nil {
 		// In theory this should never happen, because the blueprint directory customizations
@@ -396,16 +405,22 @@ func osCustomizations(t *imageType, osPackageSet rpmmd.PackageSet, options distr
 	return osc, nil
 }
 
-func ociContainerCustomizations(t *imageType) manifest.OCIContainerCustomizations {
-	imageConfig := t.getDefaultImageConfig()
+func ociContainerCustomizations(t *imageType) (manifest.OCIContainerCustomizations, error) {
+	imageConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return manifest.OCIContainerCustomizations{}, err
+	}
 
 	return manifest.OCIContainerCustomizations{
 		OCIArchiveConfig: osbuild.NewOCIArchiveConfig(imageConfig.OCI),
-	}
+	}, nil
 }
 
-func ostreeCommitServerCustomizations(t *imageType) manifest.OSTreeCommitServerCustomizations {
-	imageConfig := t.getDefaultImageConfig()
+func ostreeCommitServerCustomizations(t *imageType) (manifest.OSTreeCommitServerCustomizations, error) {
+	imageConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return manifest.OSTreeCommitServerCustomizations{}, err
+	}
 
 	c := manifest.OSTreeCommitServerCustomizations{}
 
@@ -413,7 +428,7 @@ func ostreeCommitServerCustomizations(t *imageType) manifest.OSTreeCommitServerC
 		c.OSTreeServer = imageConfig.OSTreeServer
 	}
 
-	return c
+	return c, nil
 }
 
 // We need a lock around applying/retrieving installer customizations as we run our test cases
@@ -572,7 +587,11 @@ func installerCustomizations(t *imageType, c *blueprint.Customizations, o distro
 		}
 	}
 
-	isc.KernelOptionsAppend = kernelOptions(t, c)
+	kopts, err := kernelOptions(t, c)
+	if err != nil {
+		return isc, err
+	}
+	isc.KernelOptionsAppend = kopts
 
 	return isc, nil
 }
@@ -691,7 +710,10 @@ func ostreeDeploymentCustomizations(
 	}
 	deploymentConf := manifest.OSTreeDeploymentCustomizations{}
 
-	imageConfig := t.getDefaultImageConfig()
+	imageConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return deploymentConf, err
+	}
 	kernelOptions := imageConfig.KernelOptions
 	if bpKernel := c.GetKernel(); bpKernel != nil && bpKernel.Append != "" {
 		kernelOptions = append(kernelOptions, bpKernel.Append)
@@ -717,7 +739,6 @@ func ostreeDeploymentCustomizations(
 
 	deploymentConf.Users = users.UsersFromBP(c.GetUsers())
 
-	var err error
 	groups, err := c.GetGroups()
 	if err != nil {
 		return manifest.OSTreeDeploymentCustomizations{}, err
@@ -863,7 +884,11 @@ func containerImage(t *imageType,
 	img.OSCustomizations.PayloadRepos = payloadRepos
 	img.Environment = &t.ImageTypeYAML.Environment
 
-	img.OCIContainerCustomizations = ociContainerCustomizations(t)
+	ociCust, err := ociContainerCustomizations(t)
+	if err != nil {
+		return nil, err
+	}
+	img.OCIContainerCustomizations = ociCust
 
 	return img, nil
 }
@@ -883,12 +908,14 @@ func liveInstallerImage(t *imageType,
 
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 
-	imgConfig := t.getDefaultImageConfig()
+	imgConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return nil, err
+	}
 	if locale := imgConfig.Locale; locale != nil {
 		img.Locale = *locale
 	}
 
-	var err error
 	img.InstallerCustomizations, err = installerCustomizations(t, bp.Customizations, options)
 	if err != nil {
 		return nil, err
@@ -997,7 +1024,10 @@ func ostreeCommitImage(t *imageType,
 	}
 	img.OSCustomizations.PayloadRepos = payloadRepos
 
-	imgConfig := t.getDefaultImageConfig()
+	imgConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return nil, err
+	}
 	img.OSCustomizations.Presets = imgConfig.Presets
 	if imgConfig.InstallWeakDeps != nil {
 		img.InstallWeakDeps = *imgConfig.InstallWeakDeps
@@ -1076,7 +1106,10 @@ func ostreeContainerImage(t *imageType,
 		return nil, err
 	}
 
-	imgConfig := t.getDefaultImageConfig()
+	imgConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return nil, err
+	}
 	img.OSCustomizations.Presets = imgConfig.Presets
 	if imgConfig.InstallWeakDeps != nil {
 		img.OSCustomizations.InstallWeakDeps = *imgConfig.InstallWeakDeps
@@ -1089,8 +1122,16 @@ func ostreeContainerImage(t *imageType,
 	img.OSVersion = d.OsVersion()
 	img.ExtraContainerPackages = packageSets[containerPkgsKey]
 
-	img.OCIContainerCustomizations = ociContainerCustomizations(t)
-	img.OSTreeCommitServerCustomizations = ostreeCommitServerCustomizations(t)
+	ociCust, err := ociContainerCustomizations(t)
+	if err != nil {
+		return nil, err
+	}
+	img.OCIContainerCustomizations = ociCust
+	commitServerCust, err := ostreeCommitServerCustomizations(t)
+	if err != nil {
+		return nil, err
+	}
+	img.OSTreeCommitServerCustomizations = commitServerCust
 
 	return img, nil
 }
@@ -1184,7 +1225,10 @@ func ostreeInstallerImage(t *imageType,
 		img.RootfsCompression = "xz"
 	}
 
-	imgConfig := t.getDefaultImageConfig()
+	imgConfig, err := t.getDefaultImageConfig()
+	if err != nil {
+		return nil, err
+	}
 	if locale := imgConfig.Locale; locale != nil {
 		img.Locale = *locale
 	}

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -207,10 +207,13 @@ func (t *imageType) getPartitionTable(customizations *blueprint.Customizations, 
 	return disk.NewPartitionTable(basePartitionTable, mountpoints, datasizes.Size(imageSize), options.PartitioningMode, t.platform.GetArch(), t.ImageTypeYAML.RequiredPartitionSizes, defaultFsType.String(), rng)
 }
 
-func (t *imageType) getDefaultImageConfig() *distro.ImageConfig {
+func (t *imageType) getDefaultImageConfig() (*distro.ImageConfig, error) {
 	d := t.Arch().Distro()
-	imageConfig := t.ImageConfig(d.ID(), t.arch.arch.String())
-	return imageConfig.InheritFrom(d.ImageConfig())
+	imageConfig, err := t.ImageConfig(d.ID(), t.arch.arch.String())
+	if err != nil {
+		return nil, err
+	}
+	return imageConfig.InheritFrom(d.ImageConfig()), nil
 }
 
 func (t *imageType) getDefaultInstallerConfig() (*distro.InstallerConfig, error) {

--- a/pkg/distro/generic/rhel10_test.go
+++ b/pkg/distro/generic/rhel10_test.go
@@ -395,7 +395,8 @@ func TestRH10Rhel10_KernelOption_NoIfnames(t *testing.T) {
 			for _, imgTypeName := range arch.ListImageTypes() {
 				imgType, err := arch.GetImageType(imgTypeName)
 				assert.NoError(t, err)
-				imgCfg := imgType.(*generic.ImageType).GetDefaultImageConfig()
+				imgCfg, err := imgType.(*generic.ImageType).GetDefaultImageConfig()
+				assert.NoError(t, err)
 				if imgCfg != nil {
 					assert.NotContains(t, imgCfg.KernelOptions, "net.ifnames=0", "type %s contains unwanted net.ifnames=0", imgType.Name())
 				}

--- a/pkg/distro/image_config.go
+++ b/pkg/distro/image_config.go
@@ -1,8 +1,10 @@
 package distro
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
+	"text/template"
 
 	"github.com/osbuild/image-builder/internal/common"
 	"github.com/osbuild/image-builder/pkg/customizations/fsnode"
@@ -156,6 +158,34 @@ type ImageConfig struct {
 	// /usr/lib/ostree-boot into bootupd-compatible update metadata.
 	// Only set this to true if the bootupd package is available in the image.
 	BootupdGenMetadata *bool `yaml:"bootupd_gen_metadata,omitempty"`
+}
+
+func (c *ImageConfig) ExpandTemplates(id ID, archName string) error {
+	if c == nil || c.WSL == nil || c.WSL.DistributionConfig == nil || c.WSL.DistributionConfig.OOBE == nil {
+		return nil
+	}
+	if c.WSL.DistributionConfig.OOBE.DefaultName == "" {
+		return nil
+	}
+
+	data := struct {
+		Arch   string
+		Distro ID
+	}{
+		Arch:   archName,
+		Distro: id,
+	}
+
+	tmpl, err := template.New("image-config").Parse(c.WSL.DistributionConfig.OOBE.DefaultName)
+	if err != nil {
+		return fmt.Errorf("cannot parse WSL default_name template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("cannot execute WSL default_name template: %w", err)
+	}
+	c.WSL.DistributionConfig.OOBE.DefaultName = buf.String()
+	return nil
 }
 
 // shallowMerge creates a new struct by merging a child and a parent.

--- a/pkg/manifest/os.go
+++ b/pkg/manifest/os.go
@@ -1009,13 +1009,7 @@ func (p *OS) serialize() (osbuild.Pipeline, error) {
 	}
 
 	if p.OSCustomizations.WSLDistributionConfig != nil {
-		// Format version into the name field; if there's no %s nothing special happens.
-		wslDistConfig := *p.OSCustomizations.WSLDistributionConfig
-		wslDistConfig.OOBE.DefaultName = fmt.Sprintf(
-			wslDistConfig.OOBE.DefaultName,
-			p.OSVersion,
-		)
-		pipeline.AddStage(osbuild.NewWSLDistributionConfStage(&wslDistConfig))
+		pipeline.AddStage(osbuild.NewWSLDistributionConfStage(p.OSCustomizations.WSLDistributionConfig))
 	}
 
 	if p.OSCustomizations.FIPS {


### PR DESCRIPTION
The WSL default_name field used %s (Sprintf-style) for version formatting, which produces garbage when %s is omitted.

Very mechanical implementation of the same idiom already used for InstallerConfig's templates.

Closes: #2485