### PR TITLE
Drop common runner and add architecture name to runner names in Schutzfile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -366,7 +366,7 @@ fail:
   stage: gen
   extends: .terraform
   variables:
-    RUNNER: aws/fedora-44-x86_64
+    RUNNER: aws/centos-stream-9-x86_64
     INTERNAL_NETWORK: "true"
   script:
     - sudo -E ./test/scripts/setup-osbuild-repo

--- a/Schutzfile
+++ b/Schutzfile
@@ -9,10 +9,10 @@
         "commit": "05d245c8e9a4615bc05b9bbcd79324625d24cfbc"
       }
     },
-    "gitlab-ci-runner": "aws/fedora-44",
     "gitlab-ci-runner-for": {
       "*": {
         "x86_64": {
+          "*": "aws/fedora-44",
           "qcow2": "rhos-01/fedora-44",
           "server-qcow2": "rhos-01/fedora-44",
           "generic-qcow2": "rhos-01/fedora-44",
@@ -23,6 +23,9 @@
           "everything-network-installer": "rhos-01/fedora-44",
           "server-network-installer": "rhos-01/fedora-44",
           "pxe-tar-xz": "rhos-01/fedora-44"
+        },
+        "aarch64": {
+          "*": "aws/fedora-44"
         }
       },
       "rhel-7.9": {

--- a/Schutzfile
+++ b/Schutzfile
@@ -12,25 +12,25 @@
     "gitlab-ci-runner-for": {
       "*": {
         "x86_64": {
-          "*": "aws/fedora-44",
-          "qcow2": "rhos-01/fedora-44",
-          "server-qcow2": "rhos-01/fedora-44",
-          "generic-qcow2": "rhos-01/fedora-44",
-          "cloud-qcow2": "rhos-01/fedora-44",
-          "image-installer": "rhos-01/fedora-44",
-          "minimal-installer": "rhos-01/fedora-44",
-          "network-installer": "rhos-01/fedora-44",
-          "everything-network-installer": "rhos-01/fedora-44",
-          "server-network-installer": "rhos-01/fedora-44",
-          "pxe-tar-xz": "rhos-01/fedora-44"
+          "*": "aws/fedora-44-x86_64",
+          "qcow2": "rhos-01/fedora-44-x86_64",
+          "server-qcow2": "rhos-01/fedora-44-x86_64",
+          "generic-qcow2": "rhos-01/fedora-44-x86_64",
+          "cloud-qcow2": "rhos-01/fedora-44-x86_64",
+          "image-installer": "rhos-01/fedora-44-x86_64",
+          "minimal-installer": "rhos-01/fedora-44-x86_64",
+          "network-installer": "rhos-01/fedora-44-x86_64",
+          "everything-network-installer": "rhos-01/fedora-44-x86_64",
+          "server-network-installer": "rhos-01/fedora-44-x86_64",
+          "pxe-tar-xz": "rhos-01/fedora-44-x86_64"
         },
         "aarch64": {
-          "*": "aws/fedora-44"
+          "*": "aws/fedora-44-aarch64"
         }
       },
       "rhel-7.9": {
         "x86_64": {
-          "*": "aws/centos-stream-9"
+          "*": "aws/centos-stream-9-x86_64"
         }
       }
     }

--- a/Schutzfile
+++ b/Schutzfile
@@ -1,6 +1,6 @@
 {
   "common": {
-    "rngseed": 2026070700,
+    "rngseed": 2026090700,
     "dependencies": {
       "bootc-image-builder": {
         "ref": "quay.io/centos-bootc/bootc-image-builder@sha256:9893e7209e5f449b86ababfd2ee02a58cca2e5990f77b06c3539227531fc8120"

--- a/test/scripts/dl-image-build-cache
+++ b/test/scripts/dl-image-build-cache
@@ -63,7 +63,7 @@ def get_argparser():
     parser.add_argument(
         "--output", type=str, metavar="DIR",
         help="Directory to download the image build cache to. " +
-             "If not provided, `./s3cache_osbuild-<ref>_runner-<runner-distro>` is used.",
+             "If not provided, `./s3cache_osbuild-<ref>` is used.",
     )
     parser.add_argument(
         "--dl-image", action="store_true", default=False,
@@ -117,14 +117,13 @@ def main():
     if args.image_type and args.skip_image_type:
         parser.error("--image-type and --skip-image-type are mutually exclusive")
 
-    runner_distro = testlib.testenv.get_common_ci_runner_distro()
-    osbuild_ref = testlib.testenv.get_osbuild_commit(runner_distro)
+    osbuild_ref = testlib.testenv.get_osbuild_commit()
     if osbuild_ref is None:
-        raise RuntimeError(f"Failed to determine osbuild commit for {runner_distro} from the Schutzfile")
+        raise RuntimeError("Failed to determine osbuild commit from the Schutzfile")
 
     output_dir = args.output
     if output_dir is None:
-        output_dir = f"./s3cache_osbuild-{osbuild_ref}_runner-{runner_distro}"
+        output_dir = f"./s3cache_osbuild-{osbuild_ref}"
 
     with tempfile.TemporaryDirectory() as tmpdir:
         print("📜 Generating current manifests to determine their IDs")
@@ -146,7 +145,7 @@ def main():
         print("⚠️ No image build cache files found for the specified configurations", file=sys.stderr)
         sys.exit(1)
 
-    print(f"📥 Downloading the image build cache files for osbuild-ref:{osbuild_ref} and ci-runner:{runner_distro}")
+    print(f"📥 Downloading the image build cache files for osbuild-ref:{osbuild_ref}")
     print(f"📥 Will download files for {len(build_cache_infos)} configurations into {output_dir}")
 
     s3_include_only = None
@@ -162,6 +161,7 @@ def main():
         config = build_cache_info["config"]
         manifest_id = build_cache_info["manifest-id"]
 
+        runner_distro = testlib.testenv.get_ci_runner_distro_for(distro, arch, image_type)
         target_dir = os.path.join(output_dir, testlib.build.gen_build_name(distro, arch, image_type, config))
 
         out, dl_ok = testlib.cache.dl_build_cache(

--- a/test/scripts/dl-one-image-build-cache
+++ b/test/scripts/dl-one-image-build-cache
@@ -48,7 +48,7 @@ def main():
     runner_distro = build_info.get("runner-distro")
 
     if runner_distro is None:
-        runner_distro = testlib.testenv.get_common_ci_runner_distro()
+        runner_distro = testlib.testenv.get_ci_runner_distro_for(distro, arch, image_type="*")
         print("⚠️ Runner distro not found in the build info. " +
               f"Using the CI runner distro from the current branch: {runner_distro}", file=sys.stderr)
 

--- a/test/scripts/generate-bootc-config
+++ b/test/scripts/generate-bootc-config
@@ -21,7 +21,7 @@ build/{distro}/{arch}/{image_type}/{config_name}:
   tags:
     - {tag}
   variables:
-    RUNNER: {runner}-{arch}
+    RUNNER: {runner}
     INTERNAL_NETWORK: "false"
 """
 

--- a/test/scripts/generate-build-config
+++ b/test/scripts/generate-build-config
@@ -20,7 +20,7 @@ build/{distro}/{arch}/{image_type}/{config_name}:
   tags:
     - {tag}
   variables:
-    RUNNER: {runner}-{arch}
+    RUNNER: {runner}
     INTERNAL_NETWORK: "{internal}"
 """
 

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -8,7 +8,6 @@ import imgtestlib as testlib
 
 ARCHITECTURES = ["x86_64", "aarch64"]
 MANIFEST_ONLY_ARCHES = ["ppc64le", "s390x"]
-RUNNER = testlib.testenv.get_common_ci_runner()
 OSTREE_DISTROS = ["fedora", "rhel-8", "rhel-9", "centos-9"]
 BOOTC_SOURCES = testlib.bootcsource.BOOTC_SOURCES
 
@@ -241,16 +240,17 @@ def main():
         if combo in combos:
             continue
 
+        runner = testlib.testenv.get_ci_runner_for(img["distro"], img["arch"], image_type="*")
         combos.add(combo)
         gen_stage.append(GEN_TEMPLATE.format(
             distro=img["distro"],
             arch=img["arch"],
-            runner=RUNNER))
+            runner=runner))
 
         trigger_stage.append(TRIGGER_TEMPLATE.format(
             distro=img["distro"],
             arch=img["arch"],
-            runner=RUNNER))
+            runner=runner))
 
         for ostree_distro_prefix in OSTREE_DISTROS:
             if img["distro"].startswith(ostree_distro_prefix):
@@ -261,13 +261,15 @@ def main():
         ostree_gen_stage.append(OSTREE_GEN_TEMPLATE.format(
             distro=img["distro"],
             arch=img["arch"],
-            runner=RUNNER))
+            runner=runner))
 
         ostree_trigger_stage.append(OSTREE_TRIGGER_TEMPLATE.format(
             distro=img["distro"],
             arch=img["arch"],
-            runner=RUNNER))
+            runner=runner))
 
+    # generate manifests for s390x and ppc64le on the base x86_64 runners
+    man_only_runner = testlib.testenv.get_ci_runner_for(distro="*", arch="x86_64", image_type="*")
     man_only_images = testlib.core.list_images(arches=MANIFEST_ONLY_ARCHES)
     man_gen_stage = []
     for img in sort_configs(man_only_images):
@@ -276,31 +278,35 @@ def main():
             continue
 
         combos.add(combo)
-        man_gen_stage.append(MANIFEST_GEN_TEMPLATE.format(distro=img["distro"], arch=img["arch"], runner=RUNNER))
+        man_gen_stage.append(MANIFEST_GEN_TEMPLATE.format(distro=img["distro"], arch=img["arch"],
+                                                          runner=man_only_runner))
 
-    # Run bootc-image-builder tests on Fedora 44 only for now (both arches)
+    # bootc-image-builder tests on both arches
     for arch in ("x86_64", "aarch64"):
+        runner = testlib.testenv.get_ci_runner_for(distro="*", arch=arch, image_type="*")
         for test_file_path in collect_bib_tests():
             trigger_stage.append(BOOTC_IMAGE_BUILDER_TEMPLATE.format(
-                runner=RUNNER,
+                runner=runner,
                 arch=arch,
                 test_file_path=test_file_path,
             ))
 
-    # run select unit tests on the default runner for both arches
+    # select unit tests for both arches
     test_stage = []
     for arch in ARCHITECTURES:
+        runner = testlib.testenv.get_ci_runner_for(distro="*", arch=arch, image_type="*")
         test_stage.append(UNIT_TESTS_TEMPLATE.format(
-            runner=RUNNER,
+            runner=runner,
             arch=arch,
         ))
 
     for bootc_source in BOOTC_SOURCES:
         for arch in testlib.bootcsource.BOOTC_ARCHES:
+            runner = testlib.testenv.get_ci_runner_for(distro="*", arch=arch, image_type="*")
             bootc_gen_stage.append(BOOTC_GEN_TEMPLATE.format(
                 bootc_source=bootc_source,
                 arch=arch,
-                runner=RUNNER,
+                runner=runner,
             ))
             bootc_trigger_stage.append(BOOTC_TRIGGER_TEMPLATE.format(
                 bootc_source=bootc_source,
@@ -308,7 +314,7 @@ def main():
             ))
 
     with open(config_path, "w", encoding="utf-8") as config_file:
-        config_file.write(BASE_CONFIG.format(runner=RUNNER))
+        config_file.write(BASE_CONFIG)
         config_file.write(testlib.core.BASE_CONFIG)
         config_file.write("\n".join(gen_stage))
         config_file.write("\n".join(trigger_stage))

--- a/test/scripts/generate-gitlab-ci
+++ b/test/scripts/generate-gitlab-ci
@@ -60,7 +60,7 @@ GEN_TEMPLATE = """
   stage: gen
   extends: .terraform
   variables:
-    RUNNER: {runner}-{arch}
+    RUNNER: {runner}
     INTERNAL_NETWORK: "true"
   script:
     - sudo -E ./test/scripts/setup-osbuild-repo
@@ -90,7 +90,7 @@ OSTREE_GEN_TEMPLATE = """
   stage: ostree-gen
   extends: .terraform
   variables:
-    RUNNER: {runner}-{arch}
+    RUNNER: {runner}
     INTERNAL_NETWORK: "true"
   script:
     - sudo -E ./test/scripts/setup-osbuild-repo
@@ -121,7 +121,7 @@ BOOTC_GEN_TEMPLATE = """
   stage: gen
   extends: .terraform
   variables:
-    RUNNER: {runner}-{arch}
+    RUNNER: {runner}
     INTERNAL_NETWORK: "false"
   script:
     - sudo -E ./test/scripts/setup-osbuild-repo
@@ -152,7 +152,7 @@ MANIFEST_GEN_TEMPLATE = """
   stage: gen
   extends: .terraform
   variables:
-    RUNNER: {runner}-x86_64
+    RUNNER: {runner}
     INTERNAL_NETWORK: "true"
   script: |
     sudo -E ./test/scripts/setup-osbuild-repo
@@ -179,7 +179,7 @@ BOOTC_IMAGE_BUILDER_TEMPLATE = """
   stage: test
   extends: .terraform
   variables:
-    RUNNER: {runner}-{arch}
+    RUNNER: {runner}
   rules:
     # 1. Skip the job if we're on the github merge queue
     - if: '$CI_COMMIT_BRANCH =~ /^gh-readonly-queue/'
@@ -201,7 +201,7 @@ UNIT_TESTS_TEMPLATE = """
   stage: test
   extends: .terraform
   variables:
-    RUNNER: {runner}-{arch}
+    RUNNER: {runner}
   script:
     - sudo ./test/scripts/install-dependencies
     - sudo go test -count=1 ./pkg/distro/bootc/... ./pkg/distro/generic/...

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -346,7 +346,7 @@ def generate_configs(build_requests, container_configs, pipeline_file, configs_d
         run_container_cmd = f"sudo podman run -d --rm -p{container_port}:8080 oci-archive:container.tar"
 
         pipeline_file.write(JOB_TEMPLATE.format(distro=distro, arch=arch, image_type=image_type,
-                                                runner=testlib.testenv.get_common_ci_runner(),
+                                                runner=testlib.testenv.get_ci_runner_for(distro, arch, image_type),
                                                 config_name=config_name, config=build_config_path,
                                                 dl_container=dl_container_cmd,
                                                 start_container=run_container_cmd,

--- a/test/scripts/generate-ostree-build-config
+++ b/test/scripts/generate-ostree-build-config
@@ -20,7 +20,7 @@ build/{distro}/{arch}/{image_type}/{config_name}:
     - sudo -E ./test/scripts/upload-results "{distro}" "{image_type}" "{config}"
   extends: .terraform
   variables:
-    RUNNER: {runner}-{arch}
+    RUNNER: {runner}
     INTERNAL_NETWORK: "{internal}"
   needs:
     - pipeline: "$PARENT_PIPELINE_ID"

--- a/test/scripts/imgtestlib/build.py
+++ b/test/scripts/imgtestlib/build.py
@@ -3,7 +3,8 @@ import os
 import tempfile
 from typing import Dict, List
 
-from .bootcsource import bootc_source_from_distro, resolve_bootc_source, resolve_bootc_source_ref
+from .bootcsource import (bootc_source_from_distro, resolve_bootc_source,
+                          resolve_bootc_source_ref)
 from .gitlab import log_section
 from .run import runcmd, runcmd_nc
 from .testenv import get_host_distro, get_osbuild_commit, rng_seed_env
@@ -119,7 +120,7 @@ def build_image(distro, arch, image_type, config_path):
     osbuild_ver, _ = runcmd(["osbuild", "--version"])
 
     distro_version = get_host_distro()
-    osbuild_commit = get_osbuild_commit(distro_version)
+    osbuild_commit = get_osbuild_commit()
     if osbuild_commit is None:
         osbuild_commit = "RELEASE"
 

--- a/test/scripts/imgtestlib/cache.py
+++ b/test/scripts/imgtestlib/cache.py
@@ -8,7 +8,7 @@ from .build import (gen_build_name, get_manifest_id, read_build_info,
                     write_build_info)
 from .gitlab import log_section
 from .run import runcmd, runcmd_nc
-from .testenv import get_ci_runner_for, get_osbuild_commit
+from .testenv import get_ci_runner_distro_for, get_osbuild_commit
 
 S3_BUCKET_NAME = os.environ.get("AWS_BUCKET", "images-ci-cache")
 S3_BUCKET = "s3://" + S3_BUCKET_NAME
@@ -77,14 +77,12 @@ def gen_build_info_dir_path_prefix(distro=None, arch=None, manifest_id=None, osb
     The returned path always has a trailing separator at the end to signal that it is a directory.
     """
     if runner_distro is None:
-        runner = get_ci_runner_for(distro, arch, image_type="*")
-        # Runners are defined as <platform>/<distro> (e.g. aws/fedora-44)
-        runner = runner.split("/")[1]
+        runner = get_ci_runner_distro_for(distro, arch, image_type="*")
         # special case for CentOS Stream. Our runners use centos-stream-N but the cache path generator reads os-release
         # to create the host distro name, which ends up as centos-N
         runner_distro = runner.replace("centos-stream", "centos")
     if osbuild_ref is None:
-        osbuild_ref = get_osbuild_commit(runner_distro)
+        osbuild_ref = get_osbuild_commit()
 
     path = os.path.join(f"osbuild-ref-{osbuild_ref}", f"runner-{runner_distro}")
     for p in (distro, arch, f"manifest-id-{manifest_id}" if manifest_id else None):

--- a/test/scripts/imgtestlib/core.py
+++ b/test/scripts/imgtestlib/core.py
@@ -268,6 +268,9 @@ def filter_builds(manifests, distro=None, arch=None, skip_ostree_pull=True):
         print("⚠️ Errors:")
         print("\n".join(errors))
 
+    # sorting the requests should have no functional impact but is good for reproducibility
+    build_requests = sorted(build_requests, key=lambda a: json.dumps(a, sort_keys=True))
+
     return build_requests
 
 

--- a/test/scripts/imgtestlib/testenv.py
+++ b/test/scripts/imgtestlib/testenv.py
@@ -123,5 +123,5 @@ def get_ci_runner_distro_for(distro, arch, image_type):
     the Schutzfile.
     """
     runner = get_ci_runner_for(distro, arch, image_type)
-    # given a runner like 'aws/fedora-44' we want 'fedora-44'
-    return runner.split("/")[1]
+    # given a runner like 'aws/fedora-44-x86_64' we want 'fedora-44'
+    return "-".join(runner.split("/")[1].split("-")[:-1])

--- a/test/scripts/imgtestlib/testenv.py
+++ b/test/scripts/imgtestlib/testenv.py
@@ -22,7 +22,7 @@ def get_host_distro():
     return f"{osrelease['ID']}-{osrelease['VERSION_ID']}"
 
 
-def get_osbuild_commit(distro_version):
+def get_osbuild_commit():
     """
     Get the osbuild commit defined in the Schutzfile for the host distro or common.
     If not set, returns None.
@@ -30,10 +30,7 @@ def get_osbuild_commit(distro_version):
     with open(SCHUTZFILE, encoding="utf-8") as schutzfile:
         data = json.load(schutzfile)
 
-    commit = data.get(distro_version, {}).get("dependencies", {}).get("osbuild", {}).get("commit", None)
-    if commit is None:
-        commit = data.get("common", {}).get("dependencies", {}).get("osbuild", {}).get("commit", None)
-    return commit
+    return data.get("common", {}).get("dependencies", {}).get("osbuild", {}).get("commit", None)
 
 
 def get_bib_ref():
@@ -94,6 +91,9 @@ def host_container_arch():
 
 
 def get_ci_runner_for(distro, arch, image_type):
+    """
+    Get the CI runner string for a given distribution, architecture, and image type from the Schutzfile.
+    """
     with open(SCHUTZFILE, encoding="utf-8") as schutzfile:
         data = json.load(schutzfile)
 
@@ -114,31 +114,14 @@ def get_ci_runner_for(distro, arch, image_type):
     if runner is not None:
         return runner
 
-    # fall back to global common
-    return get_common_ci_runner()
+    raise RuntimeError(f"no runner configured for distro {distro} architecture {arch} and image type {image_type}")
 
 
-def get_common_ci_runner():
+def get_ci_runner_distro_for(distro, arch, image_type):
     """
-    CI runner for common tasks.
-
-    Currently this is used for all gitlab CI jobs. In the future, we might switch to running build jobs on the same host
-    distro as the target image, but this CI runner will still be used for generic tasks like check-build-coverage.
+    Get only the distro component of the CI runner string for a given distribution, architecture, and image type from
+    the Schutzfile.
     """
-    with open(SCHUTZFILE, encoding="utf-8") as schutzfile:
-        data = json.load(schutzfile)
-
-    if (runner := data.get("common", {}).get("gitlab-ci-runner")) is None:
-        raise KeyError(f"gitlab-ci-runner not defined in {SCHUTZFILE}")
-
-    return runner
-
-
-def get_common_ci_runner_distro():
-    """
-    CI runner distro for common tasks.
-
-    Returns the distro part from the value of the common.gitlab-ci-runner key in the Schutzfile.
-    For example, if the value is "aws/fedora-999", this function will return "fedora-999".
-    """
-    return get_common_ci_runner().split("/")[1]
+    runner = get_ci_runner_for(distro, arch, image_type)
+    # given a runner like 'aws/fedora-44' we want 'fedora-44'
+    return runner.split("/")[1]

--- a/test/scripts/setup-osbuild-repo
+++ b/test/scripts/setup-osbuild-repo
@@ -52,7 +52,7 @@ def write_repo(commit, distro_version):
 @testlib.gitlab.log_section("Setting up osbuild repo")
 def main():
     distro_version = testlib.testenv.get_host_distro()
-    commit_id = testlib.testenv.get_osbuild_commit(distro_version)
+    commit_id = testlib.testenv.get_osbuild_commit()
     if not commit_id:
         print(f"Error: {distro_version} does not have the osbuild commit ID defined in the Schutzfile")
         sys.exit(1)

--- a/test/scripts/test_imgtestlib.py
+++ b/test/scripts/test_imgtestlib.py
@@ -230,7 +230,7 @@ def test_read_seed():
 ))
 def test_gen_build_info_dir_path_prefix(kwargs, expected):
     # we need to patch the functions that were imported into the cache namespace, not the originals in .testenv
-    with patch("imgtestlib.cache.get_ci_runner_for", return_value="aws/fedora-999"), \
+    with patch("imgtestlib.cache.get_ci_runner_distro_for", return_value="fedora-999"), \
          patch("imgtestlib.cache.get_osbuild_commit", return_value="abcdef123456"):
         assert testlib.cache.gen_build_info_dir_path_prefix(**kwargs) == expected
 
@@ -318,7 +318,7 @@ def test_gen_build_info_dir_path_prefix(kwargs, expected):
 ))
 def test_gen_build_info_s3_dir_path(kwargs, expected):
     # we need to patch the functions that were imported into the cache namespace, not the originals in .testenv
-    with patch("imgtestlib.cache.get_ci_runner_for", return_value="aws/fedora-999"), \
+    with patch("imgtestlib.cache.get_ci_runner_distro_for", return_value="fedora-999"), \
          patch("imgtestlib.cache.get_osbuild_commit", return_value="abcdef123456"):
         assert testlib.cache.gen_build_info_s3_dir_path(**kwargs) == expected
 


### PR DESCRIPTION
This PR makes two changes to the way we configure CI runners in GitLab:
- Adds the full runner name, including architecture, to the runner configs instead of appending it automatically when generating build configs for gitlab CI.
- Removes the common runner and relies on the globbing functionality of gitlab-ci-runner-for to control the fallback (common) runner strings.

This will help with HMS-10340 since it will allow us to set the runner to, for example, `aws/fedora-44-x86_64-kvm` without needing to think about how the architecture gets appended.