### PR TITLE
many: cross-arch bootstrapping from packages (HMS-11277)

### DIFF
--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -596,7 +596,10 @@ func cmdManifest(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	mf, err := generateManifest(pbar, cmd, args, img, io.Discard, nil)
+	opts := &cmdManifestWrapperOptions{
+		useBootstrapIfNeeded: true,
+	}
+	mf, err := generateManifest(pbar, cmd, args, img, io.Discard, opts)
 	if err != nil {
 		return err
 	}

--- a/data/distrodefs/fedora.yaml
+++ b/data/distrodefs/fedora.yaml
@@ -26,9 +26,11 @@ distros:
       aarch64: "registry.fedoraproject.org/fedora-toolbox:46"
       ppc64le: "registry.fedoraproject.org/fedora-toolbox:46"
       s390x: "registry.fedoraproject.org/fedora-toolbox:46"
-      # XXX: remove once fedora containers are part of the upstream
-      # fedora registry (and can be validated via tls)
-      riscv64: "ghcr.io/mvo5/fedora-buildroot:46"
+    bootstrap_packages:
+      riscv64:
+        - python3
+        - rpm
+        - coreutils
 
       # XXX: add repos here too, that requires some churn, see
       # https://github.com/osbuild/images/compare/main...mvo5:yaml-distroconfig?expand=1
@@ -76,9 +78,11 @@ distros:
       aarch64: "registry.fedoraproject.org/fedora-toolbox:45"
       ppc64le: "registry.fedoraproject.org/fedora-toolbox:45"
       s390x: "registry.fedoraproject.org/fedora-toolbox:45"
-      # XXX: remove once fedora containers are part of the upstream
-      # fedora registry (and can be validated via tls)
-      riscv64: "ghcr.io/mvo5/fedora-buildroot:45"
+    bootstrap_packages:
+      riscv64:
+        - python3
+        - rpm
+        - coreutils
 
       # XXX: add repos here too, that requires some churn, see
       # https://github.com/osbuild/images/compare/main...mvo5:yaml-distroconfig?expand=1
@@ -119,6 +123,8 @@ distros:
       aarch64: "registry.fedoraproject.org/fedora-toolbox:{{.MajorVersion}}"
       ppc64le: "registry.fedoraproject.org/fedora-toolbox:{{.MajorVersion}}"
       s390x: "registry.fedoraproject.org/fedora-toolbox:{{.MajorVersion}}"
-      # XXX: remove once fedora containers are part of the upstream
-      # fedora registry (and can be validated via tls)
-      riscv64: "ghcr.io/mvo5/fedora-buildroot:{{.MajorVersion}}"
+    bootstrap_packages:
+      riscv64:
+        - python3
+        - rpm
+        - coreutils

--- a/pkg/distro/defs/loader.go
+++ b/pkg/distro/defs/loader.go
@@ -103,7 +103,8 @@ type DistroYAML struct {
 	// image types file/directory.
 	DefsPath string `yaml:"defs_path"`
 
-	BootstrapContainers map[arch.Arch]string `yaml:"bootstrap_containers"`
+	BootstrapContainers map[arch.Arch]string   `yaml:"bootstrap_containers"`
+	BootstrapPkgs       map[arch.Arch][]string `yaml:"bootstrap_packages"`
 
 	OscapProfilesAllowList []oscap.Profile `yaml:"oscap_profiles_allowlist"`
 

--- a/pkg/distro/distro.go
+++ b/pkg/distro/distro.go
@@ -73,6 +73,10 @@ type Distro interface {
 	// The ref for the bootstrap container for this distro for a specific
 	// architecture.
 	BootstrapContainer(a string) (string, error)
+
+	// The packages to install for the bootstrap buildroot for a specific
+	// architecture using ignorearch.
+	BootstrapPackages(a string) ([]string, error)
 }
 
 type CustomDepsolverDistro interface {

--- a/pkg/distro/generic/bootc.go
+++ b/pkg/distro/generic/bootc.go
@@ -309,3 +309,7 @@ func (d *BootcDistro) BootstrapContainer(a string) (string, error) {
 
 	return d.buildImgref, nil
 }
+
+func (d *BootcDistro) BootstrapPackages(a string) ([]string, error) {
+	return nil, nil
+}

--- a/pkg/distro/generic/distro.go
+++ b/pkg/distro/generic/distro.go
@@ -179,6 +179,14 @@ func (d *distribution) BootstrapContainer(a string) (string, error) {
 	return d.DistroYAML.BootstrapContainers[aa], nil
 }
 
+func (d *distribution) BootstrapPackages(a string) ([]string, error) {
+	aa, err := arch.FromString(a)
+	if err != nil {
+		return nil, err
+	}
+	return d.DistroYAML.BootstrapPkgs[aa], nil
+}
+
 // architecture implements the distro.Arch interface
 var _ = distro.Arch(&architecture{})
 

--- a/pkg/distro/generic/fedora_test.go
+++ b/pkg/distro/generic/fedora_test.go
@@ -741,7 +741,10 @@ func TestFedoraDistroBootstrapRef(t *testing.T) {
 				if distroArch.Name() == "riscv64" {
 					bootstrapRef, err := imgType.Arch().Distro().BootstrapContainer(distroArch.Name())
 					require.NoError(t, err)
-					require.Equal(t, "ghcr.io/mvo5/fedora-buildroot:"+fedoraDistro.OsVersion(), bootstrapRef)
+					require.Empty(t, bootstrapRef)
+					bootstrapPkgs, err := imgType.Arch().Distro().BootstrapPackages(distroArch.Name())
+					require.NoError(t, err)
+					require.NotEmpty(t, bootstrapPkgs)
 				} else {
 					bootstrapRef, err := imgType.Arch().Distro().BootstrapContainer(distroArch.Name())
 					require.NoError(t, err)

--- a/pkg/distro/generic/imagetype.go
+++ b/pkg/distro/generic/imagetype.go
@@ -321,11 +321,25 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		return nil, nil, fmt.Errorf("no distro_like set in yaml for %q", d.Name())
 	}
 	if options.UseBootstrapContainer {
-		bootstrapContainerRef, err := t.Arch().Distro().BootstrapContainer(t.arch.Name())
+		bootstrapPkgs, err := t.Arch().Distro().BootstrapPackages(t.arch.Name())
 		if err != nil {
 			return nil, nil, err
 		}
-		mf.DistroBootstrapRef = bootstrapContainerRef
+		if len(bootstrapPkgs) > 0 {
+			mf.Bootstrap = &manifest.BootstrapConfig{
+				Packages: bootstrapPkgs,
+			}
+		} else {
+			bootstrapContainerRef, err := t.Arch().Distro().BootstrapContainer(t.arch.Name())
+			if err != nil {
+				return nil, nil, err
+			}
+			if bootstrapContainerRef != "" {
+				mf.Bootstrap = &manifest.BootstrapConfig{
+					ContainerRef: bootstrapContainerRef,
+				}
+			}
+		}
 	}
 	runner := d.Runner()
 	_, err = img.InstantiateManifest(&mf, repos, &runner, rng)

--- a/pkg/distro/test_distro/distro.go
+++ b/pkg/distro/test_distro/distro.go
@@ -148,6 +148,10 @@ func (d *TestDistro) BootstrapContainer(a string) (string, error) {
 	return "", nil
 }
 
+func (d *TestDistro) BootstrapPackages(a string) ([]string, error) {
+	return nil, nil
+}
+
 // TestArch
 
 func (a *TestArch) Name() string {

--- a/pkg/image/build.go
+++ b/pkg/image/build.go
@@ -9,48 +9,45 @@ import (
 )
 
 // addBuildBootstrapPipelines will add a build pipeline to the
-// manifest. It will also conditionally add a container bootstrap
-// stage only if the manifest contains DistroBootstrapRef or the
+// manifest. It will also conditionally add a bootstrap stage
+// only if the manifest contains a Bootstrap config or the
 // "IMAGE_BUILDER_EXPERIMENTAL=bootstrap=<container-ref>" env
 // is set.
 //
-// This bootstrap stage allows us to do cross-arch/cross-distro builds
-// by bootstraping the buildroot rpm installs with the bootstap container
-// as the "bootstrap-buildroot".
-//
-// A "bootstrap" container has only these requirements:
-//   - python3 for the runners
-//   - mount for some of the bind mounting that osbuild does (if we would
-//     move all mounts to internal code this requirement could go away)
-//   - rpm so that the real buildroot rpms can get installed
-//
-// (and does not even need a working dnf or repo setup).
+// Two bootstrap strategies are supported:
+//   - container: deploys a container image as the bootstrap root
+//   - packages: installs RPMs with ignorearch to create the
+//     bootstrap root (no pre-built container needed)
 func addBuildBootstrapPipelines(m *manifest.Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts *manifest.BuildOptions) manifest.Build {
-	bootstrapBuildrootRef := experimentalflags.String("bootstrap")
-	if bootstrapBuildrootRef == "" {
-		bootstrapBuildrootRef = m.DistroBootstrapRef
-	}
-	// no bootstrap pipeline wanted, we can finish early
-	if bootstrapBuildrootRef == "" {
-		return manifest.NewBuild(m, runner, repos, opts)
-	}
-
-	// add the bootstrap pipeline
-	cntSrcs := []container.SourceSpec{
-		{
-			Source: bootstrapBuildrootRef,
-			Name:   bootstrapBuildrootRef,
-		},
-	}
 	if opts == nil {
 		opts = &manifest.BuildOptions{}
 	}
+
+	// check for experimental override first
+	if overrideRef := experimentalflags.String("bootstrap"); overrideRef != "" {
+		m.Bootstrap = &manifest.BootstrapConfig{ContainerRef: overrideRef}
+	}
+
+	// no bootstrap wanted
+	if m.Bootstrap == nil {
+		return manifest.NewBuild(m, runner, repos, opts)
+	}
+
+	if len(m.Bootstrap.Packages) > 0 {
+		bootstrapPipeline := manifest.NewBootstrapFromPackages(m, repos, m.Bootstrap.Packages)
+		opts.BootstrapPipeline = bootstrapPipeline
+		opts.DisableSELinux = true
+		return manifest.NewBuild(m, runner, repos, opts)
+	}
+
+	cntSrcs := []container.SourceSpec{
+		{
+			Source: m.Bootstrap.ContainerRef,
+			Name:   m.Bootstrap.ContainerRef,
+		},
+	}
 	bootstrapPipeline := manifest.NewBootstrap(m, cntSrcs)
 	opts.BootstrapPipeline = bootstrapPipeline
-	// This is currently needed for bootstraped buildroot
-	// containers because most of the boostrap containers do not
-	// include setfiles(8) and when constructing the buildroot
-	// setfiles(8) is called as the last step by default.
 	opts.DisableSELinux = true
 	return manifest.NewBuild(m, runner, repos, opts)
 }

--- a/pkg/image/build_test.go
+++ b/pkg/image/build_test.go
@@ -27,23 +27,23 @@ var (
 
 func TestNewBuildWithExperimentalOverride(t *testing.T) {
 	for _, tc := range []struct {
-		name                       string
-		env                        string
-		manifestDistroBootstrapRef string
+		name      string
+		env       string
+		bootstrap *manifest.BootstrapConfig
 
 		expectBootstrap bool
 	}{
-		{"no-buildroot-env", "", "", false},
-		{"buildroot-env-set", "bootstrap=ghcr.io/ondrejbudai/cool:stuff", "", true},
-		{"manifest-opt-set", "", "ghcr.io/ondrej/cool:stuff", true},
+		{"no-buildroot-env", "", nil, false},
+		{"buildroot-env-set", "bootstrap=ghcr.io/ondrejbudai/cool:stuff", nil, true},
+		{"manifest-opt-set", "", &manifest.BootstrapConfig{ContainerRef: "ghcr.io/ondrej/cool:stuff"}, true},
 		// XXX: add test that ensures that env wins
-		{"env-set-manifest-set", "ghcr.io/from-env", "ghcr.io/from-manifest", true},
+		{"env-set-manifest-set", "ghcr.io/from-env", &manifest.BootstrapConfig{ContainerRef: "ghcr.io/from-manifest"}, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("IMAGE_BUILDER_EXPERIMENTAL", tc.env)
 			mf := manifest.New()
 			runner := &runner.Fedora{Version: 42}
-			mf.DistroBootstrapRef = tc.manifestDistroBootstrapRef
+			mf.Bootstrap = tc.bootstrap
 			buildIf := image.AddBuildBootstrapPipelines(&mf, runner, nil, nil)
 			require.NotNil(t, buildIf)
 

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -59,6 +59,7 @@ type BuildrootFromPackages struct {
 
 	rpmStageIgnoreGPGImportFailures bool
 	ignoreArch                      bool
+	extraPackages                   []string
 }
 
 type BuildOptions struct {
@@ -155,13 +156,16 @@ func (p *BuildrootFromPackages) getPackageSetChain(distro Distro) ([]rpmmd.Packa
 		}
 	}
 
+	if !p.disableSelinux {
+		addPkgs(policyPackage)
+	}
 	addPkgs(
-		policyPackage, // needed to build the build pipeline
-		"coreutils",   // /usr/bin/cp - used all over
-		"xz",          // usage unclear
+		"coreutils", // /usr/bin/cp - used all over
+		"xz",        // usage unclear
 	)
 
 	addPkgs(p.runner.GetBuildPackages()...)
+	addPkgs(p.extraPackages...)
 
 	for _, pipeline := range p.dependents {
 		pipelineBuildPackages, err := pipeline.getBuildPackages(distro)
@@ -405,6 +409,25 @@ func (p *BuildrootFromContainer) serialize() (osbuild.Pipeline, error) {
 	}
 
 	return pipeline, nil
+}
+
+// NewBootstrapFromPackages creates a bootstrap buildroot by installing
+// packages with ignorearch. This is used for cross-arch builds where
+// the bootstrap root is assembled from RPMs instead of a container.
+func NewBootstrapFromPackages(m *Manifest, repos []rpmmd.RepoConfig, packages []string) Build {
+	name := "bootstrap-buildroot"
+	pipeline := &BuildrootFromPackages{
+		Base:               NewBase(name, nil),
+		runner:             &runner.Linux{},
+		dependents:         make([]Pipeline, 0),
+		depsolveRepos:      filterRepos(repos, name),
+		containerBuildable: true,
+		disableSelinux:     true,
+		ignoreArch:         true,
+	}
+	pipeline.extraPackages = packages
+	m.addPipeline(pipeline)
+	return pipeline
 }
 
 // NewBootstrap creates a new bootstrap build pipeline from the given

--- a/pkg/manifest/build.go
+++ b/pkg/manifest/build.go
@@ -58,6 +58,7 @@ type BuildrootFromPackages struct {
 	selinuxPolicy string
 
 	rpmStageIgnoreGPGImportFailures bool
+	ignoreArch                      bool
 }
 
 type BuildOptions struct {
@@ -88,6 +89,10 @@ type BuildOptions struct {
 
 	// Ignore gpg import failures
 	RPMStageIgnoreGPGImportFailures bool
+
+	// IgnoreArch allows installing packages for a different
+	// architecture than the host, used for cross-arch builds
+	IgnoreArch bool
 }
 
 // policy or default returns the selinuxPolicy or (if unset) the
@@ -119,6 +124,7 @@ func NewBuild(m *Manifest, runner runner.Runner, repos []rpmmd.RepoConfig, opts 
 		disableSelinux:                  opts.DisableSELinux,
 		selinuxPolicy:                   policyOrDefault(opts.SELinuxPolicy),
 		rpmStageIgnoreGPGImportFailures: opts.RPMStageIgnoreGPGImportFailures,
+		ignoreArch:                      opts.IgnoreArch,
 	}
 
 	m.addPipeline(pipeline)
@@ -207,7 +213,9 @@ func (p *BuildrootFromPackages) serialize() (osbuild.Pipeline, error) {
 
 	pipeline.Runner = p.runner.String()
 
-	baseOptions := osbuild.RPMStageOptions{}
+	baseOptions := osbuild.RPMStageOptions{
+		IgnoreArch: p.ignoreArch,
+	}
 	if p.rpmStageIgnoreGPGImportFailures {
 		baseOptions.RPMKeys = &osbuild.RPMKeys{
 			IgnoreImportFailures: true,

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -109,12 +109,22 @@ type Manifest struct {
 	// different distributions and version.
 	Distro Distro
 
-	// DistroBootstrapRef defines if a bootstrap container should be used
-	// to generate the buildroot
-	// XXX: ideally we would have "Distro distro.Distro" here and a
-	// "BoostrapContainerRef()" method on this but we cannot because of
-	// circular imports so we use the same workaround as Distro above.
-	DistroBootstrapRef string
+	// Bootstrap defines the cross-arch bootstrap strategy for
+	// generating the buildroot. Either a container ref or a list
+	// of packages (installed with ignorearch) can be used.
+	Bootstrap *BootstrapConfig
+}
+
+// BootstrapConfig defines how to bootstrap a cross-arch buildroot.
+// Exactly one of ContainerRef or Packages should be set.
+type BootstrapConfig struct {
+	// ContainerRef is a container image reference to deploy as the
+	// bootstrap root
+	ContainerRef string
+
+	// Packages is a list of packages to install with ignorearch
+	// to create the bootstrap root
+	Packages []string
 }
 
 func New() Manifest {

--- a/pkg/osbuild/rpm_stage.go
+++ b/pkg/osbuild/rpm_stage.go
@@ -36,6 +36,10 @@ type RPMStageOptions struct {
 
 	RPMKeys *RPMKeys `json:"rpmkeys,omitempty"`
 
+	// Allow installation even if the architectures of the binary
+	// package and host don't match
+	IgnoreArch bool `json:"ignorearch,omitempty"`
+
 	// Set generic environment variables for RPM scriptlets
 	GenericEnv map[string]string `json:"generic_env,omitempty"`
 }
@@ -55,6 +59,7 @@ func (o *RPMStageOptions) Clone() *RPMStageOptions {
 		KernelInstallEnv: common.ClonePtr(o.KernelInstallEnv),
 		InstallLangs:     slices.Clone(o.InstallLangs),
 		RPMKeys:          common.ClonePtr(o.RPMKeys),
+		IgnoreArch:       o.IgnoreArch,
 		GenericEnv:       maps.Clone(o.GenericEnv),
 	}
 }

--- a/pkg/osbuild/rpm_stage_test.go
+++ b/pkg/osbuild/rpm_stage_test.go
@@ -35,6 +35,7 @@ func TestRPMStageOptionsClone(t *testing.T) {
 				OSTreeBooted:     common.ToPtr(true),
 				KernelInstallEnv: &KernelInstallEnv{BootRoot: "/boot"},
 				InstallLangs:     []string{"en_US", "de_DE"},
+				IgnoreArch:       true,
 				GenericEnv:       map[string]string{"IMAGE_ID": "my-image", "IMAGE_VERSION": "1.0"},
 			},
 		},
@@ -485,6 +486,22 @@ func TestGenRPMStagesFromTransactions(t *testing.T) {
 				assert.Empty(t, opts0.GPGKeysFromTree, "tx0 should not have key")
 				assert.Equal(t, []string{"/etc/pki/rpm-gpg/key1"}, opts1.GPGKeysFromTree, "tx1 should have key")
 				assert.Empty(t, opts2.GPGKeysFromTree, "tx2 should not have key")
+			},
+		},
+		"ignorearch-propagated-to-all-stages": {
+			transactions: depsolvednf.TransactionList{
+				{{Name: "pkg-a", Repo: repoNoKeys, Checksum: rpmmd.Checksum{Type: "sha256", Value: "aaa"}}},
+				{{Name: "pkg-b", Repo: repoNoKeys, Checksum: rpmmd.Checksum{Type: "sha256", Value: "bbb"}}},
+			},
+			baseOpts: &RPMStageOptions{
+				IgnoreArch: true,
+			},
+			expectStages: 2,
+			validate: func(t *testing.T, stages []*Stage) {
+				for idx, stage := range stages {
+					opts := stage.Options.(*RPMStageOptions)
+					assert.True(t, opts.IgnoreArch, "stage %d", idx)
+				}
 			},
 		},
 		"gpgkeys-from-tree-not-found-error": {


### PR DESCRIPTION
Historically we've used pre-built containers for cross-arch bootstrapping. This PR allows for cross-arch bootstrapping through RPMs instead. When a distribution definitions defines a set of packages for a given arch it is preferred over the container.

Initially this only swaps over the riscv64 bootstrap as they're the most problematic and a good area to test this. If you want to test properly it's best to rebase this PR on top of #2614a and cross-building an `everything-network-installer` for example.