### PR TITLE
Change s3_touch() to tag objects and re-enable the function on cache hits [HMS-11071]

### DIFF
--- a/test/scripts/imgtestlib/boot.py
+++ b/test/scripts/imgtestlib/boot.py
@@ -444,7 +444,8 @@ def upload_to_aws(arch, image_name, image_path, boot_mode=None):
     if boot_mode:
         cmd += ["--aws-boot-mode", boot_mode]
     cmd.append(image_path)
-    stdout, _ = runcmd(cmd)
+    stdout, stderr = runcmd(cmd)
+    print(stderr.decode())  # status messages
     result = json.loads(stdout)
     return result["image_id"]
 
@@ -503,7 +504,8 @@ def upload_to_azure(arch, image_name, image_path):
            "--azure-resource-group", az_config["resource_group"],
            "--azure-image-name", image_name,
            image_path]
-    stdout, _ = runcmd(cmd)
+    stdout, stderr = runcmd(cmd)
+    print(stderr.decode())  # status messages
     result = json.loads(stdout)
     return result["image_id"]
 

--- a/test/scripts/imgtestlib/boot.py
+++ b/test/scripts/imgtestlib/boot.py
@@ -431,7 +431,6 @@ def get_boot_mode(distro, arch, image_type):
     raise RuntimeError(f"bootmode not found in describe output for {distro}/{arch}/{image_type}")
 
 
-# pylint: disable=too-many-arguments,too-many-positional-arguments
 def upload_to_aws(arch, image_name, image_path, boot_mode=None):
     """Upload an image to AWS via image-builder and return the AMI ID."""
     aws_config = get_aws_config()

--- a/test/scripts/imgtestlib/cache.py
+++ b/test/scripts/imgtestlib/cache.py
@@ -1,7 +1,7 @@
 import json
 import os
 import subprocess as sp
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 from .build import (gen_build_name, get_manifest_id, read_build_info,
@@ -10,8 +10,11 @@ from .gitlab import log_section
 from .run import runcmd, runcmd_nc
 from .testenv import get_ci_runner_for, get_osbuild_commit
 
-S3_BUCKET = "s3://" + os.environ.get("AWS_BUCKET", "images-ci-cache")
+S3_BUCKET_NAME = os.environ.get("AWS_BUCKET", "images-ci-cache")
+S3_BUCKET = "s3://" + S3_BUCKET_NAME
 S3_PREFIX = "images/builds"
+
+DELETE_AFTER_TD = timedelta(days=14)
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -109,16 +112,20 @@ def gen_build_info_s3_dir_path(distro=None, arch=None, manifest_id=None, osbuild
 
 def touch_s3(distro, arch, manifest_id, osbuild_ref=None, runner_distro=None):
     """
-    Update the timestamps of a path in S3 by adding a metadata field to each file recursively. This can be used to
-    "freshen up" relevant files in the build cache so that images that are still current but haven't been updated in a
-    while don't get garbage collected.
+    Update the DeleteAfter tag of a path in S3 to the current time + 14 days (DELETE_AFTER_TD). The tag is used by the
+    cloud cleaner to garbage-collect old images. Only the info.json of a prefix containing an image needs to be tagged.
     """
-    # NOTE: we can make this async - updating the objects can take a few seconds and can be done in parallel
-    s3url = gen_build_info_s3_dir_path(distro, arch, manifest_id, osbuild_ref, runner_distro)
-    # the exact key and value don't matter, but let's add the current datetime to make it a bit more meaningful
-    now = str(datetime.now())
-    print(f"⌚ Updating timestamps for {s3url} ({now})")
-    cmd = ["aws", "s3", "cp", "--recursive", "--metadata", f"touched={now}", s3url, s3url]
+    s3path = os.path.join(S3_PREFIX,
+                          gen_build_info_dir_path_prefix(distro, arch, manifest_id, osbuild_ref, runner_distro),
+                          "info.json")
+    s3url = os.path.join(S3_BUCKET, s3path)
+    delete_after = datetime.now() + DELETE_AFTER_TD
+    delete_after_iso = delete_after.isoformat()
+    print(f"⌚ Setting DeleteAfter tag for {s3url} ({delete_after_iso})")
+    cmd = ["aws", "s3api", "put-object-tagging",
+           "--bucket", S3_BUCKET_NAME,
+           "--key", s3path,
+           "--tagging", f"TagSet=[{{Key=DeleteAfter,Value={delete_after_iso}}}]"]
     runcmd_nc(cmd)
 
 

--- a/test/scripts/imgtestlib/cache.py
+++ b/test/scripts/imgtestlib/cache.py
@@ -161,6 +161,7 @@ def upload_results(distro, arch, image_type, config_path):
                build_dir+"/", s3url])
     print(f"⬆️ Uploading info.json to {s3url}")
     runcmd_nc(["aws", "s3", "cp", "--no-progress", "--acl=private", "--recursive", build_dir+"/", s3url])
+    touch_s3(distro, arch, manifest_id)
     print("✅ DONE!!")
 
 

--- a/test/scripts/imgtestlib/core.py
+++ b/test/scripts/imgtestlib/core.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from .bootcsource import bootc_source_from_distro, resolve_bootc_source_ref
 from .build import get_manifest_id
-from .cache import dl_build_info, gen_build_info_dir_path_prefix
+from .cache import dl_build_info, gen_build_info_dir_path_prefix, touch_s3
 from .gitlab import log_section
 from .run import runcmd
 from .testenv import rng_seed_env
@@ -258,11 +258,9 @@ def filter_builds(manifests, distro=None, arch=None, skip_ostree_pull=True):
         if check_for_build(manifest_fname, build_request, data["manifest"], build_info_dir, errors):
             build_requests.append(build_request)
         else:
-            # The specific build configuration exists in the cache and wont be rebuilt. Update the file timestamps to
+            # The specific build configuration exists in the cache and wont be rebuilt. Update the DeleteAfter tag to
             # keep them fresh in the cache.
-            # touch_s3(distro, arch, manifest_id)
-            # NOTE(2026-06-18): Disabling this temporarily since it slows down the filtering process by a lot
-            print("WARNING: timestamp updating has been temporarily disabled", file=sys.stderr)
+            touch_s3(distro, arch, manifest_id)
 
     print("✅ Config filtering done!\n")
     if errors:


### PR DESCRIPTION
Instead of adding metadata, which requires copying a file over itself and can take time, tag an object with a DeleteAfter date that the cloud-cleaner reads to determine if an object should be deleted.  Unlike the previous method of modifying objects, this does not change the mtime.  However, the action is a single (fast) API call.

See also https://github.com/osbuild/cloud-cleaner/pull/59