### PR TITLE
test: enable fedora boot.iso (HMS-11283)

### DIFF
--- a/test/scripts/imgtestlib/boot.py
+++ b/test/scripts/imgtestlib/boot.py
@@ -599,7 +599,8 @@ def boot_image(search_path, build_config_path, keep_booted=False):
         boot_qemu(arch, image_path, build_config_path, keep_booted=keep_booted)
     elif image_type in ("image-installer", "minimal-installer"):
         boot_qemu_iso(arch, image_path, build_config_path)
-    elif image_type in ("network-installer", "everything-network-installer", "bootc-generic-iso"):
+    elif image_type in ("network-installer", "everything-network-installer", "server-network-installer",
+                        "bootc-generic-iso"):
         boot_qemu_iso_no_unattended_support(
             distro, arch, image_type, image_path, build_config_path, iso_embedded_ks_path)
     elif image_type in ("pxe-tar-xz"):

--- a/test/scripts/imgtestlib/core.py
+++ b/test/scripts/imgtestlib/core.py
@@ -447,14 +447,12 @@ def can_boot_test(manifest_fname, manifest_data, image_type, arch, distro, bluep
                   "FATAL: FIPS integrity test failed")
             return False
         if not image_type.startswith("bootc-") and not _is_bootc_manifest(manifest_data):
-            # Note that this needs adjustment when we switch to librepo
-            curl_items = manifest_data.get("sources", {}).get("org.osbuild.curl", {}).get("items", {})
-            if not curl_items:
-                print(f"  not bootable: no org.osbuild.curl source in manifest {manifest_fname} ({arch} {image_type})")
-                print("   (parsing librepo sources not implemented yet")
+            pkg_names = _get_source_package_names(manifest_data)
+            if not pkg_names:
+                print(f"  not bootable: no org.osbuild.curl or org.osbuild.librepo source"
+                      f" in manifest {manifest_fname} ({arch} {image_type})")
                 return False
-            urls = [src["url"] for src in curl_items.values()]
-            if not any("ssh-server" in url for url in urls):
+            if not any("ssh-server" in name for name in pkg_names):
                 # This can happen e.g. when an image is build with the "minimal: true" customization.
                 # We could use guestfs to inject keys, see PR#1995
                 print(f"  not bootable: ssh-server not found in manifest {manifest_fname} ({arch} {image_type})")
@@ -462,11 +460,26 @@ def can_boot_test(manifest_fname, manifest_data, image_type, arch, distro, bluep
 
             # We need jq in the image many images do not have it
             # (e.g. centos-9/rhel-9 with releasever config) so skip those too
-            if not any("jq" in url for url in urls):
+            if not any("jq" in name for name in pkg_names):
                 print(f"  not bootable: jq not found in {manifest_fname} ({arch} {image_type})")
                 return False
 
     return True
+
+
+def _get_source_package_names(manifest_data):
+    """Get package names from manifest sources."""
+    sources = manifest_data.get("sources", {})
+
+    curl_items = sources.get("org.osbuild.curl", {}).get("items", {})
+    if curl_items:
+        return [item["url"] for item in curl_items.values()]
+
+    librepo_items = sources.get("org.osbuild.librepo", {}).get("items", {})
+    if librepo_items:
+        return [item["path"] for item in librepo_items.values()]
+
+    return []
 
 
 def _is_bootc_manifest(manifest_data):

--- a/test/scripts/imgtestlib/core.py
+++ b/test/scripts/imgtestlib/core.py
@@ -30,6 +30,7 @@ CAN_BOOT_TEST = {
     ],
     "x86_64": [
         "image-installer", "minimal-installer", "network-installer",
+        "everything-network-installer", "server-network-installer",
         "qcow2", "generic-qcow2", "cloud-qcow2",
         "wsl", "generic-wsl",
         "bootc-generic-iso",
@@ -431,10 +432,6 @@ def can_boot_test(manifest_fname, manifest_data, image_type, arch, distro, bluep
         if distro in ["rhel-10.1", "rhel-10.3"]:  # 10.1 should be removed soon
             print("  not bootable: rhel network-installer tests have incomplete repos in nightly snapshot"
                   "and won't install")
-            return False
-        if distro.startswith("fedora"):
-            print("  not bootable: fedora network-installer crashes in sshd,"
-                  "see https://bugzilla.redhat.com/show_bug.cgi?id=2415883")
             return False
         if distro == "centos-9":
             print("  not bootable: centos-9 will not start an install and waits on source selection")


### PR DESCRIPTION
An old(er) bug prevented us from testing Fedora boot.iso-style media. Let's see if the bug still applies and fix it if it does.