### PR TITLE
pkg/manifest: erofs pipeline generator

### DIFF
--- a/pkg/manifest/erofs.go
+++ b/pkg/manifest/erofs.go
@@ -1,0 +1,53 @@
+package manifest
+
+import (
+	"github.com/osbuild/image-builder/pkg/artifact"
+	"github.com/osbuild/image-builder/pkg/osbuild"
+)
+
+type Erofs struct {
+	Base
+	filename      string
+	inputPipeline Pipeline
+}
+
+func NewErofs(buildPipeline Build, inputPipeline Pipeline, pipelinename string) *Erofs {
+	p := &Erofs{
+		Base:          NewBase(pipelinename, buildPipeline),
+		inputPipeline: inputPipeline,
+		filename:      "image.raw",
+	}
+	buildPipeline.addDependent(p)
+	return p
+}
+
+func (p *Erofs) Filename() string {
+	return p.filename
+}
+
+func (p *Erofs) SetFilename(filename string) {
+	p.filename = filename
+}
+
+func (p *Erofs) serialize() (osbuild.Pipeline, error) {
+	pipeline, err := p.Base.serialize()
+	if err != nil {
+		return osbuild.Pipeline{}, err
+	}
+
+	erofsOptions := osbuild.ErofsStageOptions{
+		Filename: p.filename,
+	}
+	pipeline.AddStage(osbuild.NewErofsStage(erofsOptions, p.inputPipeline.Name()))
+
+	return pipeline, nil
+}
+
+func (p *Erofs) getBuildPackages(Distro) ([]string, error) {
+	return []string{"erofs-utils"}, nil
+}
+
+func (p *Erofs) Export() *artifact.Artifact {
+	p.Base.export = true
+	return artifact.New(p.Name(), p.Filename(), nil)
+}

--- a/pkg/manifest/erofs_test.go
+++ b/pkg/manifest/erofs_test.go
@@ -1,0 +1,81 @@
+package manifest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/image-builder/pkg/manifest"
+	"github.com/osbuild/image-builder/pkg/osbuild"
+	"github.com/osbuild/image-builder/pkg/runner"
+)
+
+func TestErofsSerialize(t *testing.T) {
+	mani := manifest.New()
+	runner := &runner.Linux{}
+	build := manifest.NewBuild(&mani, runner, nil, nil)
+
+	rawImage := manifest.NewRawImage(build, nil, manifest.DiskCustomizations{})
+	erofsPipeline := manifest.NewErofs(build, rawImage, "erofs")
+	erofsPipeline.SetFilename("image.erofs")
+
+	osbuildPipeline, err := manifest.Serialize(erofsPipeline)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "erofs", osbuildPipeline.Name)
+	assert.Equal(t, 1, len(osbuildPipeline.Stages))
+	erofsStage := osbuildPipeline.Stages[0]
+	assert.Equal(t, &osbuild.ErofsStageOptions{
+		Filename: "image.erofs",
+	}, erofsStage.Options.(*osbuild.ErofsStageOptions))
+}
+
+func TestErofsDefaultFilename(t *testing.T) {
+	mani := manifest.New()
+	runner := &runner.Linux{}
+	build := manifest.NewBuild(&mani, runner, nil, nil)
+
+	rawImage := manifest.NewRawImage(build, nil, manifest.DiskCustomizations{})
+	erofsPipeline := manifest.NewErofs(build, rawImage, "erofs")
+
+	assert.Equal(t, "image.raw", erofsPipeline.Filename())
+}
+
+func TestErofsSetFilename(t *testing.T) {
+	mani := manifest.New()
+	runner := &runner.Linux{}
+	build := manifest.NewBuild(&mani, runner, nil, nil)
+
+	rawImage := manifest.NewRawImage(build, nil, manifest.DiskCustomizations{})
+	erofsPipeline := manifest.NewErofs(build, rawImage, "erofs")
+
+	erofsPipeline.SetFilename("custom.erofs")
+	assert.Equal(t, "custom.erofs", erofsPipeline.Filename())
+}
+
+func TestErofsGetBuildPackages(t *testing.T) {
+	mani := manifest.New()
+	runner := &runner.Linux{}
+	build := manifest.NewBuild(&mani, runner, nil, nil)
+
+	rawImage := manifest.NewRawImage(build, nil, manifest.DiskCustomizations{})
+	erofsPipeline := manifest.NewErofs(build, rawImage, "erofs")
+
+	osbuildPipeline, err := manifest.Serialize(erofsPipeline)
+	assert.NoError(t, err)
+	assert.NotNil(t, osbuildPipeline)
+}
+
+func TestErofsExport(t *testing.T) {
+	mani := manifest.New()
+	runner := &runner.Linux{}
+	build := manifest.NewBuild(&mani, runner, nil, nil)
+
+	rawImage := manifest.NewRawImage(build, nil, manifest.DiskCustomizations{})
+	erofsPipeline := manifest.NewErofs(build, rawImage, "erofs")
+	erofsPipeline.SetFilename("exported.erofs")
+
+	art := erofsPipeline.Export()
+	assert.NotNil(t, art)
+	assert.Equal(t, "exported.erofs", art.Filename())
+}


### PR DESCRIPTION
Introduce an erofs pipeline generator that takes an input and turns it into an erofs image.