### PR TITLE
[DRAFT] Add ISCSI packages to support bare metal shapes in OCI

### DIFF
--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -1048,7 +1048,8 @@ image_types:
       <<: *default_partition_tables
     package_sets:
       os:
-        - include:
+        - &qcow2_pkgset
+          include:
             - "@core"
             - "chrony"
             - "cloud-init"

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -1292,7 +1292,7 @@ image_types:
     package_sets:
       os:
         - *qcow2_pkgset
-        - packages:
+        - include:
             # Required so dracut iscsi module check passes during kernel-core %posttrans.
             - "iscsi-initiator-utils"
     blueprint:

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -1289,6 +1289,12 @@ image_types:
                     label: "root"
                     mountpoint: "/"
                     fstab_options: "defaults"
+    package_sets:
+      os:
+        - *qcow2_pkgset
+        - packages:
+            # Required so dracut iscsi module check passes during kernel-core %posttrans.
+            - "iscsi-initiator-utils"
     blueprint:
       supported_options: *supported_options_disk
 

--- a/data/distrodefs/rhel-10/imagetypes.yaml
+++ b/data/distrodefs/rhel-10/imagetypes.yaml
@@ -1213,11 +1213,18 @@ image_types:
           config:
             datasource_list:
               - "Oracle"
+      # iSCSI in initramfs so OCI BM can attach the boot LUN.
       dracut_conf:
         - filename: "oci.conf"
           config:
             add_drivers:
               - "mlx5_core"
+              - "iscsi_ibft"
+            add_dracutmodules:
+              - "iscsi"
+              - "network"
+            install:
+              - "/usr/sbin/iscsiadm"
       conditions:
         <<: *qcow2_image_config_conditions
         "oracle linux is hostonly":

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1775,7 +1775,7 @@ image_types:
     package_sets:
       os:
         - *qcow2_pkgset
-        - packages:
+        - include:
             # Required so dracut iscsi module check passes during kernel-core %posttrans.
             - "iscsi-initiator-utils"
         - conditions:

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1775,6 +1775,9 @@ image_types:
     package_sets:
       os:
         - *qcow2_pkgset
+        - packages:
+            # Required so dracut iscsi module check passes during kernel-core %posttrans.
+            - "iscsi-initiator-utils"
         - conditions:
             "system reinstall bootc": *conditions_pkgsets_system_reinstall_bootc
     partition_table:

--- a/data/distrodefs/rhel-9/imagetypes.yaml
+++ b/data/distrodefs/rhel-9/imagetypes.yaml
@@ -1747,11 +1747,18 @@ image_types:
           config:
             datasource_list:
               - "Oracle"
+      # iSCSI in initramfs so OCI BM can attach the boot LUN.
       dracut_conf:
         - filename: "oci.conf"
           config:
             add_drivers:
               - "mlx5_core"
+              - "iscsi_ibft"
+            add_dracutmodules:
+              - "iscsi"
+              - "network"
+            install:
+              - "/usr/sbin/iscsiadm"
       conditions:
         <<: *qcow2_image_config_conditions
         "oracle linux is hostonly":


### PR DESCRIPTION
BM shapes require additional configuration so that these images can be booted up in OCI.

This PR aims to add those changes. Currently, we are testing these changes in our pipeline.